### PR TITLE
Add propolis state monitoring API

### DIFF
--- a/propolis-client/src/api.rs
+++ b/propolis-client/src/api.rs
@@ -26,6 +26,17 @@ pub struct InstanceGetResponse {
     pub instance: Instance,
 }
 
+#[derive(Deserialize, Serialize, JsonSchema)]
+pub struct InstanceStateMonitorRequest {
+    pub gen: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct InstanceStateMonitorResponse {
+    pub gen: u64,
+    pub state: InstanceState,
+}
+
 /// Requested state of an Instance.
 #[derive(Deserialize, Serialize, JsonSchema)]
 pub struct InstanceStateChange {
@@ -50,7 +61,7 @@ pub struct InstanceSerialResponse {
 }
 
 /// Current state of an Instance.
-#[derive(Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub enum InstanceState {
     Creating,
     Starting,
@@ -62,10 +73,8 @@ pub enum InstanceState {
     Destroyed,
 }
 
-#[derive(Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Deserialize, PartialEq, Serialize, JsonSchema)]
 pub struct InstanceProperties {
-    pub generation_id: u64,
-
     /// Unique identifier for this Instance.
     pub id: Uuid,
     /// Human-readable name of the Instance.

--- a/propolis-client/src/lib.rs
+++ b/propolis-client/src/lib.rs
@@ -126,6 +126,20 @@ impl Client {
         self.get(path, None).await
     }
 
+    /// Long-poll for state changes.
+    pub async fn instance_state_monitor(
+        &self,
+        id: Uuid,
+        gen: u64,
+    ) -> Result<api::InstanceStateMonitorResponse, Error> {
+        let path = format!("http://{}/instances/{}/state-monitor", self.address, id);
+        let body = Body::from(serde_json::to_string(
+            &api::InstanceStateMonitorRequest {
+                gen,
+            }).unwrap());
+        self.get(path, Some(body)).await
+    }
+
     /// Puts an instance into a new state.
     pub async fn instance_state_put(
         &self,

--- a/propolis-client/src/lib.rs
+++ b/propolis-client/src/lib.rs
@@ -132,11 +132,12 @@ impl Client {
         id: Uuid,
         gen: u64,
     ) -> Result<api::InstanceStateMonitorResponse, Error> {
-        let path = format!("http://{}/instances/{}/state-monitor", self.address, id);
-        let body = Body::from(serde_json::to_string(
-            &api::InstanceStateMonitorRequest {
-                gen,
-            }).unwrap());
+        let path =
+            format!("http://{}/instances/{}/state-monitor", self.address, id);
+        let body = Body::from(
+            serde_json::to_string(&api::InstanceStateMonitorRequest { gen })
+                .unwrap(),
+        );
         self.get(path, Some(body)).await
     }
 

--- a/propolis-server/src/main.rs
+++ b/propolis-server/src/main.rs
@@ -85,8 +85,8 @@ fn propolis_to_api_state(
         PropolisState::Boot => ApiState::Starting,
         PropolisState::Run => ApiState::Running,
         PropolisState::Quiesce => ApiState::Stopped,
-        PropolisState::Halt => todo!(),
-        PropolisState::Reset => todo!(),
+        PropolisState::Halt => ApiState::Stopped,
+        PropolisState::Reset => ApiState::Stopped,
         PropolisState::Destroy => ApiState::Destroyed,
     }
 }


### PR DESCRIPTION
This PR allows a caller to long-poll for any state changes which occur in Propolis. This is necessary for the Sled Agent to accurately monitor state and report changes to Nexus.

Additionally, idempotency of "instance_ensure" has been improved.