### PR TITLE
Serial Console over WebSockets

### DIFF
--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -50,16 +50,6 @@ pub enum InstanceStateRequested {
     Reboot,
 }
 
-#[derive(Deserialize, Serialize, JsonSchema)]
-pub struct InstanceSerialRequest {
-    pub bytes: Vec<u8>,
-}
-
-#[derive(Deserialize, Serialize, JsonSchema)]
-pub struct InstanceSerialResponse {
-    pub bytes: Vec<u8>,
-}
-
 /// Current state of an Instance.
 #[derive(Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
 pub enum InstanceState {

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -151,12 +151,4 @@ impl Client {
         let body = Body::from(serde_json::to_string(&state).unwrap());
         self.put_no_response(path, Some(body)).await
     }
-
-    /// Inputs bytes to the serial console, and returns any new output.
-    ///
-    /// TODO: This method is NOT idempotent, uses short-polling, and should be
-    /// replaced by a websocket-based interface (or equivalent).
-    pub async fn instance_serial(&self, _id: Uuid) -> Result<(), Error> {
-        todo!()
-    }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -158,11 +158,8 @@ impl Client {
     /// replaced by a websocket-based interface (or equivalent).
     pub async fn instance_serial(
         &self,
-        id: Uuid,
-        input: api::InstanceSerialRequest,
-    ) -> Result<api::InstanceSerialResponse, Error> {
-        let path = format!("http://{}/instances/{}/serial", self.address, id);
-        let body = Body::from(serde_json::to_string(&input).unwrap());
-        self.put(path, Some(body)).await
+        _id: Uuid,
+    ) -> Result<(), Error> {
+        todo!()
     }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -156,10 +156,7 @@ impl Client {
     ///
     /// TODO: This method is NOT idempotent, uses short-polling, and should be
     /// replaced by a websocket-based interface (or equivalent).
-    pub async fn instance_serial(
-        &self,
-        _id: Uuid,
-    ) -> Result<(), Error> {
+    pub async fn instance_serial(&self, _id: Uuid) -> Result<(), Error> {
         todo!()
     }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,11 +21,14 @@ anyhow = "1.0"
 # dropshot = "0.6"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
 futures = "0.3"
+hyper =  "0.14"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
+tokio-tungstenite = "0.14"
 toml = "0.5"
 serde = "1.0"
 serde_derive = "1.0"
+slog = "2.7"
 structopt = { version = "0.3", default-features = false }
 propolis = { path = "../propolis" }
 propolis-client = { path = "../client" }
@@ -36,4 +39,3 @@ hex = "0.4.3"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 ring = "0.16"
 slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_debug" ] }
-

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{oneshot, watch, Mutex};
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
-use tokio_tungstenite::tungstenite::protocol::CloseFrame;
+use tokio_tungstenite::tungstenite::protocol::{CloseFrame, WebSocketConfig};
 use tokio_tungstenite::tungstenite::{
     self, handshake, protocol::Role, Message,
 };
@@ -509,8 +509,12 @@ async fn instance_serial(
     tokio::spawn(
         async move {
             let upgraded = upgrade_fut.await?;
+            let config = WebSocketConfig {
+                max_send_queue: Some(1024),
+                ..Default::default()
+            };
             let ws_stream =
-                WebSocketStream::from_raw_socket(upgraded, Role::Server, None)
+                WebSocketStream::from_raw_socket(upgraded, Role::Server, Some(config))
                     .await;
             instance_serial_task(detach_recv, serial, ws_stream, ws_log).await
         }

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -12,15 +12,15 @@ use slog::{error, info, o, Logger};
 use std::borrow::Cow;
 use std::io::{Error, ErrorKind};
 use std::sync::Arc;
+use thiserror::Error;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{oneshot, watch, Mutex};
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 use tokio_tungstenite::tungstenite::{
     self, handshake, protocol::Role, Message,
 };
 use tokio_tungstenite::WebSocketStream;
-use thiserror::Error;
-use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
-use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 
 use propolis::dispatch::DispCtx;
 use propolis::hw::chipset::Chipset;
@@ -510,7 +510,8 @@ async fn instance_serial(
         async move {
             let upgraded = upgrade_fut.await?;
             let ws_stream =
-                WebSocketStream::from_raw_socket(upgraded, Role::Server, None).await;
+                WebSocketStream::from_raw_socket(upgraded, Role::Server, None)
+                    .await;
             instance_serial_task(detach_recv, serial, ws_stream, ws_log).await
         }
         .inspect_err(move |err| error!(err_log, "Serial Task Failed: {}", err)),


### PR DESCRIPTION
Here's the code from the demo cleaned up a bit. Also includes a detach endpoint to forcibly detach an existing serial session!

The corresponding method in `propolis-client` has just been removed for now. We don't have any consumers there yet and we can later better plan how they'll need to consume the serial console.