### PR TITLE
Update propolis / sled-agent state translation to include rebooting

### DIFF
--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -68,6 +68,7 @@ pub enum InstanceState {
     Running,
     Stopping,
     Stopped,
+    Rebooting,
     Repairing,
     Failed,
     Destroyed,

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -76,9 +76,9 @@ fn propolis_to_api_state(
         PropolisState::Initialize => ApiState::Creating,
         PropolisState::Boot => ApiState::Starting,
         PropolisState::Run => ApiState::Running,
-        PropolisState::Quiesce => ApiState::Stopped,
+        PropolisState::Quiesce => ApiState::Stopping,
         PropolisState::Halt => ApiState::Stopped,
-        PropolisState::Reset => ApiState::Stopped,
+        PropolisState::Reset => ApiState::Rebooting,
         PropolisState::Destroy => ApiState::Destroyed,
     }
 }


### PR DESCRIPTION
- Adds a "rebooting" state to align with https://github.com/oxidecomputer/omicron/pull/118
- Updates "quiesce" to be correctly identified as "stopping", distinct from "halt", which is "stopped"

(Sometime after this PR, I plan to align the propolis / omicron names for states, but I want them to be aligned *first* to make the rename patch nomenclature only, without any logic shifting)