### PR TITLE
Fix warning by dev/release profiles from member Cargo.toml to workspace Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,8 @@ members = [
   "propolis-client",
   "propolis-server",
 ]
+
+[profile.dev]
+panic = "abort"
+[profile.release]
+panic = "abort"

--- a/propolis-cli/Cargo.toml
+++ b/propolis-cli/Cargo.toml
@@ -7,11 +7,6 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[profile.dev]
-panic = "abort"
-[profile.release]
-panic = "abort"
-
 [dependencies]
 pico-args = "0.3"
 libc = "0.2"

--- a/propolis-client/Cargo.toml
+++ b/propolis-client/Cargo.toml
@@ -6,11 +6,6 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[profile.dev]
-panic = "abort"
-[profile.release]
-panic = "abort"
-
 [dependencies]
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 ring = "0.16"

--- a/propolis-server/Cargo.toml
+++ b/propolis-server/Cargo.toml
@@ -7,11 +7,6 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[profile.dev]
-panic = "abort"
-[profile.release]
-panic = "abort"
-
 [dependencies]
 anyhow = "1.0"
 bitflags = "1.2"

--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -7,11 +7,6 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[profile.dev]
-panic = "abort"
-[profile.release]
-panic = "abort"
-
 [dependencies]
 libc = "0.2"
 bitflags = "1.2"


### PR DESCRIPTION
Clear up the warning about "profiles for the non root package will be ignored" by moving these to the workspace root.

If we need to, we can add specific workspace member [overrides](https://doc.rust-lang.org/cargo/reference/profiles.html#overrides) though that does come with the limitation that you can't specify `panic`, `lto` or `rpath` settings. Another limitation is if we publish one of the binary workspace members then `cargo install` does would not use the workspace root profile settings ([details](https://github.com/rust-lang/cargo/issues/8264)).