### PR TITLE
Add basic nvme emulation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /*/target
 **/Cargo.lock
+debug.out

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -221,7 +221,8 @@ fn main() {
                     let nvme = hw::nvme::PciNvme::create(0x1de, 0x1000, ns);
 
                     chipset.pci_attach(bdf.unwrap(), nvme);
-                    plain.start_dispatch(format!("bdev-{} thread", name), &disp);
+                    plain
+                        .start_dispatch(format!("bdev-{} thread", name), &disp);
                 }
                 _ => {
                     eprintln!("unrecognized driver: {}", name);

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -4,6 +4,7 @@ use std::collections::VecDeque;
 use std::fs::{metadata, File, OpenOptions};
 use std::io::Result;
 use std::os::unix::fs::FileTypeExt;
+use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::sync::Condvar;
 use std::sync::{Arc, Mutex, Weak};
@@ -14,6 +15,7 @@ use crate::dispatch::{DispCtx, Dispatcher};
 /// Type of operations which may be issued to a virtual block device.
 #[derive(Copy, Clone, Debug)]
 pub enum BlockOp {
+    Flush,
     Read,
     Write,
 }
@@ -106,6 +108,15 @@ impl<R: BlockReq> PlainBdev<R> {
 
             if let Some(mut req) = reqs.pop_front() {
                 let res = match req.oper() {
+                    BlockOp::Flush => {
+                        let res =
+                            unsafe { libc::fdatasync(self.fp.as_raw_fd()) };
+                        if res == -1 {
+                            BlockResult::Failure
+                        } else {
+                            BlockResult::Success
+                        }
+                    }
                     BlockOp::Read => self.process_read(&mut req, ctx),
                     BlockOp::Write => self.process_write(&mut req, ctx),
                 };

--- a/propolis/src/hw/mod.rs
+++ b/propolis/src/hw/mod.rs
@@ -1,5 +1,6 @@
 pub mod chipset;
 pub mod ibmpc;
+pub mod nvme;
 pub mod pci;
 pub mod ps2ctrl;
 pub mod qemu;

--- a/propolis/src/hw/nvme/admin.rs
+++ b/propolis/src/hw/nvme/admin.rs
@@ -171,12 +171,6 @@ impl NvmeCtrl {
         cmd: &cmds::SetFeaturesCmd,
         _ctx: &DispCtx,
     ) -> cmds::Completion {
-        if cmd.save {
-            return cmds::Completion::specific_err(
-                StatusCodeType::CmdSpecific,
-                STS_SET_FEATURE_NOT_SAVEABLE,
-            );
-        }
         match cmd.fid {
             cmds::FeatureIdent::NumberOfQueues { ncqr, nsqr } => {
                 // NVMe 1.3, Section 5.21.1.7: ncqr/nsqr can't be 65535

--- a/propolis/src/hw/nvme/admin.rs
+++ b/propolis/src/hw/nvme/admin.rs
@@ -7,7 +7,9 @@ use crate::{common::PAGE_SIZE, dispatch::DispCtx};
 use super::{cmds, NvmeCtrl, NvmeError};
 
 impl NvmeCtrl {
-    /// Create a new I/O Completion Queue
+    /// Service Create I/O Completion Queue command.
+    ///
+    /// See NVMe 1.0e Section 5.3 Create I/O Completion Queue command
     pub(super) fn acmd_create_io_cq(
         &mut self,
         cmd: &cmds::CreateIOCQCmd,
@@ -46,7 +48,9 @@ impl NvmeCtrl {
         }
     }
 
-    /// Creates a new I/O Submission Queue
+    /// Service I/O Create Submission Queue command.
+    ///
+    /// See NVMe 1.0e Section 5.4 Create I/O Submission Queue command
     pub(super) fn acmd_create_io_sq(
         &mut self,
         cmd: &cmds::CreateIOSQCmd,
@@ -84,6 +88,9 @@ impl NvmeCtrl {
         }
     }
 
+    /// Service Get Log Page command.
+    ///
+    /// See NVMe 1.0e Section 5.10 Get Log Page command
     pub(super) fn acmd_get_log_page(
         &self,
         cmd: &cmds::GetLogPageCmd,
@@ -99,6 +106,9 @@ impl NvmeCtrl {
         cmds::Completion::success()
     }
 
+    /// Service Identify command.
+    ///
+    /// See NVMe 1.0e Section 5.11 Identify command
     pub(super) fn acmd_identify(
         &self,
         cmd: &cmds::IdentifyCmd,
@@ -153,6 +163,9 @@ impl NvmeCtrl {
         }
     }
 
+    /// Service Set Features command.
+    ///
+    /// See NVMe 1.0e Section 5.12 Set Features command
     pub(super) fn acmd_set_features(
         &self,
         cmd: &cmds::SetFeaturesCmd,

--- a/propolis/src/hw/nvme/admin.rs
+++ b/propolis/src/hw/nvme/admin.rs
@@ -193,19 +193,9 @@ impl NvmeCtrl {
             | cmds::FeatureIdent::VolatileWriteCache
             | cmds::FeatureIdent::InterruptCoalescing
             | cmds::FeatureIdent::InterruptVectorConfiguration
-            | cmds::FeatureIdent::WriteAtomicityNormal
+            | cmds::FeatureIdent::WriteAtomicity
             | cmds::FeatureIdent::AsynchronousEventConfiguration
-            | cmds::FeatureIdent::AutonomousPowerStateTransition
-            | cmds::FeatureIdent::HostMemoryBuffer
-            | cmds::FeatureIdent::Timestamp
-            | cmds::FeatureIdent::KeepAliveTimer
-            | cmds::FeatureIdent::HostControlledThermalManagement
-            | cmds::FeatureIdent::NonOperationPowerStateConfig
-            | cmds::FeatureIdent::Managment(_)
             | cmds::FeatureIdent::SoftwareProgressMarker
-            | cmds::FeatureIdent::HostIdentifier
-            | cmds::FeatureIdent::ReservationNotificationMask
-            | cmds::FeatureIdent::ReservationPersistance
             | cmds::FeatureIdent::Vendor(_) => {
                 cmds::Completion::generic_err(STS_INVAL_FIELD)
             }

--- a/propolis/src/hw/nvme/admin.rs
+++ b/propolis/src/hw/nvme/admin.rs
@@ -1,0 +1,193 @@
+use std::mem::size_of;
+
+use crate::common::GuestAddr;
+use crate::{common::PAGE_SIZE, dispatch::DispCtx};
+use super::bits::{self, *};
+
+use super::{NvmeCtrl, NvmeError, cmds};
+
+impl NvmeCtrl {
+    /// Create a new I/O Completion Queue
+    pub(super) fn acmd_create_io_cq(
+        &mut self,
+        cmd: &cmds::CreateIOCQCmd,
+        ctx: &DispCtx,
+    ) -> cmds::Completion {
+        if cmd.intr_vector >= super::NVME_MSIX_COUNT {
+            return cmds::Completion::specific_err(
+                StatusCodeType::CmdSpecific,
+                STS_CREATE_IO_Q_INVAL_INT_VEC
+            );
+        }
+
+        // We only support physical contiguous queues
+        if !cmd.phys_contig {
+            return cmds::Completion::generic_err(bits::STS_INVAL_FIELD);
+        }
+
+        // Finally, create the Completion Queue
+        match self.create_cq(
+            cmd.qid,
+            cmd.intr_vector,
+            GuestAddr(cmd.prp),
+            cmd.qsize as u32,
+            ctx
+        ) {
+            Ok(_) => cmds::Completion::success(),
+            Err(NvmeError::InvalidCompQueue(_) | NvmeError::CompQueueAlreadyExists(_)) =>
+                cmds::Completion::specific_err(
+                    StatusCodeType::CmdSpecific,
+                    STS_CREATE_IO_Q_INVAL_QID
+                ),
+            Err(NvmeError::QueueCreateErr(err)) => err.into(),
+            Err(_) => cmds::Completion::generic_err(STS_INTERNAL_ERR),
+        }
+    }
+
+    /// Creates a new I/O Submission Queue
+    pub(super) fn acmd_create_io_sq(
+        &mut self,
+        cmd: &cmds::CreateIOSQCmd,
+        ctx: &DispCtx,
+    ) -> cmds::Completion {
+        // We only support physical contiguous queues
+        if !cmd.phys_contig {
+            return cmds::Completion::generic_err(bits::STS_INVAL_FIELD);
+        }
+
+        // Finally, create the Submission Queue
+        match self.create_sq(
+            cmd.qid,
+            cmd.cqid,
+            GuestAddr(cmd.prp),
+            cmd.qsize as u32,
+            ctx
+        ) {
+            Ok(_) => cmds::Completion::success(),
+            Err(NvmeError::InvalidCompQueue(_)) =>
+                cmds::Completion::specific_err(
+                    StatusCodeType::CmdSpecific,
+                    STS_CREATE_IO_Q_INVAL_CQ
+            ),
+            Err(NvmeError::InvalidSubQueue(_) | NvmeError::SubQueueAlreadyExists(_)) =>
+                cmds::Completion::specific_err(
+                    StatusCodeType::CmdSpecific,
+                    STS_CREATE_IO_Q_INVAL_QID
+                ),
+            Err(NvmeError::QueueCreateErr(err)) => err.into(),
+            Err(_) => cmds::Completion::generic_err(STS_INTERNAL_ERR),
+        }
+    }
+
+    pub(super) fn acmd_get_log_page(
+        &self,
+        cmd: &cmds::GetLogPageCmd,
+        ctx: &DispCtx,
+    ) -> cmds::Completion {
+        assert!((cmd.len as usize) < PAGE_SIZE);
+        let buf = cmd.data(ctx.mctx.memctx()).next().expect("missing prp entry for log page response");
+        // TODO: actually keep a log that we can write back instead of all zeros
+        assert!(ctx.mctx.memctx().write_byte(buf.0, 0, cmd.len as usize));
+        cmds::Completion::success()
+    }
+
+    pub(super) fn acmd_identify(
+        &self,
+        cmd: &cmds::IdentifyCmd,
+        ctx: &DispCtx,
+    ) -> cmds::Completion {
+        match cmd.cns {
+            IDENT_CNS_NAMESPACE => match cmd.nsid {
+                // TODO: We only support a single namespace currently
+                1 => {
+                    assert!(size_of::<bits::IdentifyNamespace>() <= PAGE_SIZE);
+                    let buf = cmd.data(ctx.mctx.memctx()).next().expect("missing prp entry for ident response");
+                    assert!(ctx.mctx.memctx().write(buf.0, &self.ns.ident));
+                    cmds::Completion::success()
+                }
+                // 0 is not a valid NSID (See NVMe 1.3, Section 6.1)
+                // We also don't currently support namespace management
+                // and so treat the 'broadcast' NSID (0xffffffff) as invalid
+                // along with any other namespace
+                0 | 0xffffffff | _ => {
+                    cmds::Completion::generic_err(STS_INVALID_NS)
+                }
+            },
+            IDENT_CNS_CONTROLLER => {
+                let ident = bits::IdentifyController {
+                    vid: self.vendor_id,
+                    ssvid: self.vendor_id,
+                    // TODO: fill out serial number
+                    // TODO: move to const somewhere
+                    ieee: [0xA8, 0x40, 0x25], // Oxide OUI
+                    sqes: size_of::<bits::RawSubmission>() as u8,
+                    cqes: size_of::<bits::RawCompletion>() as u8,
+                    // hardcode a single namespace for now
+                    nn: 1,
+                    // bit 0 indicates volatile write cache is present
+                    vwc: 1,
+                    ..Default::default()
+                };
+                assert!(size_of::<bits::IdentifyController>() <= PAGE_SIZE);
+                let buf = cmd.data(ctx.mctx.memctx()).next().expect("missing prp entry for ident response");
+                assert!(ctx.mctx.memctx().write(buf.0, &ident));
+                cmds::Completion::success()
+            }
+            // We currently present NVMe version 1.0 in which CNS is a 1-bit field
+            // and hence only need to support the NAMESPACE and CONTROLLER cases
+            _ => cmds::Completion::generic_err(bits::STS_INVAL_FIELD),
+        }
+    }
+
+    pub(super) fn acmd_set_features(
+        &self,
+        cmd: &cmds::SetFeaturesCmd,
+        _ctx: &DispCtx,
+    ) -> cmds::Completion {
+        if cmd.save {
+            return cmds::Completion::specific_err(
+                StatusCodeType::CmdSpecific,
+                STS_SET_FEATURE_NOT_SAVEABLE
+            );
+        }
+        match cmd.fid {
+            cmds::FeatureIdent::NumberOfQueues { ncqr, nsqr } => {
+                // NVMe 1.3, Section 5.21.1.7: ncqr/nsqr can't be 65535
+                if ncqr == 0xFFFF || nsqr == 0xFFFF {
+                    return cmds::Completion::generic_err(STS_INVAL_FIELD);
+                }
+                // TODO: error if called after initialization
+                // TODO: we only support a single pair of I/O queues
+                let ncqa = 1;
+                let nsqa = 1;
+                // `ncqa`/`nsqa` are 0-based values so subtract 1
+                cmds::Completion::success_val((ncqa - 1) << 16 | (nsqa - 1))
+            },
+            cmds::FeatureIdent::Reserved |
+            cmds::FeatureIdent::Arbitration |
+            cmds::FeatureIdent::PowerManagement |
+            cmds::FeatureIdent::LbaRangeType |
+            cmds::FeatureIdent::TemperatureThreshold |
+            cmds::FeatureIdent::ErrorRecovery |
+            cmds::FeatureIdent::VolatileWriteCache |
+            cmds::FeatureIdent::InterruptCoalescing |
+            cmds::FeatureIdent::InterruptVectorConfiguration |
+            cmds::FeatureIdent::WriteAtomicityNormal |
+            cmds::FeatureIdent::AsynchronousEventConfiguration |
+            cmds::FeatureIdent::AutonomousPowerStateTransition |
+            cmds::FeatureIdent::HostMemoryBuffer |
+            cmds::FeatureIdent::Timestamp |
+            cmds::FeatureIdent::KeepAliveTimer |
+            cmds::FeatureIdent::HostControlledThermalManagement |
+            cmds::FeatureIdent::NonOperationPowerStateConfig |
+            cmds::FeatureIdent::Managment(_) |
+            cmds::FeatureIdent::SoftwareProgressMarker |
+            cmds::FeatureIdent::HostIdentifier |
+            cmds::FeatureIdent::ReservationNotificationMask |
+            cmds::FeatureIdent::ReservationPersistance |
+            cmds::FeatureIdent::Vendor(_) => {
+                cmds::Completion::generic_err(STS_INVAL_FIELD)
+            }
+        }
+    }
+}

--- a/propolis/src/hw/nvme/admin.rs
+++ b/propolis/src/hw/nvme/admin.rs
@@ -117,7 +117,7 @@ impl NvmeCtrl {
     ) -> cmds::Completion {
         match cmd.cns {
             IDENT_CNS_NAMESPACE => match cmd.nsid {
-                n if n > 0 && n < super::ns::MAX_NUM_NAMESPACES as u32 => {
+                n if n > 0 && n <= super::ns::MAX_NUM_NAMESPACES as u32 => {
                     assert!(size_of::<bits::IdentifyNamespace>() <= PAGE_SIZE);
                     let buf = cmd
                         .data(ctx.mctx.memctx())

--- a/propolis/src/hw/nvme/admin.rs
+++ b/propolis/src/hw/nvme/admin.rs
@@ -126,7 +126,7 @@ impl NvmeCtrl {
                     assert!(ctx.mctx.memctx().write(buf.0, &self.ns.ident));
                     cmds::Completion::success()
                 }
-                // 0 is not a valid NSID (See NVMe 1.3, Section 6.1)
+                // 0 is not a valid NSID (See NVMe 1.0e, Section 6.1 Namespaces)
                 // We also don't currently support namespace management
                 // and so treat the 'broadcast' NSID (0xffffffff) as invalid
                 // along with any other namespace
@@ -173,8 +173,7 @@ impl NvmeCtrl {
     ) -> cmds::Completion {
         match cmd.fid {
             cmds::FeatureIdent::NumberOfQueues { ncqr, nsqr } => {
-                // NVMe 1.3, Section 5.21.1.7: ncqr/nsqr can't be 65535
-                if ncqr == 0xFFFF || nsqr == 0xFFFF {
+                if ncqr == 0 || nsqr == 0 {
                     return cmds::Completion::generic_err(STS_INVAL_FIELD);
                 }
                 // TODO: error if called after initialization

--- a/propolis/src/hw/nvme/bits.rs
+++ b/propolis/src/hw/nvme/bits.rs
@@ -24,7 +24,7 @@ pub struct RawSubmission {
     /// The namespace that this command applies to.
     pub nsid: u32,
 
-    /// Reserved
+    /// Reserved - Bytes 15:08
     pub rsvd: u64,
 
     /// Metadata Pointer (MPTR)
@@ -106,7 +106,7 @@ pub struct RawCompletion {
     /// A command specific value.
     pub dw0: u32,
 
-    /// Reserved
+    /// Reserved (DW1) - Bytes 07:04
     pub rsvd: u32,
 
     /// Submission Queue Head Pointer (SQHD)
@@ -414,7 +414,7 @@ pub struct PowerStateDescriptor {
     /// The value multiplied by 0.01 is equal to the power in Watts.
     pub mp: u16,
 
-    /// Reserved
+    /// Reserved - Bits 31:16
     pub _resv1: u16,
 
     /// Entry Latency (ENLAT)
@@ -431,31 +431,31 @@ pub struct PowerStateDescriptor {
     ///
     /// Must be less than the number of supported power states.
     ///
-    /// Top 4 bits are reserved.
+    /// Top 3 bits are reserved - Bits 103:101
     pub rrt: u8,
 
     /// Relative Read Latency (RRL)
     ///
     /// Must be less than the number of supported power states.
     ///
-    /// Top 4 bits are reserved.
+    /// Top 3 bits are reserved - Bits 111:109
     pub rrl: u8,
 
     /// Relative Write Throughput (RWT)
     ///
     /// Must be less than the number of supported power states.
     ///
-    /// Top 4 bits are reserved.
+    /// Top 3 bits are reserved - Bits 119:117
     pub rwt: u8,
 
     /// Relative Write Latency (RWL)
     ///
     /// Must be less than the number of supported power states.
     ///
-    /// Top 4 bits are reserved.
+    /// Top 3 bits are reserved - Bits 127:125
     pub rwl: u8,
 
-    /// Reserved
+    /// Reserved - Bits 255:128
     pub _resv: [u8; 16],
 }
 
@@ -509,7 +509,7 @@ pub struct IdentifyController {
     /// reported as a power of two (2^n). A value of 0h indicates no restrictions on
     /// transfer size. The restrictions includes interleaved metadata.
     pub mdts: u8,
-    /// Reserved
+    /// Reserved - Bytes 255:78
     pub _resv1: [u8; 178],
 
     // bytes 256-511 - Admin Command Set Attributes & Optional Controller Capabilities
@@ -586,7 +586,7 @@ pub struct IdentifyController {
     /// Controllers with proprietary extensions may support a larger size.
     /// Both the required and maximum CQES values are in bytes and reported as powers of two (2^n).
     pub cqes: u8,
-    /// Reserved
+    /// Reserved - Bytes 515:514
     pub _resv3: [u8; 2],
     /// Number of Namespaces (NN)
     ///
@@ -634,9 +634,9 @@ pub struct IdentifyController {
     /// See NVMe 1.0e Section 4.2, Figure 8 Command Format - Admin and NVM Vendor Specific Commands (Optional)
     /// See NVMe 1.0e Section 8.7 Standard Vendor Specific Command Format
     pub nvscc: u8,
-    /// Reserved
+    /// Reserved - Bytes 703:531
     pub _resv4: [u8; 173],
-    /// Reserved (I/O Command Set Attributes)
+    /// Reserved (I/O Command Set Attributes) - Bytes 2047:704
     pub _resv5: [u8; 1344],
 
     // bytes 2048-3071 - Power State Descriptors
@@ -793,13 +793,13 @@ pub struct IdentifyNamespace {
     ///     100b-111b = Reserved
     /// See NVMe 1.0e Section 8.3 End-to-end Data Protection (Optional)
     pub dps: u8,
-    /// Reserved
+    /// Reserved - Bytes 127:30
     pub _resv1: [u8; 98],
     /// LBA Formats (LBAF0-LBAF15)
     ///
     /// The list of supported LBA formats.
     pub lbaf: [LbaFormat; 16],
-    /// Reserved
+    /// Reserved - Bytes 383:192
     pub _resv2: [u8; 192],
     /// Vendor Specific (VS)
     pub vs: [u8; 3712],

--- a/propolis/src/hw/nvme/bits.rs
+++ b/propolis/src/hw/nvme/bits.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(dead_code)]
 
 #[derive(Debug, Default, Copy, Clone)]
 #[repr(C)]

--- a/propolis/src/hw/nvme/bits.rs
+++ b/propolis/src/hw/nvme/bits.rs
@@ -127,7 +127,6 @@ pub const IDENT_CNS_CONTROLLER: u8 = 0x1;
 pub const IDENT_CNS_ACTIVE_NSID: u8 = 0x2;
 pub const IDENT_CNS_NSID_DESC: u8 = 0x3;
 
-
 #[derive(Copy, Clone)]
 #[repr(u8)]
 pub enum StatusCodeType {

--- a/propolis/src/hw/nvme/bits.rs
+++ b/propolis/src/hw/nvme/bits.rs
@@ -1,0 +1,366 @@
+#![allow(unused)]
+
+#[derive(Debug, Default, Copy, Clone)]
+#[repr(C)]
+pub struct RawSubmission {
+    pub cdw0: u32,
+    pub nsid: u32,
+    pub rsvd: u64,
+    pub mptr: u64,
+    pub prp1: u64,
+    pub prp2: u64,
+    pub cdw10: u32,
+    pub cdw11: u32,
+    pub cdw12: u32,
+    pub cdw13: u32,
+    pub cdw14: u32,
+    pub cdw15: u32,
+}
+impl RawSubmission {
+    pub fn cid(&self) -> u16 {
+        (self.cdw0 >> 16) as u16
+    }
+    pub fn opcode(&self) -> u8 {
+        self.cdw0 as u8
+    }
+}
+
+#[derive(Debug, Default, Copy, Clone)]
+#[repr(C)]
+pub struct RawCompletion {
+    pub cdw0: u32,
+    pub rsvd: u32,
+    pub sqhd: u16,
+    pub sqid: u16,
+    pub cid: u16,
+    pub status: u16,
+}
+
+// Register bits
+
+pub const CAP_CCS: u64 = 1 << 37; // CAP.CCS - NVM command set
+pub const CAP_CQR: u64 = 1 << 16; // CAP.CQR - require contiguous queus
+
+pub const CC_EN: u32 = 0x1;
+
+pub const CSTS_READY: u32 = 0x1;
+
+// Version definitions
+
+pub const NVME_VER_1_0: u32 = 0x00010000;
+
+// Admin Command Opcodes
+
+pub const ADMIN_OPC_DELETE_IO_SQ: u8 = 0x00;
+pub const ADMIN_OPC_CREATE_IO_SQ: u8 = 0x01;
+pub const ADMIN_OPC_GET_LOG_PAGE: u8 = 0x02;
+pub const ADMIN_OPC_DELETE_IO_CQ: u8 = 0x04;
+pub const ADMIN_OPC_CREATE_IO_CQ: u8 = 0x05;
+pub const ADMIN_OPC_IDENTIFY: u8 = 0x06;
+pub const ADMIN_OPC_ABORT: u8 = 0x08;
+pub const ADMIN_OPC_SET_FEATURES: u8 = 0x09;
+pub const ADMIN_OPC_GET_FEATURES: u8 = 0x0a;
+pub const ADMIN_OPC_ASYNC_EVENT_REQ: u8 = 0x0c;
+
+// Nvm Command Opcodes
+
+pub const NVM_OPC_FLUSH: u8 = 0x00;
+pub const NVM_OPC_WRITE: u8 = 0x01;
+pub const NVM_OPC_READ: u8 = 0x02;
+
+// Command Status values
+
+pub const STS_SUCCESS: u8 = 0x0;
+pub const STS_INVAL_OPC: u8 = 0x1;
+pub const STS_INVAL_FIELD: u8 = 0x2;
+pub const STS_CID_CONFLICT: u8 = 0x3;
+pub const STS_DATA_XFER_ERR: u8 = 0x4;
+pub const STS_PWR_LOSS_ABRT: u8 = 0x5;
+pub const STS_INTERNAL_ERR: u8 = 0x6;
+pub const STS_ABORT_REQ: u8 = 0x7;
+pub const STS_ABORT_SQ_DEL: u8 = 0x8;
+pub const STS_FAILED_FUSED: u8 = 0x9;
+pub const STS_MISSING_FUSED: u8 = 0xa;
+pub const STS_INVALID_NS: u8 = 0xb;
+pub const STS_COMMAND_SEQ_ERR: u8 = 0xc;
+pub const STS_INVAL_SGL_DESC: u8 = 0xd;
+pub const STS_INVAL_SGL_NUM: u8 = 0xe;
+pub const STS_INVAL_SGL_LEN: u8 = 0xf;
+pub const STS_INVAL_SGL_META_LEN: u8 = 0x10;
+pub const STS_INVAL_SGL_TYPE_LEN: u8 = 0x11;
+pub const STS_INVAL_CMB_USE: u8 = 0x12;
+pub const STS_INVAL_PRP_OFFSET: u8 = 0x13;
+
+pub const STS_CREATE_IO_Q_INVAL_CQ: u8 = 0x0;
+pub const STS_CREATE_IO_Q_INVAL_QID: u8 = 0x1;
+pub const STS_CREATE_IO_Q_INVAL_QSIZE: u8 = 0x2;
+pub const STS_CREATE_IO_Q_INVAL_INT_VEC: u8 = 0x8;
+
+// SetFeature Command Specific Status values
+
+pub const STS_SET_FEATURE_NOT_SAVEABLE: u8 = 0x0D;
+pub const STS_SET_FEATURE_NOT_CHANGEABLE: u8 = 0x0E;
+pub const STS_SET_FEATURE_NOT_NAMESPACE_SPECIFIC: u8 = 0x0F;
+pub const STS_SET_FEATURE_OVERLAPPING_RANGES: u8 = 0x14;
+
+// Read Command Status values
+
+pub const STS_READ_CONFLICTING_ATTRS: u8 = 0x80;
+pub const STS_READ_INVALID_PROT_INFO: u8 = 0x81;
+
+// Feature identifiers
+
+pub const FEAT_ID_ARBITRATION: u8 = 0x01;
+pub const FEAT_ID_POWER_MGMT: u8 = 0x02;
+pub const FEAT_ID_TEMP_THRESH: u8 = 0x04;
+pub const FEAT_ID_ERROR_RECOVERY: u8 = 0x05;
+pub const FEAT_ID_NUM_QUEUES: u8 = 0x07;
+pub const FEAT_ID_INTR_COALESCE: u8 = 0x08;
+pub const FEAT_ID_INTR_VEC_CFG: u8 = 0x09;
+pub const FEAT_ID_WRITE_ATOMIC: u8 = 0x0a;
+pub const FEAT_ID_ASYNC_EVENT_CFG: u8 = 0x0b;
+
+// Identify CNS values
+
+pub const IDENT_CNS_NAMESPACE: u8 = 0x0;
+pub const IDENT_CNS_CONTROLLER: u8 = 0x1;
+pub const IDENT_CNS_ACTIVE_NSID: u8 = 0x2;
+pub const IDENT_CNS_NSID_DESC: u8 = 0x3;
+
+
+#[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum StatusCodeType {
+    Generic = 0,
+    CmdSpecific = 1,
+    MediaDataIntegrity = 2,
+    VendorSpecific = 7,
+}
+
+#[derive(Default, Copy, Clone)]
+#[repr(C)]
+pub struct PowerStateDescriptor {
+    /// Maximum Power
+    pub mp: u16,
+    /// Reserved
+    pub _resv1: u16,
+    /// Entry Latency
+    pub enlat: u32,
+    /// Exit Latency
+    pub exlat: u32,
+    /// Relative Read Throughput
+    pub rrt: u8,
+    /// Relative Read Latency
+    pub rrl: u8,
+    /// Relative Write Throughput
+    pub rwt: u8,
+    /// Relative Write Latency
+    pub rwl: u8,
+    /// Reserved
+    pub _resv: [u8; 16],
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct IdentifyController {
+    // bytes 0-255 - Controller Capabilities and Features
+    /// PCI Vendor ID
+    pub vid: u16,
+    /// PCI Subsystem Vendor ID
+    pub ssvid: u16,
+    /// Serial Number
+    pub sn: [u8; 20],
+    /// Model Number
+    pub mn: [u8; 40],
+    /// Firmware Revision
+    pub fr: [u8; 8],
+    /// Recommended Arbitration Burst
+    pub rab: u8,
+    /// IEEE OUI Identifier
+    pub ieee: [u8; 3],
+    /// Multi-Interface Capabilities
+    pub cmic: u8,
+    /// Maximum Data Transfer Size
+    pub mdts: u8,
+    /// Reserved
+    pub _resv1: [u8; 178],
+
+    // bytes 256-511 - Admin Command Set Attributes & Optional Controller Capabilities
+    /// Optional Admin Command Support
+    pub oacs: u16,
+    /// Abort Command Limit
+    pub acl: u8,
+    /// Asynchronous Event Request Limit
+    pub aerl: u8,
+    /// Firmware Updates
+    pub frmw: u8,
+    /// Log Page Attributes
+    pub lpa: u8,
+    /// Error Log Page Etnries
+    pub elpe: u8,
+    /// Number of Power States Support
+    pub npss: u8,
+    /// Admin Vedor Specific Command Configuration
+    pub avscc: u8,
+    /// Reserved
+    pub _resv2: [u8; 246],
+
+    // bytes 512-2047 - NVM Command Set Attributes
+    /// Submission Queue Entry Size
+    pub sqes: u8,
+    /// Completion Queue Entry Size
+    pub cqes: u8,
+    /// Reserved
+    pub _resv3: [u8; 2],
+    /// Number of Namespaces
+    pub nn: u32,
+    /// Option NVM Command Support
+    pub oncs: u16,
+    /// Fused Operation Support
+    pub fuses: u16,
+    /// Format NVM Attributes
+    pub fna: u8,
+    /// Volatile Write Cache
+    pub vwc: u8,
+    /// Atomic Write Unit Normal
+    pub awun: u16,
+    /// Atomic Write Unit Power Fail
+    pub awupf: u16,
+    /// NVM Vendor Specific Command Configuration
+    pub nvscc: u8,
+    /// Reserved
+    pub _resv4: [u8; 173],
+    /// Reserved (I/O Command Set Attributes)
+    pub _resv5: [u8; 1344],
+
+    // bytes 2048-3071 - Power State Descriptors
+    /// Power State Descriptors (PSD0-PSD31)
+    pub psd: [PowerStateDescriptor; 32],
+
+    // bytes 3072-4095 - Vendor Specific
+    /// Vendor Specific
+    pub vs: [u8; 1024],
+}
+
+// We can't derive Default since Default isn't impl'd
+// for [T; N] where N > 32 yet (rust #61415)
+impl Default for IdentifyController {
+    fn default() -> Self {
+        Self {
+            vid: 0,
+            ssvid: 0,
+            sn: [0; 20],
+            mn: [0; 40],
+            fr: [0; 8],
+            rab: 0,
+            ieee: [0; 3],
+            cmic: 0,
+            mdts: 0,
+            oacs: 0,
+            acl: 0,
+            aerl: 0,
+            frmw: 0,
+            lpa: 0,
+            elpe: 0,
+            npss: 0,
+            avscc: 0,
+            sqes: 0,
+            cqes: 0,
+            nn: 0,
+            oncs: 0,
+            fuses: 0,
+            fna: 0,
+            vwc: 0,
+            awun: 0,
+            awupf: 0,
+            nvscc: 0,
+            psd: [PowerStateDescriptor::default(); 32],
+            vs: [0; 1024],
+
+            _resv1: [0; 178],
+            _resv2: [0; 246],
+            _resv3: [0; 2],
+            _resv4: [0; 173],
+            _resv5: [0; 1344],
+        }
+    }
+}
+
+#[derive(Default, Copy, Clone)]
+#[repr(C)]
+pub struct LbaFormat {
+    /// Metadata Size
+    pub ms: u16,
+    /// LBA Data Size
+    pub lbads: u8,
+    /// Relative Performance
+    pub rp: u8,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct IdentifyNamespace {
+    /// Namespace Size
+    pub nsze: u64,
+    /// Namespace Capacity
+    pub ncap: u64,
+    /// Namespace Utilization
+    pub nuse: u64,
+    /// Namespace Features
+    pub nsfeat: u8,
+    /// Number of LBA Formats
+    pub nlbaf: u8,
+    /// Formatted LBA Size
+    pub flbas: u8,
+    /// Metadata Capabilities
+    pub mc: u8,
+    /// End-to-end Data Protection Capabilities
+    pub dpc: u8,
+    /// End-to-end Data Protection Type Settings
+    pub dps: u8,
+    /// Reserved
+    pub _resv1: [u8; 98],
+    /// LBA Formats
+    pub lbaf: [LbaFormat; 16],
+    /// Reserved
+    pub _resv2: [u8; 192],
+    /// Vendor Specific
+    pub vs: [u8; 3712],
+}
+
+impl Default for IdentifyNamespace {
+    fn default() -> Self {
+        Self {
+            nsze: 0,
+            ncap: 0,
+            nuse: 0,
+            nsfeat: 0,
+            nlbaf: 0,
+            flbas: 0,
+            mc: 0,
+            dpc: 0,
+            dps: 0,
+            lbaf: [LbaFormat::default(); 16],
+            vs: [0; 3712],
+
+            _resv1: [0; 98],
+            _resv2: [0; 192],
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::mem::size_of;
+
+    #[test]
+    fn entry_sizing() {
+        assert_eq!(size_of::<RawSubmission>(), 64);
+        assert_eq!(size_of::<RawCompletion>(), 16);
+        assert_eq!(size_of::<PowerStateDescriptor>(), 32);
+        assert_eq!(size_of::<IdentifyController>(), 4096);
+        assert_eq!(size_of::<LbaFormat>(), 4);
+        assert_eq!(size_of::<IdentifyNamespace>(), 4096);
+    }
+}

--- a/propolis/src/hw/nvme/bits.rs
+++ b/propolis/src/hw/nvme/bits.rs
@@ -231,7 +231,6 @@ pub const NVM_OPC_WRITE: u8 = 0x01;
 /// Read Command Opcode
 pub const NVM_OPC_READ: u8 = 0x02;
 
-
 // Generic Command Status values
 // See NVMe 1.0e Section 4.5.1.2.1, Figure 17 Status Code - Generic Command Status Values
 
@@ -329,7 +328,6 @@ pub const STS_WRITE_READ_ONLY_RANGE: u8 = 0x82;
 
 // Feature identifiers
 // See NVMe 1.0e Section 5.12.1, Figure 73 Set Features - Feature Identifiers
-
 
 /// Arbitration
 ///
@@ -470,7 +468,6 @@ pub struct PowerStateDescriptor {
 #[repr(C)]
 pub struct IdentifyController {
     // bytes 0-255 - Controller Capabilities and Features
-
     /// PCI Vendor ID (VID)
     ///
     /// Same value reported in ID register.
@@ -516,7 +513,6 @@ pub struct IdentifyController {
     pub _resv1: [u8; 178],
 
     // bytes 256-511 - Admin Command Set Attributes & Optional Controller Capabilities
-
     /// Optional Admin Command Support (OACS)
     ///
     /// Bits 15:3 are reserved.
@@ -570,7 +566,6 @@ pub struct IdentifyController {
     pub _resv2: [u8; 246],
 
     // bytes 512-2047 - NVM Command Set Attributes
-
     /// Submission Queue Entry Size (SQES)
     ///
     /// Defines the required and maximum Submission Queue entry sizes when using the NVM Command Set.
@@ -645,12 +640,10 @@ pub struct IdentifyController {
     pub _resv5: [u8; 1344],
 
     // bytes 2048-3071 - Power State Descriptors
-
     /// Power State Descriptors (PSD0-PSD31)
     pub psd: [PowerStateDescriptor; 32],
 
     // bytes 3072-4095 - Vendor Specific
-
     /// Vendor Specific (VS)
     pub vs: [u8; 1024],
 }

--- a/propolis/src/hw/nvme/cmds.rs
+++ b/propolis/src/hw/nvme/cmds.rs
@@ -1,5 +1,5 @@
 use super::bits::{self, RawSubmission, StatusCodeType};
-use super::queue::QueueCreateErr;
+use super::queue::{QueueCreateErr, QueueId};
 use crate::common::*;
 use crate::hw::nvme::bits::STS_INVAL_PRP_OFFSET;
 use crate::vmm::MemCtx;
@@ -20,8 +20,6 @@ pub enum ParseErr {
     #[error("reserved FUSE value specified")]
     ReservedFuse,
 }
-
-type QueueId = u16;
 
 #[derive(Debug)]
 pub enum AdminCmd {

--- a/propolis/src/hw/nvme/cmds.rs
+++ b/propolis/src/hw/nvme/cmds.rs
@@ -1,0 +1,560 @@
+use super::bits::{self, RawSubmission, StatusCodeType};
+use super::queue::QueueCreateErr;
+use crate::common::*;
+use crate::hw::nvme::bits::STS_INVAL_PRP_OFFSET;
+use crate::vmm::MemCtx;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ParseErr {
+    #[error("SGLs not supported")]
+    SGL,
+
+    #[error("Fused ops not supported")]
+    Fused,
+
+    #[error("reserved PSDT value specified")]
+    ReservedPsdt,
+
+    #[error("reserved FUSE value specified")]
+    ReservedFuse,
+}
+
+type QueueId = u16;
+
+#[derive(Debug)]
+pub enum AdminCmd {
+    DeleteIOSubQ(QueueId),
+    CreateIOSubQ(CreateIOSQCmd),
+    GetLogPage(GetLogPageCmd),
+    DeleteIOCompQ(QueueId),
+    CreateIOCompQ(CreateIOCQCmd),
+    Identify(IdentifyCmd),
+    Abort,
+    SetFeatures(SetFeaturesCmd),
+    GetFeatures,
+    AsyncEventReq,
+    Unknown(RawSubmission),
+}
+impl AdminCmd {
+    pub fn parse(
+        raw: RawSubmission,
+    ) -> Result<(Self, SubmissionEntry), ParseErr> {
+        let cmd = match raw.opcode() {
+            bits::ADMIN_OPC_DELETE_IO_SQ => {
+                AdminCmd::DeleteIOSubQ(raw.cdw10 as u16)
+            }
+            bits::ADMIN_OPC_CREATE_IO_SQ => {
+                let queue_prio = match (raw.cdw11 & 0b110) >> 1 {
+                    0b00 => QueuePriority::Urgent,
+                    0b01 => QueuePriority::High,
+                    0b10 => QueuePriority::Medium,
+                    0b11 => QueuePriority::Low,
+                    _ => unreachable!(),
+                };
+                AdminCmd::CreateIOSubQ(CreateIOSQCmd {
+                    prp: raw.prp1,
+                    qsize: (raw.cdw10 >> 16) as u16,
+                    qid: raw.cdw10 as u16,
+                    cqid: (raw.cdw11 >> 16) as u16,
+                    queue_prio,
+                    phys_contig: (raw.cdw11 & 1) != 0,
+                })
+            }
+            bits::ADMIN_OPC_GET_LOG_PAGE => {
+                AdminCmd::GetLogPage(GetLogPageCmd {
+                    nsid: raw.nsid,
+                    len: (((raw.cdw11 as u16) as u32) << 16
+                        | (raw.cdw10 >> 16)) * 4,
+                    retain_async_ev: (raw.cdw10 & (1 << 15) != 0),
+                    log_specific_field: (raw.cdw10 >> 8) as u8 & 0b1111,
+                    log_page_ident: LogPageIdent::from(raw.cdw10 as u8),
+                    log_page_offset: raw.cdw12 as u64
+                        | (raw.cdw13 as u64) << 32,
+                    prp1: raw.prp1,
+                    prp2: raw.prp2,
+                })
+            }
+            bits::ADMIN_OPC_DELETE_IO_CQ => {
+                AdminCmd::DeleteIOCompQ(raw.cdw10 as u16)
+            }
+            bits::ADMIN_OPC_CREATE_IO_CQ => {
+                AdminCmd::CreateIOCompQ(CreateIOCQCmd {
+                    prp: raw.prp1,
+                    qsize: (raw.cdw10 >> 16) as u16,
+                    qid: raw.cdw10 as u16,
+                    intr_vector: (raw.cdw11 >> 16) as u16,
+                    intr_enable: (raw.cdw11 & 0b10) != 0,
+                    phys_contig: (raw.cdw11 & 0b1) != 0,
+                })
+            }
+            bits::ADMIN_OPC_IDENTIFY => AdminCmd::Identify(IdentifyCmd {
+                cns: raw.cdw10 as u8,
+                cntid: (raw.cdw10 >> 16) as u16,
+                nsid: raw.nsid,
+                prp1: raw.prp1,
+                prp2: raw.prp2,
+            }),
+            bits::ADMIN_OPC_ABORT => AdminCmd::Abort,
+            bits::ADMIN_OPC_SET_FEATURES => AdminCmd::SetFeatures(SetFeaturesCmd {
+                save: (raw.cdw10 & (1 << 31)) != 0,
+                fid: FeatureIdent::from((raw.cdw10 as u8, raw.cdw11)),
+            }),
+            bits::ADMIN_OPC_GET_FEATURES => AdminCmd::GetFeatures,
+            bits::ADMIN_OPC_ASYNC_EVENT_REQ => AdminCmd::AsyncEventReq,
+            _ => AdminCmd::Unknown(raw),
+        };
+        let _psdt = match (raw.cdw0 >> 14) & 0b11 {
+            0b00 => Ok(()),             // PRP
+            0b01 => Err(ParseErr::SGL), // SGL buffer
+            0b10 => Err(ParseErr::SGL), // SGL segment
+            _ => Err(ParseErr::ReservedPsdt),
+        }?;
+        let _fuse = match (raw.cdw0 >> 8) & 0b11 {
+            0b00 => Ok(()),                 // Normal (non-fused) operation
+            0b01 => Err(ParseErr::Fused),   // First fused op
+            0b10 => Err(ParseErr::Fused),   // Second fused op
+            _ => Err(ParseErr::ReservedFuse),
+        }?;
+        Ok((cmd, SubmissionEntry::new(&raw)))
+    }
+}
+
+pub struct SubmissionEntry {
+    pub cid: u16,
+    pub prp1: u64,
+    pub prp2: u64,
+}
+impl SubmissionEntry {
+    fn new(raw: &RawSubmission) -> Self {
+        Self { cid: raw.cid(), prp1: raw.prp1, prp2: raw.prp2 }
+    }
+}
+
+#[derive(Debug)]
+pub struct CreateIOCQCmd {
+    pub prp: u64,
+    pub qsize: u16,
+    pub qid: QueueId,
+    pub intr_vector: u16,
+    pub intr_enable: bool,
+    pub phys_contig: bool,
+}
+#[derive(Debug)]
+pub struct CreateIOSQCmd {
+    pub prp: u64,
+    pub qsize: u16,
+    pub qid: QueueId,
+    pub cqid: QueueId,
+    pub queue_prio: QueuePriority,
+    pub phys_contig: bool,
+}
+
+#[derive(Debug)]
+pub enum QueuePriority {
+    Urgent,
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug)]
+pub struct GetLogPageCmd {
+    pub nsid: u32,
+    pub len: u32,
+    pub retain_async_ev: bool,
+    pub log_specific_field: u8,
+    pub log_page_ident: LogPageIdent,
+    pub log_page_offset: u64,
+    prp1: u64,
+    prp2: u64,
+}
+
+impl GetLogPageCmd {
+    pub fn data<'a>(&'a self, mem: MemCtx<'a>) -> PrpIter<'a> {
+        PrpIter::new(PAGE_SIZE as u64, self.prp1, self.prp2, mem)
+    }
+}
+
+#[derive(Debug)]
+pub enum LogPageIdent {
+    Reserved,
+    Error,
+    Smart,
+    Firmware,
+    Reservation,
+    SanitizeStatus,
+    Vendor(u8),
+}
+
+impl From<u8> for LogPageIdent {
+    fn from(ident: u8) -> Self {
+        match ident {
+            0 => LogPageIdent::Reserved,
+            1 => LogPageIdent::Error,
+            2 => LogPageIdent::Smart,
+            3 => LogPageIdent::Firmware,
+            4..=8 => LogPageIdent::Reserved,
+            9..=0x6F => LogPageIdent::Reserved,
+            0x70 => LogPageIdent::Reserved,
+            0x71..=0x7F => LogPageIdent::Reserved,
+            0x80 => LogPageIdent::Reservation,
+            0x81 => LogPageIdent::SanitizeStatus,
+            0x82..=0xBF => LogPageIdent::Reserved,
+            0xC0..=0xFF => LogPageIdent::Vendor(ident),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct IdentifyCmd {
+    pub cns: u8,
+    pub cntid: u16,
+    pub nsid: u32,
+    prp1: u64,
+    prp2: u64,
+}
+impl IdentifyCmd {
+    pub fn data<'a>(&'a self, mem: MemCtx<'a>) -> PrpIter<'a> {
+        PrpIter::new(PAGE_SIZE as u64, self.prp1, self.prp2, mem)
+    }
+}
+
+#[derive(Debug)]
+pub struct SetFeaturesCmd {
+    pub save: bool,
+    pub fid: FeatureIdent,
+}
+
+#[derive(Debug)]
+pub enum FeatureIdent {
+    Reserved,
+    Arbitration,
+    PowerManagement,
+    LbaRangeType,
+    TemperatureThreshold,
+    ErrorRecovery,
+    VolatileWriteCache,
+    NumberOfQueues {
+        /// Number of I/O Completion Queues Requested
+        ncqr: u16,
+        /// Number of I/O Submission Queues Requested
+        nsqr: u16,
+    },
+    InterruptCoalescing,
+    InterruptVectorConfiguration,
+    WriteAtomicityNormal,
+    AsynchronousEventConfiguration,
+    AutonomousPowerStateTransition,
+    HostMemoryBuffer,
+    Timestamp,
+    KeepAliveTimer,
+    HostControlledThermalManagement,
+    NonOperationPowerStateConfig,
+    Managment(u8),
+    SoftwareProgressMarker,
+    HostIdentifier,
+    ReservationNotificationMask,
+    ReservationPersistance,
+    Vendor(u8),
+}
+
+impl From<(u8, u32)> for FeatureIdent {
+    fn from((id, cdw11): (u8, u32)) -> Self {
+        use FeatureIdent::*;
+        match id {
+            0 => Reserved,
+            1 => Arbitration,
+            2 => PowerManagement,
+            3 => LbaRangeType,
+            4 => TemperatureThreshold,
+            5 => ErrorRecovery,
+            6 => VolatileWriteCache,
+            7 => NumberOfQueues {
+                ncqr: (cdw11 >> 16) as u16,
+                nsqr: cdw11 as u16
+            },
+            8 => InterruptCoalescing,
+            9 => InterruptVectorConfiguration,
+            0xA => WriteAtomicityNormal,
+            0xB => AsynchronousEventConfiguration,
+            0xC => AutonomousPowerStateTransition,
+            0xD => HostMemoryBuffer,
+            0xE => Timestamp,
+            0xF => KeepAliveTimer,
+            0x10 => HostControlledThermalManagement,
+            0x11 => NonOperationPowerStateConfig,
+            0x12..=0x77 => Reserved,
+            0x78..=0x7F => Managment(id),
+            0x80 => SoftwareProgressMarker,
+            0x81 => HostIdentifier,
+            0x82 => ReservationNotificationMask,
+            0x83 => ReservationPersistance,
+            0x84..=0xBF => Reserved,
+            0xC0..=0xFF => Vendor(id),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum NvmCmd {
+    Flush,
+    Write(WriteCmd),
+    Read(ReadCmd),
+    Unknown(RawSubmission),
+}
+
+impl NvmCmd {
+    pub fn parse(
+        raw: RawSubmission,
+    ) -> Result<(Self, SubmissionEntry), ParseErr> {
+        let _psdt = match (raw.cdw0 >> 14) & 0b11 {
+            0b00 => Ok(()),                 // PRP
+            0b01 => Err(ParseErr::SGL),     // SGL buffer
+            0b10 => Err(ParseErr::SGL),     // SGL segment
+            _ => Err(ParseErr::ReservedPsdt),
+        }?;
+        let _fuse = match (raw.cdw0 >> 8) & 0b11 {
+            0b00 => Ok(()), // Normal (non-fused) operation
+            0b01 => Err(ParseErr::Fused),   // First fused op
+            0b10 => Err(ParseErr::Fused),   // Second fused op
+            _ => Err(ParseErr::ReservedFuse),
+        }?;
+        let cmd = match raw.opcode() {
+            bits::NVM_OPC_FLUSH => NvmCmd::Flush,
+            bits::NVM_OPC_WRITE => NvmCmd::Write(WriteCmd {
+                slba: (raw.cdw11 as u64) << 32 | raw.cdw10 as u64,
+                nlb: raw.cdw12 as u16,
+                prp1: raw.prp1,
+                prp2: raw.prp2,
+            }),
+            bits::NVM_OPC_READ => NvmCmd::Read(ReadCmd {
+                slba: (raw.cdw11 as u64) << 32 | raw.cdw10 as u64,
+                nlb: raw.cdw12 as u16,
+                prp1: raw.prp1,
+                prp2: raw.prp2,
+            }),
+            _ => NvmCmd::Unknown(raw),
+        };
+        Ok((cmd, SubmissionEntry::new(&raw)))
+    }
+}
+
+#[derive(Debug)]
+pub struct WriteCmd {
+    pub slba: u64,
+    pub nlb: u16,
+    prp1: u64,
+    prp2: u64,
+}
+
+impl WriteCmd {
+    pub fn data<'a>(&'a self, sz: u64, mem: MemCtx<'a>) -> PrpIter<'a> {
+        PrpIter::new(sz, self.prp1, self.prp2, mem)
+    }
+}
+
+#[derive(Debug)]
+pub struct ReadCmd {
+    pub slba: u64,
+    pub nlb: u16,
+    prp1: u64,
+    prp2: u64,
+}
+
+impl ReadCmd {
+    pub fn data<'a>(&'a self, sz: u64, mem: MemCtx<'a>) -> PrpIter<'a> {
+        PrpIter::new(sz, self.prp1, self.prp2, mem)
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+enum PrpNext {
+    Prp1,
+    Prp2,
+    List(u64, u16),
+    Done,
+}
+
+// 512 64-bit entries in a PRP list
+const PRP_LIST_MAX: u16 = 511;
+
+pub struct PrpIter<'a> {
+    prp1: u64,
+    prp2: u64,
+    mem: MemCtx<'a>,
+    remain: u64,
+    next: PrpNext,
+    error: Option<&'static str>,
+}
+impl<'a> PrpIter<'a> {
+    pub fn new(size: u64, prp1: u64, prp2: u64, mem: MemCtx<'a>) -> Self {
+        // prp1 and prp2 are expected to be 32-bit aligned
+        assert!(prp1 & 0b11 == 0);
+        assert!(prp2 & 0b11 == 0);
+        Self { prp1, prp2, mem, remain: size, next: PrpNext::Prp1, error: None }
+    }
+}
+
+impl PrpIter<'_> {
+    fn get_next(&mut self) -> Result<GuestRegion, &'static str> {
+        assert!(self.remain > 0);
+        assert!(self.error.is_none());
+
+        let (addr, size, next) = match self.next {
+            PrpNext::Prp1 => {
+                let offset = self.prp1 & PAGE_OFFSET as u64;
+                let size = u64::min(PAGE_SIZE as u64 - offset, self.remain);
+                let after = self.remain - size;
+                let next = if after == 0 {
+                    PrpNext::Done
+                } else if after <= PAGE_SIZE as u64 {
+                    // Remaining data can be covered by single additional PRP
+                    // entry which should be present in PRP2
+                    PrpNext::Prp2
+                } else {
+                    let list_off = (self.prp2 & PAGE_OFFSET as u64) / 8;
+                    PrpNext::List(self.prp2, list_off as u16)
+                };
+                (self.prp1, size, next)
+            }
+            PrpNext::Prp2 => {
+                // If a second PRP entry is present within a command, it shall
+                // have a memory page offset of 0h
+                if self.prp2 & PAGE_OFFSET as u64 != 0 {
+                    return Err("Inappropriate PRP2 offset");
+                }
+                let size = self.remain;
+                assert!(size <= PAGE_SIZE as u64);
+                (self.prp2, size, PrpNext::Done)
+            }
+            PrpNext::List(base, idx) => {
+                assert!(idx <= PRP_LIST_MAX);
+                let entry_addr = base + (idx as u64) * 8;
+                let entry: u64 = self
+                    .mem
+                    .read(GuestAddr(entry_addr))
+                    .ok_or_else(|| "Unable to read PRP list entry")?;
+                if entry & PAGE_OFFSET as u64 != 0 {
+                    return Err("Inappropriate PRP list entry offset");
+                }
+                if self.remain <= PAGE_SIZE as u64 {
+                    (entry, self.remain, PrpNext::Done)
+                } else {
+                    if idx != PRP_LIST_MAX {
+                        (entry, PAGE_SIZE as u64, PrpNext::List(base, idx + 1))
+                    } else {
+                        // Chase the PRP to the next PRP list and read the first entry from it to
+                        // use as the next result.
+                        let next_entry: u64 =
+                            self.mem.read(GuestAddr(entry)).ok_or_else(
+                                || "Unable to read PRP list entry",
+                            )?;
+                        if next_entry & PAGE_OFFSET as u64 != 0 {
+                            return Err("Inappropriate PRP list entry offset");
+                        }
+                        (next_entry, PAGE_SIZE as u64, PrpNext::List(entry, 1))
+                    }
+                }
+            }
+            PrpNext::Done => {
+                // prior checks of self.remain should prevent us from ever reaching this
+                panic!()
+            }
+        };
+
+        assert!(size <= self.remain);
+        if size == self.remain {
+            assert_eq!(next, PrpNext::Done);
+        }
+        self.remain -= size;
+        self.next = next;
+
+        Ok(GuestRegion(GuestAddr(addr), size as usize))
+    }
+}
+impl Iterator for PrpIter<'_> {
+    type Item = GuestRegion;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remain == 0 || self.error.is_some() {
+            return None;
+        }
+        match self.get_next() {
+            Ok(res) => Some(res),
+            Err(e) => {
+                self.error = Some(e);
+                None
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Completion {
+    /// Status Code Type and Status Code
+    pub status: u16,
+    pub cdw0: u32,
+}
+
+impl Completion {
+    pub fn success() -> Self {
+        Self {
+            cdw0: 0,
+            status: Self::status_field(
+                StatusCodeType::Generic,
+                bits::STS_SUCCESS,
+            ),
+        }
+    }
+    pub fn success_val(cdw0: u32) -> Self {
+        Self {
+            cdw0,
+            status: Self::status_field(
+                StatusCodeType::Generic,
+                bits::STS_SUCCESS,
+            ),
+        }
+    }
+
+    pub fn specific_err(sct: StatusCodeType, status: u8) -> Self {
+        // success doesn't belong in an error
+        assert_ne!(status, bits::STS_SUCCESS);
+
+        Self {
+            cdw0: 0,
+            status: Self::status_field(sct, status),
+        }
+    }
+
+    pub fn generic_err(status: u8) -> Self {
+        // success doesn't belong in an error
+        assert_ne!(status, bits::STS_SUCCESS);
+
+        Self {
+            cdw0: 0,
+            status: Self::status_field(StatusCodeType::Generic, status),
+        }
+    }
+
+    fn status_field(sct: StatusCodeType, sc: u8) -> u16 {
+        (sc as u16) << 1 | ((sct as u8) as u16) << 9
+        // | (more as u16) << 14
+        // | (dnr as u16) << 15
+    }
+}
+
+impl From<QueueCreateErr> for Completion {
+    fn from(e: QueueCreateErr) -> Self {
+        match e {
+            QueueCreateErr::InvalidBaseAddr =>
+                Completion::generic_err(STS_INVAL_PRP_OFFSET),
+            QueueCreateErr::InvalidSize =>
+                Completion::specific_err(
+                    StatusCodeType::CmdSpecific,
+                    bits::STS_CREATE_IO_Q_INVAL_QSIZE
+                ),
+        }
+    }
+}

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -18,7 +18,7 @@ mod ns;
 mod queue;
 
 use bits::*;
-use queue::{CompQueue, SubQueue, QueueId};
+use queue::{CompQueue, QueueId, SubQueue};
 
 const NVME_MSIX_COUNT: u16 = 1024;
 
@@ -157,7 +157,10 @@ impl NvmeCtrl {
     }
 
     /// Returns a reference to the [`CompQueue`] which corresponds to the given completion queue id (`cqid`).
-    fn get_cq(&self, cqid: QueueId) -> Result<Arc<Mutex<CompQueue>>, NvmeError> {
+    fn get_cq(
+        &self,
+        cqid: QueueId,
+    ) -> Result<Arc<Mutex<CompQueue>>, NvmeError> {
         debug_assert!((cqid as usize) < MAX_NUM_QUEUES);
         self.cqs[cqid as usize]
             .as_ref()
@@ -476,7 +479,7 @@ impl PciNvme {
                 // XXX: set controller error state?
                 continue;
             }
-            let (cmd, _) = parsed.unwrap();
+            let cmd = parsed.unwrap();
             let comp = match cmd {
                 AdminCmd::CreateIOCompQ(cmd) => {
                     state.acmd_create_io_cq(&cmd, ctx)
@@ -500,7 +503,7 @@ impl PciNvme {
             };
 
             let completion = RawCompletion {
-                dw0: comp.cdw0,
+                dw0: comp.dw0,
                 rsvd: 0,
                 sqhd: sq.head(),
                 sqid: sq.id(),

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -347,8 +347,9 @@ impl PciNvme {
                 // TO = 0 - 0 * 500ms to wait for controller ready
                 // AMS = 0x0 - no additional abitrary mechs (besides RR)
                 // CQR = 0x1 - contig queues required for now
-                // MQES = 0xfff - 4k (zeros-based)
-                ro.write_u64(CAP_CCS | CAP_CQR | 0x0fff);
+                // Convert to 0's based
+                let mqes = (queue::MAX_QUEUE_SIZE - 1) as u64;
+                ro.write_u64(CAP_CCS | CAP_CQR | mqes);
             }
             CtrlrReg::Version => {
                 ro.write_u32(NVME_VER_1_0);

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -122,9 +122,10 @@ impl NvmeCtrl {
     ///
     /// Admin queues are always created with `cqid`/`sqid` `0`.
     fn create_admin_queues(&mut self, ctx: &DispCtx) -> Result<(), NvmeError> {
+        // Admin CQ uses interrupt vector 0 (See NVMe 1.0e Section 3.1.9 ACQ)
         self.create_cq(
             queue::ADMIN_QUEUE_ID,
-            0, // Admin CQ uses interrupt vector 0
+            0,
             GuestAddr(self.ctrl.admin_cq_base),
             self.ctrl.admin_cq_size as u32,
             ctx,

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -23,7 +23,7 @@ use queue::{CompQueue, SubQueue};
 const NVME_MSIX_COUNT: u16 = 1024;
 
 #[derive(Debug, Error)]
-pub enum NvmeError {
+enum NvmeError {
     #[error("the completion queue specified ({0}) is invalid")]
     InvalidCompQueue(u16),
 

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -323,7 +323,7 @@ impl PciNvme {
                 let mut val = 0;
 
                 if state.ctrl.ready {
-                    val |= CSTS_READY;
+                    val |= CSTS_RDY;
                 }
                 ro.write_u32(val);
             }
@@ -500,12 +500,12 @@ impl PciNvme {
             };
 
             let completion = RawCompletion {
-                cdw0: comp.cdw0,
+                dw0: comp.cdw0,
                 rsvd: 0,
                 sqhd: sq.head(),
                 sqid: sq.id(),
                 cid: sub.cid(),
-                status: comp.status | cq.phase(),
+                status_phase: comp.status | cq.phase(),
             };
             cq.push(completion, ctx);
         }

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -1,0 +1,610 @@
+use std::convert::TryInto;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use crate::common::*;
+use crate::dispatch::DispCtx;
+use crate::hw::pci;
+use crate::util::regmap::RegMap;
+
+use lazy_static::lazy_static;
+use thiserror::Error;
+
+pub use ns::NvmeNs;
+
+mod admin;
+mod bits;
+mod cmds;
+mod ns;
+mod queue;
+
+use bits::*;
+use queue::{CompQueue, SubQueue};
+
+const NVME_MSIX_COUNT: u16 = 1024;
+
+#[derive(Debug, Error)]
+pub enum NvmeError {
+    #[error("the completion queue specified ({0}) is invalid")]
+    InvalidCompQueue(u16),
+
+    #[error("the submission queue specified ({0}) is invalid")]
+    InvalidSubQueue(u16),
+
+    #[error("the completition queue specified ({0}) already exists")]
+    CompQueueAlreadyExists(u16),
+
+    #[error("the submission queue specified ({0}) already exists")]
+    SubQueueAlreadyExists(u16),
+
+    #[error("failed to create queue: {0}")]
+    QueueCreateErr(#[from] queue::QueueCreateErr),
+
+    #[error("the MSI-X interrupt handle is unavailable")]
+    MsixHdlUnavailable,
+
+    #[error("failed to parse command: {0}")]
+    CommandParseErr(#[from] cmds::ParseErr),
+}
+
+#[derive(Debug, Default)]
+struct CtrlState {
+    enabled: bool,
+    ready: bool,
+    admin_sq_base: u64,
+    admin_cq_base: u64,
+    admin_sq_size: u16,
+    admin_cq_size: u16,
+}
+
+/// The max number of completion or submission queues we support.
+const MAX_NUM_QUEUES: usize = 16;
+
+/// The Admin Completion and Submission are always ID 0
+const ADMIN_QUEUE_ID: u16 = 0;
+
+struct NvmeCtrl {
+    /// Internal NVMe Controller state
+    ctrl: CtrlState,
+
+    /// MSI-X Interrupt Handle to signal VM
+    msix_hdl: Option<pci::MsixHdl>,
+
+    /// The list of Completion Queues handled by the controller
+    cqs: [Option<Arc<Mutex<CompQueue>>>; MAX_NUM_QUEUES],
+
+    /// The list of Submission Queues handled by the controller
+    sqs: [Option<Arc<Mutex<SubQueue>>>; MAX_NUM_QUEUES],
+
+    // TODO: Support more than 1 namespace
+    ns: ns::NvmeNs,
+
+    /// The PCI Vendor ID the Controller is initialized with
+    vendor_id: u16,
+}
+
+impl NvmeCtrl {
+    /// Creates the admin completion and submission queues.
+    ///
+    /// Admin queues are always created with `cqid`/`sqid` `0`.
+    fn create_admin_queues(&mut self, ctx: &DispCtx) -> Result<(), NvmeError> {
+        self.create_cq(
+            ADMIN_QUEUE_ID,
+            0, // Admin CQ uses interrupt vector 0
+            GuestAddr(self.ctrl.admin_cq_base),
+            self.ctrl.admin_cq_size as u32,
+            ctx
+        )?;
+        self.create_sq(
+            ADMIN_QUEUE_ID,
+            ADMIN_QUEUE_ID,
+            GuestAddr(self.ctrl.admin_sq_base),
+            self.ctrl.admin_sq_size as u32,
+            ctx
+        )?;
+        Ok(())
+    }
+
+    /// Creates and stores a new completion queue ([`CompQueue`]) for the controller.
+    ///
+    /// The specified `cqid` must not already be in use by another completion queue.
+    fn create_cq(
+        &mut self,
+        cqid: u16,
+        iv: u16,
+        base: GuestAddr,
+        size: u32,
+        ctx: &DispCtx
+    ) -> Result<(), NvmeError> {
+        if (cqid as usize) >= MAX_NUM_QUEUES {
+            return Err(NvmeError::InvalidCompQueue(cqid));
+        }
+        if self.cqs[cqid as usize].is_some() {
+            return Err(NvmeError::CompQueueAlreadyExists(cqid));
+        }
+        let msix_hdl = self.msix_hdl.as_ref().ok_or(NvmeError::MsixHdlUnavailable)?.clone();
+        let cq = CompQueue::new(cqid, iv, size, base, ctx, msix_hdl)?;
+        self.cqs[cqid as usize] = Some(Arc::new(Mutex::new(cq)));
+        Ok(())
+    }
+
+    /// Creates and stores a new submission queue ([`SubQueue`]) for the controller.
+    ///
+    /// The specified `sqid` must not already be in use by another submission queue.
+    /// The corresponding completion queue specified (`cqid`) must already exist.
+    fn create_sq(
+        &mut self,
+        sqid: u16,
+        cqid: u16,
+        base: GuestAddr,
+        size: u32,
+        ctx: &DispCtx
+    ) -> Result<(), NvmeError> {
+        if (sqid as usize) >= MAX_NUM_QUEUES {
+            return Err(NvmeError::InvalidSubQueue(cqid));
+        }
+        if (cqid as usize) >= MAX_NUM_QUEUES || self.cqs[cqid as usize].is_none() {
+            return Err(NvmeError::InvalidCompQueue(cqid));
+        }
+        if self.sqs[sqid as usize].is_some() {
+            return Err(NvmeError::SubQueueAlreadyExists(cqid));
+        }
+        let sq = SubQueue::new(sqid, cqid, size, base, ctx)?;
+        self.sqs[sqid as usize] = Some(Arc::new(Mutex::new(sq)));
+        Ok(())
+    }
+
+    /// Returns a reference to the [`CompQueue`] which corresponds to the given completion queue id (`cqid`).
+    fn get_cq(&self, cqid: u16) -> Result<Arc<Mutex<CompQueue>>, NvmeError> {
+        debug_assert!((cqid as usize) < MAX_NUM_QUEUES);
+        self.cqs[cqid as usize].as_ref().map(Arc::clone).ok_or(NvmeError::InvalidCompQueue(cqid))
+    }
+
+    /// Returns a reference to the [`SubQueue`] which corresponds to the given submission queue id (`cqid`).
+    fn get_sq(&self, sqid: u16) -> Result<Arc<Mutex<SubQueue>>, NvmeError> {
+        debug_assert!((sqid as usize) < MAX_NUM_QUEUES);
+        self.sqs[sqid as usize].as_ref().map(Arc::clone).ok_or(NvmeError::InvalidSubQueue(sqid))
+    }
+
+    /// Returns a reference to the Admin [`CompQueue`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the Admin Completion Queue hasn't been created yet.
+    fn get_admin_cq(&self) -> Arc<Mutex<CompQueue>> {
+        self.get_cq(ADMIN_QUEUE_ID).unwrap()
+    }
+
+    /// Returns a reference to the Admin [`SubQueue`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the Admin Submission Queue hasn't been created yet.
+    fn get_admin_sq(&self) -> Arc<Mutex<SubQueue>> {
+        self.get_sq(ADMIN_QUEUE_ID).unwrap()
+    }
+
+    /// Performs a Controller Reset.
+    ///
+    /// The reset deletes all I/O Submission & Completion Queues, resets
+    /// the Admin Submission & Completion Queues, and brings the hardware
+    /// to an idle state. The reset does not affect PCI Express registers
+    /// nor the Admin Queue registers (AQA, ASQ, or ACQ).  All other
+    /// controller registers and internal controller state that are not
+    /// persistent across power states) are reset to their default values.
+    /// The controller shall ensure that there is no data loss for commands
+    /// that have had corresponding completion queue entries posted to an I/O
+    /// Completion Queue prior to the reset operation.
+    fn reset(&mut self) {
+        // TODO: handle any pending commands
+
+        for sq in &mut self.sqs {
+            *sq = None;
+        }
+        for cq in &mut self.cqs {
+            *cq = None;
+        }
+    }
+}
+
+pub struct PciNvme {
+    state: Mutex<NvmeCtrl>,
+}
+
+impl PciNvme {
+    pub fn create(vendor: u16, device: u16, ns: NvmeNs) -> Arc<pci::DeviceInst> {
+        let builder = pci::Builder::new(pci::Ident {
+            vendor_id: vendor,
+            device_id: device,
+            sub_vendor_id: vendor,
+            sub_device_id: device,
+            class: pci::bits::CLASS_STORAGE,
+            subclass: pci::bits::SUBCLASS_NVM,
+            prog_if: pci::bits::PROGIF_ENTERPRISE_NVMHCI,
+            ..Default::default()
+        });
+
+        let state = NvmeCtrl {
+            ctrl: CtrlState::default(),
+            msix_hdl: None,
+            cqs: Default::default(),
+            sqs: Default::default(),
+            vendor_id: vendor,
+            ns,
+        };
+
+        let nvme = PciNvme {
+            state: Mutex::new(state),
+        };
+
+        builder
+            // XXX: add room for doorbells
+            .add_bar_mmio64(pci::BarN::BAR0, CONTROLLER_REG_SZ as u64)
+            // BAR0/1 are used for the main config and doorbell registers
+            // BAR2 is for the optional index/data registers
+            // Place MSIX in BAR4 for now
+            .add_cap_msix(pci::BarN::BAR4, NVME_MSIX_COUNT)
+            .finish(Arc::new(nvme))
+    }
+
+    fn ctrlr_cfg_write(&self, val: u32, ctx: &DispCtx) -> Result<(), NvmeError> {
+        let mut state = self.state.lock().unwrap();
+
+        if !state.ctrl.enabled {
+            // TODO: apply any necessary config changes
+        }
+
+        let now_enabled = val & CC_EN != 0;
+        if now_enabled && !state.ctrl.enabled {
+            state.ctrl.enabled = true;
+
+            // Create the Admin Completion and Submission queues
+            state.create_admin_queues(ctx)?;
+
+            state.ctrl.ready = true;
+        } else if !now_enabled && state.ctrl.enabled {
+            state.ctrl.enabled = false;
+            state.ctrl.ready = false;
+
+            state.reset();
+        }
+
+        Ok(())
+    }
+    fn reg_ctrl_read(&self, id: &CtrlrReg, ro: &mut ReadOp, _ctx: &DispCtx) -> Result<(), NvmeError> {
+        match id {
+            CtrlrReg::CtrlrCaps => {
+                // MPSMIN = MPSMAX = 0 (4k pages)
+                // CCS = 0x1 - NVM command set
+                // DSTRD = 0 - standard (32-bit) doorbell stride
+                // TO = 0 - 0 * 500ms to wait for controller ready
+                // AMS = 0x0 - no additional abitrary mechs (besides RR)
+                // CQR = 0x1 - contig queues required for now
+                // MQES = 0xfff - 4k (zeros-based)
+                ro.write_u64(CAP_CCS | CAP_CQR | 0x0fff);
+            }
+            CtrlrReg::Version => {
+                ro.write_u32(NVME_VER_1_0);
+            }
+
+            CtrlrReg::IntrMaskSet | CtrlrReg::IntrMaskClear => {
+                // Only MSI-X is exposed for now, so this is undefined
+                ro.fill(0);
+            }
+
+            CtrlrReg::CtrlrCfg => {
+                let state = self.state.lock().unwrap();
+                let mut val = if state.ctrl.enabled { 1 } else { 0 };
+                val |= 4 << 20 // IOCQES 23:20 - 2^4 = 16 bytes
+                | 6 << 16; // IOSQES 19:16 - 2^6 = 64 bytes
+                ro.write_u32(val);
+            }
+            CtrlrReg::CtrlrStatus => {
+                let state = self.state.lock().unwrap();
+                let mut val = 0;
+
+                if state.ctrl.ready {
+                    val |= CSTS_READY;
+                }
+                ro.write_u32(val);
+            }
+            CtrlrReg::AdminQueueAttr => {
+                let state = self.state.lock().unwrap();
+                ro.write_u32(
+                    state.ctrl.admin_sq_size as u32
+                        | (state.ctrl.admin_cq_size as u32) << 16,
+                );
+            }
+            CtrlrReg::AdminSubQAddr => {
+                let state = self.state.lock().unwrap();
+                ro.write_u64(state.ctrl.admin_sq_base);
+            }
+            CtrlrReg::AdminCompQAddr => {
+                let state = self.state.lock().unwrap();
+                ro.write_u64(state.ctrl.admin_cq_base);
+            }
+            CtrlrReg::Reserved => {
+                ro.fill(0);
+            }
+            CtrlrReg::DoorBellAdminSQ
+            | CtrlrReg::DoorBellAdminCQ
+            | CtrlrReg::DoorBellIoSQ1
+            | CtrlrReg::DoorBellIoCQ1 => {
+                // The host should not read from the doorbells, and the contents
+                // can be vendor/implementation specific (in our case, zeroed).
+                ro.fill(0);
+            }
+        }
+
+        Ok(())
+    }
+    fn reg_ctrl_write(&self, id: &CtrlrReg, wo: &mut WriteOp, ctx: &DispCtx) -> Result<(), NvmeError> {
+        match id {
+            CtrlrReg::CtrlrCaps
+            | CtrlrReg::Version
+            | CtrlrReg::CtrlrStatus
+            | CtrlrReg::Reserved => {
+                // Read-only registers
+            }
+            CtrlrReg::IntrMaskSet | CtrlrReg::IntrMaskClear => {
+                // Only MSI-X is exposed for now, so this is undefined
+            }
+
+            CtrlrReg::CtrlrCfg => {
+                self.ctrlr_cfg_write(wo.read_u32(), ctx)?;
+            }
+            CtrlrReg::AdminQueueAttr => {
+                let mut state = self.state.lock().unwrap();
+                if !state.ctrl.enabled {
+                    let val = wo.read_u32();
+                    // bits 27:16 - ACQS, zeroes-based
+                    let compq: u16 = ((val >> 16) & 0xfff) as u16 + 1;
+                    // bits 27:16 - ASQS, zeroes-based
+                    let subq: u16 = (val & 0xfff) as u16 + 1;
+
+                    state.ctrl.admin_cq_size = compq;
+                    state.ctrl.admin_sq_size = subq;
+                }
+            }
+            CtrlrReg::AdminSubQAddr => {
+                let mut state = self.state.lock().unwrap();
+                if !state.ctrl.enabled {
+                    state.ctrl.admin_sq_base = wo.read_u64() & PAGE_MASK as u64;
+                }
+            }
+            CtrlrReg::AdminCompQAddr => {
+                let mut state = self.state.lock().unwrap();
+                if !state.ctrl.enabled {
+                    state.ctrl.admin_cq_base = wo.read_u64() & PAGE_MASK as u64;
+                }
+            }
+
+            CtrlrReg::DoorBellAdminSQ => {
+                let val = wo.read_u32().try_into().unwrap();
+                let state = self.state.lock().unwrap();
+                let admin_sq = state.get_admin_sq();
+                let mut sq = admin_sq.lock().unwrap();
+                match sq.notify_tail(val) {
+                    Ok(_) => {}
+                    Err(_) => todo!("set controller error state"),
+                }
+
+                // Process any new SQ entries
+                self.process_admin_queue(state, sq, ctx)?;
+            }
+            CtrlrReg::DoorBellAdminCQ => {
+                let val = wo.read_u32().try_into().unwrap();
+                let state = self.state.lock().unwrap();
+                let admin_cq = state.get_admin_cq();
+                let mut cq = admin_cq.lock().unwrap();
+                match cq.notify_head(val) {
+                    Ok(_) => {}
+                    Err(_) => todo!("set controller error state"),
+                }
+                // TODO: post any entries to the CQ now that it has more space
+            }
+
+            CtrlrReg::DoorBellIoSQ1 => {
+                let val = wo.read_u32().try_into().unwrap();
+                let state = self.state.lock().unwrap();
+                // TODO: Support more than 1 I/O queue
+                let io_sq = state.get_sq(1)?;
+                let mut sq = io_sq.lock().unwrap();
+                match sq.notify_tail(val) {
+                    Ok(_) => {}
+                    Err(_) => todo!("set controller error state"),
+                }
+                drop(sq);
+                self.process_io_queue(state, io_sq, ctx)?;
+            }
+            CtrlrReg::DoorBellIoCQ1 => {
+                let val = wo.read_u32().try_into().unwrap();
+                let state = self.state.lock().unwrap();
+                // TODO: Support more than 1 I/O queue
+                let io_cq = state.get_cq(1)?;
+                let mut cq = io_cq.lock().unwrap();
+                match cq.notify_head(val) {
+                    Ok(_) => {}
+                    Err(_) => todo!("set controller error state"),
+                }
+                // TODO: post any entries to the CQ now that it has more space
+            }
+        }
+
+        Ok(())
+    }
+
+    fn process_admin_queue(
+        &self,
+        mut state: MutexGuard<NvmeCtrl>,
+        mut sq: MutexGuard<SubQueue>,
+        ctx: &DispCtx
+    ) -> Result<(), NvmeError> {
+        // Grab the Admin CQ too
+        let admin_cq = state.get_admin_cq();
+        let mut cq = admin_cq.lock().unwrap();
+
+        while let Some(sub) = sq.pop(ctx) {
+            use cmds::AdminCmd;
+
+            let parsed = AdminCmd::parse(sub);
+            if parsed.is_err() {
+                // XXX: set controller error state?
+                continue;
+            }
+            let (cmd, _) = parsed.unwrap();
+            let comp = match cmd {
+                AdminCmd::CreateIOCompQ(cmd) => {
+                    state.acmd_create_io_cq(&cmd, ctx)
+                }
+                AdminCmd::CreateIOSubQ(cmd) => {
+                    state.acmd_create_io_sq(&cmd, ctx)
+                }
+                AdminCmd::GetLogPage(cmd) => {
+                    state.acmd_get_log_page(&cmd, ctx)
+                }
+                AdminCmd::Identify(cmd) => {
+                    state.acmd_identify(&cmd, ctx)
+                }
+                AdminCmd::SetFeatures(cmd) => {
+                    state.acmd_set_features(&cmd, ctx)
+                }
+                AdminCmd::DeleteIOSubQ(_) |
+                AdminCmd::DeleteIOCompQ(_) |
+                AdminCmd::Abort |
+                AdminCmd::GetFeatures |
+                AdminCmd::AsyncEventReq |
+                AdminCmd::Unknown(_) => {
+                    cmds::Completion::generic_err(bits::STS_INTERNAL_ERR)
+                }
+            };
+
+            let completion = RawCompletion {
+                cdw0: comp.cdw0,
+                rsvd: 0,
+                sqhd: sq.head(),
+                sqid: sq.id(),
+                cid: sub.cid(),
+                status: comp.status | cq.phase(),
+            };
+            cq.push(completion, ctx);
+        }
+
+        // Notify for any newly added completions
+        cq.fire_interrupt(ctx);
+
+        Ok(())
+    }
+
+    fn process_io_queue(
+        &self,
+        state: MutexGuard<NvmeCtrl>,
+        io_sq: Arc<Mutex<SubQueue>>,
+        ctx: &DispCtx
+    ) -> Result<(), NvmeError> {
+        let mut sq = io_sq.lock().unwrap();
+
+        // Grab the corresponding CQ
+        let io_cq = state.get_cq(sq.cqid())?;
+
+        // Collect all the IO SQ entries
+        let mut io_cmds = vec![];
+        while let Some(sub) = sq.pop(ctx) {
+            // TODO: 1 hardcoded namespace
+            assert_eq!(sub.nsid, 1);
+
+            io_cmds.push(sub);
+        }
+
+        drop(sq);
+
+        // Queue up said IO entries to the underlying block device
+        state.ns.queue_io_cmds(io_cmds, io_cq.clone(), io_sq, ctx)?;
+
+        // Notify for any newly added completions
+        let cq = io_cq.lock().unwrap();
+        cq.fire_interrupt(ctx);
+
+        Ok(())
+    }
+}
+
+impl pci::Device for PciNvme {
+    fn bar_rw(&self, bar: pci::BarN, mut rwo: RWOp, ctx: &DispCtx) {
+        assert_eq!(bar, pci::BarN::BAR0);
+        CONTROLLER_REGS.process(&mut rwo, |id, rwo| {
+            let res = match rwo {
+                RWOp::Read(ro) => self.reg_ctrl_read(id, ro, ctx),
+                RWOp::Write(wo) => self.reg_ctrl_write(id, wo, ctx),
+            };
+            // TODO: is there a better way to report errors
+            if let Err(err) = res {
+                eprintln!("nvme reg read/write failed: {}", err);
+            }
+        });
+    }
+
+    fn attach(
+        &self,
+        lintr_pin: Option<pci::INTxPin>,
+        msix_hdl: Option<pci::MsixHdl>,
+    ) {
+        assert!(lintr_pin.is_none());
+        assert!(msix_hdl.is_some());
+        self.state.lock().unwrap().msix_hdl = msix_hdl;
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum CtrlrReg {
+    CtrlrCaps,
+    Version,
+    IntrMaskSet,
+    IntrMaskClear,
+    CtrlrCfg,
+    CtrlrStatus,
+    AdminQueueAttr,
+    AdminSubQAddr,
+    AdminCompQAddr,
+    Reserved,
+
+    DoorBellAdminSQ,
+    DoorBellAdminCQ,
+
+    // XXX: Can we coalesce these
+    DoorBellIoSQ1,
+    DoorBellIoCQ1,
+}
+// XXX: single IO doorbell for prototype
+const CONTROLLER_REG_SZ: usize = 0x2000;
+lazy_static! {
+    static ref CONTROLLER_REGS: RegMap<CtrlrReg> = {
+        let layout = [
+            (CtrlrReg::CtrlrCaps, 8),
+            (CtrlrReg::Version, 4),
+            (CtrlrReg::IntrMaskSet, 4),
+            (CtrlrReg::IntrMaskClear, 4),
+            (CtrlrReg::CtrlrCfg, 4),
+            (CtrlrReg::Reserved, 4),
+            (CtrlrReg::CtrlrStatus, 4),
+            (CtrlrReg::Reserved, 4),
+            (CtrlrReg::AdminQueueAttr, 4),
+            (CtrlrReg::AdminSubQAddr, 8),
+            (CtrlrReg::AdminCompQAddr, 8),
+            (CtrlrReg::Reserved, 0xec8),
+            (CtrlrReg::Reserved, 0x100),
+            // XXX: hardcode 0 stride for doorbells
+            (CtrlrReg::DoorBellAdminSQ, 4),
+            (CtrlrReg::DoorBellAdminCQ, 4),
+            // XXX: hardcode a single IO doorbell
+            (CtrlrReg::DoorBellIoSQ1, 4),
+            (CtrlrReg::DoorBellIoCQ1, 4),
+            // XXX: pad out to next power of 2
+            (CtrlrReg::Reserved, 0x1000 - 16),
+        ];
+        RegMap::create_packed(
+            CONTROLLER_REG_SZ,
+            &layout,
+            Some(CtrlrReg::Reserved),
+        )
+    };
+}

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -276,7 +276,7 @@ impl PciNvme {
             sub_device_id: device,
             class: pci::bits::CLASS_STORAGE,
             subclass: pci::bits::SUBCLASS_NVM,
-            prog_if: pci::bits::PROGIF_ENTERPRISE_NVMHCI,
+            prog_if: pci::bits::PROGIF_ENTERPRISE_NVME,
             ..Default::default()
         });
 

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -126,7 +126,7 @@ impl NvmeCtrl {
             .as_ref()
             .ok_or(NvmeError::MsixHdlUnavailable)?
             .clone();
-        let cq = CompQueue::new(cqid, iv, size, base, ctx, msix_hdl)?;
+        let cq = CompQueue::new(iv, size, base, ctx, msix_hdl)?;
         self.cqs[cqid as usize] = Some(Arc::new(Mutex::new(cq)));
         Ok(())
     }

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -363,6 +363,8 @@ impl PciNvme {
             CtrlrReg::CtrlrCfg => {
                 let state = self.state.lock().unwrap();
                 let mut val = if state.ctrl.enabled { 1 } else { 0 };
+                // MPS = 0 (4k pages)
+                // CSS = 0 (NVM command set)
                 val |= 4 << 20 // IOCQES 23:20 - 2^4 = 16 bytes
                 | 6 << 16; // IOSQES 19:16 - 2^6 = 64 bytes
                 ro.write_u32(val);

--- a/propolis/src/hw/nvme/ns.rs
+++ b/propolis/src/hw/nvme/ns.rs
@@ -55,7 +55,7 @@ impl NvmeNs {
 
     /// Takes the given list of raw IO commands and queues up reads and writes to the underlying
     /// block device as appropriate.
-    pub fn queue_io_cmds(
+    pub(super) fn queue_io_cmds(
         &self,
         cmds: Vec<RawSubmission>,
         cq: Arc<Mutex<CompQueue>>,

--- a/propolis/src/hw/nvme/ns.rs
+++ b/propolis/src/hw/nvme/ns.rs
@@ -84,12 +84,12 @@ impl NvmeNs {
                     };
 
                     let completion = RawCompletion {
-                        cdw0: comp.cdw0,
+                        dw0: comp.cdw0,
                         rsvd: 0,
                         sqhd: sq.head(),
                         sqid: sq.id(),
                         cid: sub.cid,
-                        status: comp.status | cq.phase(),
+                        status_phase: comp.status | cq.phase(),
                     };
 
                     cq.push(completion, ctx);
@@ -210,12 +210,12 @@ impl BlockReq for Request {
         let mut cq = self.cq.lock().unwrap();
 
         let completion = bits::RawCompletion {
-            cdw0: comp.cdw0,
+            dw0: comp.cdw0,
             rsvd: 0,
             sqhd: sq.head(),
             sqid: sq.id(),
             cid: self.cid,
-            status: comp.status | cq.phase(),
+            status_phase: comp.status | cq.phase(),
         };
 
         cq.push(completion, ctx);

--- a/propolis/src/hw/nvme/ns.rs
+++ b/propolis/src/hw/nvme/ns.rs
@@ -1,0 +1,230 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use crate::block::*;
+use crate::hw::nvme::bits::RawCompletion;
+use crate::hw::nvme::cmds::{self, NvmCmd};
+use crate::{common, dispatch::DispCtx};
+
+use super::NvmeError;
+use super::bits::{self, RawSubmission};
+use super::cmds::{Completion, ReadCmd, WriteCmd};
+use super::queue::{CompQueue, SubQueue};
+
+const BLOCK_SZ: u64 = 512;
+
+pub struct NvmeNs {
+    pub ident: bits::IdentifyNamespace,
+    bdev: Arc<dyn BlockDev<Request>>,
+}
+
+impl NvmeNs {
+    pub fn create(bdev: Arc<dyn BlockDev<Request>>) -> Self {
+        let binfo = bdev.inquire();
+        let total_bytes = binfo.total_size * binfo.block_size as u64;
+        let nsze = total_bytes / BLOCK_SZ;
+
+        let mut ident = bits::IdentifyNamespace {
+            // No thin provisioning so nsze == ncap == nuse
+            nsze,
+            ncap: nsze,
+            nuse: nsze,
+            nlbaf: 0, // We only support a single LBA format (1 but 0-based)
+            flbas: 0, // And it is at index 0 in the lbaf array
+            ..Default::default()
+        };
+
+        debug_assert_eq!(BLOCK_SZ.count_ones(), 1, "BLOCK_SZ must be a power of 2");
+        debug_assert!(BLOCK_SZ.trailing_zeros() >= 9, "BLOCK_SZ must be at least 512 bytes");
+        ident.lbaf[0].lbads = BLOCK_SZ.trailing_zeros() as u8;
+
+        NvmeNs { ident, bdev }
+    }
+
+    /// Convert some number of logical blocks to bytes with the currently active LBA data size
+    fn nlb_to_size(&self, b: usize) -> usize {
+        b << (self.ident.lbaf[(self.ident.flbas & 0xF) as usize].lbads)
+    }
+
+    /// Takes the given list of raw IO commands and queues up reads and writes to the underlying
+    /// block device as appropriate.
+    pub fn queue_io_cmds(
+        &self,
+        cmds: Vec<RawSubmission>,
+        cq: Arc<Mutex<CompQueue>>,
+        sq: Arc<Mutex<SubQueue>>,
+        ctx: &DispCtx
+    ) -> Result<(), NvmeError> {
+        for cmd in cmds {
+            let (cmd, sub) = NvmCmd::parse(cmd)?;
+            match cmd {
+                NvmCmd::Write(cmd) => self.write_cmd(sub.cid, cmd, ctx, cq.clone(), sq.clone()),
+                NvmCmd::Read(cmd) => self.read_cmd(sub.cid, cmd, ctx, cq.clone(), sq.clone()),
+                NvmCmd::Flush |
+                NvmCmd::Unknown(_) => {
+                    // For any other command, just immediately complete it
+                    let mut cq = cq.lock().unwrap();
+                    let sq = sq.lock().unwrap();
+
+                    let comp = if matches!(cmd, NvmCmd::Flush) {
+                        // TODO: is there anything else to do for flush?
+                        Completion::success()
+                    } else {
+                        Completion::generic_err(bits::STS_INTERNAL_ERR)
+                    };
+
+                    let completion = RawCompletion {
+                        cdw0: comp.cdw0,
+                        rsvd: 0,
+                        sqhd: sq.head(),
+                        sqid: sq.id(),
+                        cid: sub.cid,
+                        status: comp.status | cq.phase()
+                    };
+
+                    cq.push(completion, ctx);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn read_cmd(
+        &self,
+        cid: u16,
+        mut cmd: ReadCmd,
+        ctx: &DispCtx,
+        cq: Arc<Mutex<CompQueue>>,
+        sq: Arc<Mutex<SubQueue>>
+    ) {
+        // `nlb` is a 0-based value and so add 1 to get the corresponding value
+        cmd.nlb += 1;
+        let off = self.nlb_to_size(cmd.slba as usize);
+        let size = self.nlb_to_size(cmd.nlb as usize);
+        // TODO: handles if it gets unmapped?
+        let bufs = cmd.data(size as u64, ctx.mctx.memctx()).collect();
+        self.bdev.enqueue(Request::new_read(off, size, bufs, cid, cq, sq));
+    }
+
+    fn write_cmd(
+        &self,
+        cid: u16,
+        mut cmd: WriteCmd,
+        ctx: &DispCtx,
+        cq: Arc<Mutex<CompQueue>>,
+        sq: Arc<Mutex<SubQueue>>
+    ) {
+        // `nlb` is a 0-based value and so add 1 to get the corresponding value
+        cmd.nlb += 1;
+        let off = self.nlb_to_size(cmd.slba as usize);
+        let size = self.nlb_to_size(cmd.nlb as usize);
+        // TODO: handles if it gets unmapped?
+        let bufs = cmd.data(size as u64, ctx.mctx.memctx()).collect();
+        self.bdev.enqueue(Request::new_write(off, size, bufs, cid, cq, sq));
+    }
+}
+
+pub struct Request {
+    op: BlockOp,
+    off: usize,
+    xfer_left: usize,
+    bufs: VecDeque<common::GuestRegion>,
+    cid: u16,
+    cq: Arc<Mutex<CompQueue>>,
+    sq: Arc<Mutex<SubQueue>>,
+}
+
+impl Request {
+    fn new_read(
+        off: usize,
+        size: usize,
+        bufs: VecDeque<common::GuestRegion>,
+        cid: u16,
+        cq: Arc<Mutex<CompQueue>>,
+        sq: Arc<Mutex<SubQueue>>
+    ) -> Self {
+        Self {
+            op: BlockOp::Read,
+            off,
+            xfer_left: size,
+            bufs,
+            cid,
+            cq,
+            sq
+        }
+    }
+
+    fn new_write(
+        off: usize,
+        size: usize,
+        bufs: VecDeque<common::GuestRegion>,
+        cid: u16,
+        cq: Arc<Mutex<CompQueue>>,
+        sq: Arc<Mutex<SubQueue>>
+    ) -> Self {
+        Self {
+            op: BlockOp::Write,
+            off,
+            xfer_left: size,
+            bufs,
+            cid,
+            cq,
+            sq
+        }
+    }
+}
+
+impl BlockReq for Request {
+    fn oper(&self) -> BlockOp {
+        self.op
+    }
+
+    fn offset(&self) -> usize {
+        self.off
+    }
+
+    fn next_buf(&mut self) -> Option<common::GuestRegion> {
+        if self.xfer_left == 0 {
+            return None;
+        }
+
+        if let Some(mut region) = self.bufs.pop_front() {
+            if region.1 > self.xfer_left {
+                region.1 = self.xfer_left;
+            }
+            self.xfer_left -= region.1;
+            Some(region)
+        } else {
+            None
+        }
+    }
+
+    fn complete(self, res: BlockResult, ctx: &DispCtx) {
+        let comp = match res {
+            BlockResult::Success => cmds::Completion::success(),
+            BlockResult::Failure => cmds::Completion::generic_err(bits::STS_DATA_XFER_ERR),
+            BlockResult::Unsupported => cmds::Completion::specific_err(
+                bits::StatusCodeType::CmdSpecific,
+                bits::STS_READ_CONFLICTING_ATTRS
+            )
+        };
+
+        let sq = self.sq.lock().unwrap();
+        let mut cq = self.cq.lock().unwrap();
+
+        let completion = bits::RawCompletion {
+            cdw0: comp.cdw0,
+            rsvd: 0,
+            sqhd: sq.head(),
+            sqid: sq.id(),
+            cid: self.cid,
+            status: comp.status | cq.phase(),
+        };
+
+        cq.push(completion, ctx);
+
+        // TODO: should this be done here?
+        cq.fire_interrupt(ctx);
+    }
+}

--- a/propolis/src/hw/nvme/ns.rs
+++ b/propolis/src/hw/nvme/ns.rs
@@ -11,6 +11,9 @@ use super::cmds::{Completion, ReadCmd, WriteCmd};
 use super::queue::{CompQueue, SubQueue};
 use super::NvmeError;
 
+/// Max number of namespaces we support
+pub const MAX_NUM_NAMESPACES: usize = 16;
+
 /// Supported block size.
 /// TODO: Support more
 const BLOCK_SZ: u64 = 512;

--- a/propolis/src/hw/nvme/queue.rs
+++ b/propolis/src/hw/nvme/queue.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use super::bits::{self, RawCompletion, RawSubmission};
 use crate::common::*;
 use crate::dispatch::DispCtx;
@@ -7,59 +9,98 @@ use thiserror::Error;
 
 /// Each queue is identified by a 16-bit ID.
 ///
-/// NVMe 1.0e Section 4.1.4 Queue Identifier
+/// See NVMe 1.0e Section 4.1.4 Queue Identifier
 pub type QueueId = u16;
 
 /// The minimum number of entries in either a Completion or Submission Queue.
 ///
 /// Note: One entry will always be unavailable for use due to Head and Tail entry pointer defition.
-/// NVMe 1.0e Section 4.1.3 Queue Size
+/// See NVMe 1.0e Section 4.1.3 Queue Size
 const MIN_QUEUE_SIZE: u32 = 2;
 
 /// The maximum number of entries in either a Completion or Submission Queue.
 ///
-/// NVMe 1.0e Section 4.1.3 Queue Size
+/// See NVMe 1.0e Section 4.1.3 Queue Size
 const MAX_QUEUE_SIZE: u32 = 1 << 16;
 
 /// The maximum number of entries in the Admin Completion or Admin Submission Queues.
 ///
-/// NVMe 1.0e Section 4.1.3 Queue Size
+/// See NVMe 1.0e Section 4.1.3 Queue Size
 const MAX_ADMIN_QUEUE_SIZE: u32 = 1 << 12;
 
 /// The Admin Completion and Submission are defined to have ID 0.
 ///
-/// NVMe 1.0e Section 1.6.1 Admin Queue
+/// See NVMe 1.0e Section 1.6.1 Admin Queue
 pub const ADMIN_QUEUE_ID: QueueId = 0;
 
-struct QueueState {
+/// Marker type to indicate a Completion Queue.
+enum CompletionQueueType {}
+
+/// Marker type to indicate a Submission Queue.
+enum SubmissionQueueType {}
+
+/// Helper for manipulating Completion/Submission Queues
+///
+/// The type parameter `QT` is used to constrain the set of
+/// methods exposed based on whether the queue in question
+/// is a Completion or Submission queue. Use either
+/// `CompletionQueueType` or `SubmissionQueueType`.
+struct QueueState<QT> {
+    /// The size of the queue in question.
+    ///
+    /// See NVMe 1.0e Section 4.1.3 Queue Size
     size: u32,
+
+    /// The current Head entry pointer.
+    ///
+    /// The consumer of entries on a queue uses the current Head entry pointer
+    /// to identify the next entry to be pulled off the queue.
+    ///
+    /// See NVMe 1.0e Section 4.1 Submission Queue & Completion Queue Definition
     head: u16,
+
+    /// The current Tail entry pointer.
+    ///
+    /// The submitter of entries to a queue uses the current Tail entry pointer
+    /// to identify the next open queue entry space.
+    ///
+    /// See NVMe 1.0e Section 4.1 Submission Queue & Completion Queue Definition
     tail: u16,
+
+    /// Marker type to indicate what type of Queue we're modeling.
+    _qt: PhantomData<QT>,
 }
-impl QueueState {
+
+impl<QT> QueueState<QT> {
+    /// Create a new `QueueState`
     fn new(size: u32, head: u16, tail: u16) -> Self {
         assert!(size >= MIN_QUEUE_SIZE && size <= MAX_QUEUE_SIZE);
-        Self { size, head, tail }
+        Self { size, head, tail, _qt: PhantomData }
     }
+
+    /// Returns if the queue is currently empty.
+    ///
+    /// A queue is empty when the Head entry pointer equals the Tail entry pointer.
+    ///
+    /// See: NVMe 1.0e Section 4.1.1 Empty Queue
     fn is_empty(&self) -> bool {
-        // 4.1.1 Empty Queue
-        //
-        // The queue is Empty when the Head entry pointer equals the Tail entry
-        // pointer.
         self.head == self.tail
     }
+
+    /// Returns if the queue is currently full.
+    ///
+    /// The queue is full when the Head entry pointer equals one more than the Tail
+    /// entry pointer. The number of entries in a queue will always be 1 less than
+    /// the queue size.
+    ///
+    /// See: NVMe 1.0e Section 4.1.2 Full Queue
     fn is_full(&self) -> bool {
-        // 4.1.2 Full Queue
-        //
-        // The queue is Full when the Head equals one more than the Tail.  The
-        // number of entries in a queue when full is one less than the queue
-        // size.
         (self.head > 0 && self.tail == (self.head - 1))
             || (self.head == 0 && self.tail == (self.size - 1) as u16)
     }
 
-    /// Calculate a positive offset for a given index, wrapping at the size of
-    /// the queue.
+    /// Helper method to calculate a positive offset for a given index, wrapping at
+    //// the size of the queue.
     fn wrap_add(&self, idx: u16, off: u16) -> u16 {
         debug_assert!((idx as u32) < self.size);
         debug_assert!((off as u32) < self.size);
@@ -71,8 +112,9 @@ impl QueueState {
             res as u16
         }
     }
-    /// Calculate a negative offset for a given index, wrapping at the size of
-    /// the queue.
+
+    /// Helper method to calculate a negative offset for a given index, wrapping at
+    /// the size of the queue.
     fn wrap_sub(&self, idx: u16, off: u16) -> u16 {
         debug_assert!((idx as u32) < self.size);
         debug_assert!((off as u32) < self.size);
@@ -84,45 +126,42 @@ impl QueueState {
         }
     }
 
-    /// How many slots are empty between the tail and the head
+    /// How many slots are empty between the tail and the head i.e., how many
+    /// entries can we write to the queue currently.
     fn avail_empty(&self) -> u16 {
         self.wrap_sub(self.wrap_sub(self.head, 1), self.tail)
     }
-    /// How many slots are occupied between the head and the tail
+
+    /// How many slots are occupied between the head and the tail i.e., how
+    /// many entries can we read from the queue currently.
     fn avail_occupied(&self) -> u16 {
         self.wrap_sub(self.tail, self.head)
     }
+}
 
+impl QueueState<CompletionQueueType> {
+    /// Attempt to return the Tail entry pointer and then move it forward by 1.
+    ///
+    /// If the queue is full this method returns [`None`].
+    /// Otherwise, this method returns the current Tail entry pointer and then
+    /// increments the Tail entry pointer by 1 (wrapping if necessary). It will
+    /// also return whether the Tail entry pointer wrapped after incrementing.
     fn push_tail(&mut self) -> Option<(u16, bool)> {
         if self.is_full() {
             None
         } else {
             let result = Some(self.tail);
             self.tail = self.wrap_add(self.tail, 1);
-            result.map(|r| (r, self.tail as u32 > self.size))
-        }
-    }
-    fn pop_head(&mut self) -> Option<u16> {
-        if self.is_empty() {
-            None
-        } else {
-            let result = Some(self.head);
-            self.head = self.wrap_add(self.head, 1);
-            result
+            result.map(|r| (r, (r + 1) as u32 >= self.size))
         }
     }
 
-    fn push_tail_to(&mut self, idx: u16) -> Result<(), &'static str> {
-        if idx as u32 >= self.size {
-            return Err("invalid index");
-        }
-        let push_count = self.wrap_sub(idx, self.tail);
-        if push_count > self.avail_empty() {
-            return Err("index too far");
-        }
-        self.tail = idx;
-        Ok(())
-    }
+    /// Attempt to move the Head entry pointer forward to the given index.
+    ///
+    /// The given index must be less than the size of the queue. The queue
+    /// must have enough occupied slots otherwise we return an error.
+    /// Conceptually this method indicates some entries have been consumed
+    /// from the queue.
     fn pop_head_to(&mut self, idx: u16) -> Result<(), &'static str> {
         if idx as u32 >= self.size {
             return Err("invalid index");
@@ -136,25 +175,74 @@ impl QueueState {
     }
 }
 
+impl QueueState<SubmissionQueueType> {
+    /// Attempt to return the Head entry pointer and then move it forward by 1.
+    ///
+    /// If the queue is empty this method returns [`None`].
+    /// Otherwise, this method returns the current Head entry pointer and then
+    /// increments the Head entry pointer by 1 (wrapping if necessary).
+    fn pop_head(&mut self) -> Option<u16> {
+        if self.is_empty() {
+            None
+        } else {
+            let result = Some(self.head);
+            self.head = self.wrap_add(self.head, 1);
+            result
+        }
+    }
+
+    /// Attempt to move the Tail entry pointer forward to the given index.
+    ///
+    /// The given index must be less than the size of the queue. The queue
+    /// must have enough empty slots available otherwise we return an error.
+    /// Conceptually this method indicates new entries have been added to the
+    /// queue.
+    fn push_tail_to(&mut self, idx: u16) -> Result<(), &'static str> {
+        if idx as u32 >= self.size {
+            return Err("invalid index");
+        }
+        let push_count = self.wrap_sub(idx, self.tail);
+        if push_count > self.avail_empty() {
+            return Err("index too far");
+        }
+        self.tail = idx;
+        Ok(())
+    }
+}
+
+/// Errors that may be encountered during Queue creation.
 #[derive(Error, Debug)]
 pub enum QueueCreateErr {
+    /// The specified base address is invalid.
     #[error("invalid base address")]
     InvalidBaseAddr,
+
+    /// The specified length is invalid.
     #[error("invalid size")]
     InvalidSize,
 }
 
+/// Type for manipulating Submission Queues.
 pub struct SubQueue {
+    /// The ID of queue in question.
     id: QueueId,
+
+    /// The ID of the corresponding Completion Queue.
     cqid: u16,
-    state: QueueState,
+
+    /// Queue state such as the size and current head/tail entry pointers.
+    state: QueueState<SubmissionQueueType>,
+
+    /// The [`GuestAddr`] at which the Queue is mapped.
     base: GuestAddr,
 }
 
 impl SubQueue {
+    /// Create a Submission Queue object backed by the guest memory at the
+    /// given base address.
     pub fn new(
         id: QueueId,
-        cqid: u16,
+        cqid: QueueId,
         size: u32,
         base: GuestAddr,
         ctx: &DispCtx,
@@ -162,9 +250,13 @@ impl SubQueue {
         Self::validate(id, base, size, ctx)?;
         Ok(Self { id, cqid, state: QueueState::new(size, 0, 0), base })
     }
+
+    /// Attempt to move the Tail entry pointer forward to the given index.
     pub fn notify_tail(&mut self, idx: u16) -> Result<(), &'static str> {
         self.state.push_tail_to(idx)
     }
+
+    /// Returns the next entry off of the Queue or [`None`] if it is empty.
     pub fn pop(&mut self, ctx: &DispCtx) -> Option<bits::RawSubmission> {
         if let Some(idx) = self.state.pop_head() {
             let mem = ctx.mctx.memctx();
@@ -175,20 +267,33 @@ impl SubQueue {
             None
         }
     }
+
+    /// Returns the current Head entry pointer.
     pub fn head(&self) -> u16 {
         self.state.head
     }
-    pub fn id(&self) -> u16 {
+
+    /// Returns the ID of this Submission Queue.
+    pub fn id(&self) -> QueueId {
         self.id
     }
-    pub fn cqid(&self) -> u16 {
+
+    /// Returns the ID of the corresponding Completion Queue
+    /// to this Submission Queue.
+    pub fn cqid(&self) -> QueueId {
         self.cqid
     }
+
+    /// Returns the corresponding [`GuestAddr`] for a given entry in
+    /// the Submission Queue.
     fn entry_addr(&self, idx: u16) -> GuestAddr {
         let res = self.base.0
             + idx as u64 * std::mem::size_of::<RawSubmission>() as u64;
         GuestAddr(res)
     }
+
+    /// Validates whether the given parameters may be used to create
+    /// a Submission Queue object.
     fn validate(
         id: QueueId,
         base: GuestAddr,
@@ -215,14 +320,31 @@ impl SubQueue {
     }
 }
 
+/// Type for manipulating Completion Queues.
 pub struct CompQueue {
+    /// The Interrupt Vector used to signal to the host (VM) upon pushing
+    /// entries onto the Completion Queue.
     iv: u16,
-    state: QueueState,
+
+    /// Queue state such as the size and current head/tail entry pointers.
+    state: QueueState<CompletionQueueType>,
+
+    /// The [`GuestAddr`] at which the Queue is mapped.
     base: GuestAddr,
-    phase: u16,
+
+    /// The current Phase Tag to identify to the host (VM) that a Completion
+    /// entry is new. Flips every time the Tail entry pointer wraps around.
+    ///
+    /// See NVMe 1.0e Section 4.6 Completion Queue Entry - Phase Tag (P)
+    phase: bool,
+
+    /// MSI-X object associated with PCIe device to signal host (VM).
     hdl: pci::MsixHdl,
 }
+
 impl CompQueue {
+    /// Creates a Completion Queue object backed by the guest memory at the
+    /// given base address.
     pub fn new(
         id: QueueId,
         iv: u16,
@@ -236,13 +358,19 @@ impl CompQueue {
             iv,
             state: QueueState::new(size, 0, 0),
             base,
-            phase: 1,
+            phase: true,
             hdl,
         })
     }
+
+    /// Attempt to move the Head entry pointer forward to the given index.
     pub fn notify_head(&mut self, idx: u16) -> Result<(), &'static str> {
         self.state.pop_head_to(idx)
     }
+
+    /// Attempt to add a new entry to the Completion Queue.
+    ///
+    /// TODO: handle the case where the queue may be currently full.
     pub fn push(&mut self, entry: RawCompletion, ctx: &DispCtx) {
         if let Some((idx, wrapped)) = self.state.push_tail() {
             let mem = ctx.mctx.memctx();
@@ -255,22 +383,35 @@ impl CompQueue {
             // XXX: figure out interrupts
         }
     }
+
+    /// Returns the current Phase Tag bit.
+    ///
+    /// The current Phase Tag to identify to the host (VM) that a Completion
+    /// entry is new. Flips every time the Tail entry pointer wraps around.
+    ///
+    /// See NVMe 1.0e Section 4.6 Completion Queue Entry - Phase Tag (P)
     pub fn phase(&self) -> u16 {
-        self.phase
+        self.phase as u16
     }
-    pub fn is_empty(&self) -> bool {
-        self.state.is_empty()
-    }
+
+    /// Fires an interrupt to the guest with the associated interrupt vector
+    /// if the queue is not currently empty.
     pub fn fire_interrupt(&self, ctx: &DispCtx) {
-        if !self.is_empty() {
+        if !self.state.is_empty() {
             self.hdl.fire(self.iv, ctx);
         }
     }
+
+    /// Returns the corresponding [`GuestAddr`] for a given entry in
+    /// the Completion Queue.
     fn entry_addr(&self, idx: u16) -> GuestAddr {
         let res = self.base.0
             + idx as u64 * std::mem::size_of::<RawCompletion>() as u64;
         GuestAddr(res)
     }
+
+    /// Validates whether the given parameters may be used to create
+    /// a Completion Queue object.
     fn validate(
         id: QueueId,
         base: GuestAddr,

--- a/propolis/src/hw/nvme/queue.rs
+++ b/propolis/src/hw/nvme/queue.rs
@@ -335,7 +335,7 @@ pub struct CompQueue {
     /// The current Phase Tag to identify to the host (VM) that a Completion
     /// entry is new. Flips every time the Tail entry pointer wraps around.
     ///
-    /// See NVMe 1.0e Section 4.6 Completion Queue Entry - Phase Tag (P)
+    /// See NVMe 1.0e Section 4.5 Completion Queue Entry - Phase Tag (P)
     phase: bool,
 
     /// MSI-X object associated with PCIe device to signal host (VM).
@@ -389,7 +389,7 @@ impl CompQueue {
     /// The current Phase Tag to identify to the host (VM) that a Completion
     /// entry is new. Flips every time the Tail entry pointer wraps around.
     ///
-    /// See NVMe 1.0e Section 4.6 Completion Queue Entry - Phase Tag (P)
+    /// See NVMe 1.0e Section 4.5 Completion Queue Entry - Phase Tag (P)
     pub fn phase(&self) -> u16 {
         self.phase as u16
     }

--- a/propolis/src/hw/nvme/queue.rs
+++ b/propolis/src/hw/nvme/queue.rs
@@ -1,0 +1,260 @@
+#![allow(unused)]
+
+use std::sync::Mutex;
+
+use super::bits::{self, RawSubmission, RawCompletion};
+use crate::common::*;
+use crate::dispatch::DispCtx;
+use crate::hw::pci;
+
+use thiserror::Error;
+
+const MIN_SIZE: u32 = 2;
+const MAX_SIZE: u32 = 1 << 16;
+
+struct QueueState {
+    size: u32,
+    head: u16,
+    tail: u16,
+}
+impl QueueState {
+    fn new(size: u32, head: u16, tail: u16) -> Self {
+        assert!(size >= MIN_SIZE && size <= MAX_SIZE);
+        Self { size, head, tail }
+    }
+    fn is_empty(&self) -> bool {
+        // 4.1.1 Empty Queue
+        //
+        // The queue is Empty when the Head entry pointer equals the Tail entry
+        // pointer.
+        self.head == self.tail
+    }
+    fn is_full(&self) -> bool {
+        // 4.1.2 Full Queue
+        //
+        // The queue is Full when the Head equals one more than the Tail.  The
+        // number of entries in a queue when full is one less than the queue
+        // size.
+        (self.head > 0 && self.tail == (self.head - 1))
+            || (self.head == 0 && self.tail == (self.size - 1) as u16)
+    }
+
+    /// Calculate a positive offset for a given index, wrapping at the size of
+    /// the queue.
+    fn wrap_add(&self, idx: u16, off: u16) -> u16 {
+        debug_assert!((idx as u32) < self.size);
+        debug_assert!((off as u32) < self.size);
+
+        let res = idx as u32 + off as u32;
+        if res >= self.size {
+            (res - self.size) as u16
+        } else {
+            res as u16
+        }
+    }
+    /// Calculate a negative offset for a given index, wrapping at the size of
+    /// the queue.
+    fn wrap_sub(&self, idx: u16, off: u16) -> u16 {
+        debug_assert!((idx as u32) < self.size);
+        debug_assert!((off as u32) < self.size);
+
+        if off > idx {
+            ((idx as u32 + self.size) - off as u32) as u16
+        } else {
+            idx - off
+        }
+    }
+
+    /// How many slots are empty between the tail and the head
+    fn avail_empty(&self) -> u16 {
+        self.wrap_sub(self.wrap_sub(self.head, 1), self.tail)
+    }
+    /// How many slots are occupied between the head and the tail
+    fn avail_occupied(&self) -> u16 {
+        self.wrap_sub(self.tail, self.head)
+    }
+
+    fn push_tail(&mut self) -> Option<(u16, bool)> {
+        if self.is_full() {
+            None
+        } else {
+            let result = Some(self.tail);
+            self.tail = self.wrap_add(self.tail, 1);
+            result.map(|r| (r, self.tail as u32 > self.size))
+        }
+    }
+    fn pop_head(&mut self) -> Option<u16> {
+        if self.is_empty() {
+            None
+        } else {
+            let result = Some(self.head);
+            self.head = self.wrap_add(self.head, 1);
+            result
+        }
+    }
+
+    fn push_tail_to(&mut self, idx: u16) -> Result<(), &'static str> {
+        if idx as u32 >= self.size {
+            return Err("invalid index");
+        }
+        let push_count = self.wrap_sub(idx, self.tail);
+        if push_count > self.avail_empty() {
+            return Err("index too far");
+        }
+        self.tail = idx;
+        Ok(())
+    }
+    fn pop_head_to(&mut self, idx: u16) -> Result<(), &'static str> {
+        if idx as u32 >= self.size {
+            return Err("invalid index");
+        }
+        let pop_count = self.wrap_sub(idx, self.head);
+        if pop_count > self.avail_occupied() {
+            return Err("index too far");
+        }
+        self.head = idx;
+        Ok(())
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum QueueCreateErr {
+    #[error("invalid base address")]
+    InvalidBaseAddr,
+    #[error("invalid size")]
+    InvalidSize,
+}
+
+pub struct SubQueue {
+    id: u16,
+    cqid: u16,
+    state: QueueState,
+    base: GuestAddr,
+}
+
+impl SubQueue {
+    pub fn new(
+        id: u16,
+        cqid: u16,
+        size: u32,
+        base: GuestAddr,
+        ctx: &DispCtx
+    ) -> Result<Self, QueueCreateErr> {
+        Self::validate(base, size, ctx)?;
+        Ok(Self { id, cqid, state: QueueState::new(size, 0, 0), base })
+    }
+    pub fn notify_tail(&mut self, idx: u16) -> Result<(), &'static str> {
+        self.state.push_tail_to(idx)
+    }
+    pub fn pop(&mut self, ctx: &DispCtx) -> Option<bits::RawSubmission> {
+        if let Some(idx) = self.state.pop_head() {
+            let mem = ctx.mctx.memctx();
+            let ent: Option<RawSubmission> = mem.read(self.entry_addr(idx));
+            // XXX: handle a guest addr that becomes unmapped later
+            ent
+        } else {
+            None
+        }
+    }
+    pub fn head(&self) -> u16 {
+        self.state.head
+    }
+    pub fn id(&self) -> u16 {
+        self.id
+    }
+    pub fn cqid(&self) -> u16 {
+        self.cqid
+    }
+    fn entry_addr(&self, idx: u16) -> GuestAddr {
+        let res = self.base.0 + idx as u64 * std::mem::size_of::<RawSubmission>() as u64;
+        GuestAddr(res)
+    }
+    fn validate(base: GuestAddr, size: u32, ctx: &DispCtx) -> Result<(), QueueCreateErr> {
+        if (base.0 & PAGE_OFFSET as u64) != 0 {
+            return Err(QueueCreateErr::InvalidBaseAddr);
+        }
+        if size < MIN_SIZE || size > MAX_SIZE {
+            return Err(QueueCreateErr::InvalidSize);
+        }
+        let queue_size =
+            size as usize * std::mem::size_of::<bits::RawSubmission>();
+        let memctx = ctx.mctx.memctx();
+        let region = memctx.readable_region(&GuestRegion(base, queue_size));
+
+        region.map(|_| ()).ok_or(QueueCreateErr::InvalidBaseAddr)
+    }
+}
+
+pub struct CompQueue {
+    id: u16,
+    iv: u16,
+    state: QueueState,
+    base: GuestAddr,
+    phase: u16,
+    hdl: pci::MsixHdl,
+}
+
+impl CompQueue {
+    pub fn new(
+        id: u16,
+        iv: u16,
+        size: u32,
+        base: GuestAddr,
+        ctx: &DispCtx,
+        hdl: pci::MsixHdl
+    ) -> Result<Self, QueueCreateErr> {
+        Self::validate(base, size, ctx)?;
+        Ok(Self {
+            id,
+            iv,
+            state: QueueState::new(size, 0, 0),
+            base,
+            phase: 1,
+            hdl
+        })
+    }
+    pub fn notify_head(&mut self, idx: u16) -> Result<(), &'static str> {
+        self.state.pop_head_to(idx)
+    }
+    pub fn push(&mut self, entry: RawCompletion, ctx: &DispCtx) {
+        if let Some((idx, wrapped)) = self.state.push_tail() {
+            let mem = ctx.mctx.memctx();
+            let addr = self.entry_addr(idx);
+            mem.write(addr, &entry);
+            if wrapped {
+                self.phase = !self.phase;
+            }
+            // XXX: handle a guest addr that becomes unmapped later
+            // XXX: figure out interrupts
+        }
+    }
+    pub fn phase(&self) -> u16 {
+        self.phase
+    }
+    pub fn is_empty(&self) -> bool {
+        self.state.is_empty()
+    }
+    pub fn fire_interrupt(&self, ctx: &DispCtx) {
+        if !self.is_empty() {
+            self.hdl.fire(self.iv, ctx);
+        }
+    }
+    fn entry_addr(&self, idx: u16) -> GuestAddr {
+        let res = self.base.0 + idx as u64 * std::mem::size_of::<RawCompletion>() as u64;
+        GuestAddr(res)
+    }
+    fn validate(base: GuestAddr, size: u32, ctx: &DispCtx) -> Result<(), QueueCreateErr> {
+        if (base.0 & PAGE_OFFSET as u64) != 0 {
+            return Err(QueueCreateErr::InvalidBaseAddr);
+        }
+        if size < MIN_SIZE || size > MAX_SIZE {
+            return Err(QueueCreateErr::InvalidSize);
+        }
+        let queue_size =
+            size as usize * std::mem::size_of::<bits::RawSubmission>();
+        let memctx = ctx.mctx.memctx();
+        let region = memctx.writable_region(&GuestRegion(base, queue_size));
+
+        region.map(|_| ()).ok_or(QueueCreateErr::InvalidBaseAddr)
+    }
+}

--- a/propolis/src/hw/nvme/queue.rs
+++ b/propolis/src/hw/nvme/queue.rs
@@ -21,7 +21,7 @@ const MIN_QUEUE_SIZE: u32 = 2;
 /// The maximum number of entries in either a Completion or Submission Queue.
 ///
 /// See NVMe 1.0e Section 4.1.3 Queue Size
-const MAX_QUEUE_SIZE: u32 = 1 << 16;
+pub const MAX_QUEUE_SIZE: u32 = 1 << 16;
 
 /// The maximum number of entries in the Admin Completion or Admin Submission Queues.
 ///

--- a/propolis/src/hw/nvme/queue.rs
+++ b/propolis/src/hw/nvme/queue.rs
@@ -1,7 +1,3 @@
-#![allow(unused)]
-
-use std::sync::Mutex;
-
 use super::bits::{self, RawCompletion, RawSubmission};
 use crate::common::*;
 use crate::dispatch::DispCtx;
@@ -191,7 +187,6 @@ impl SubQueue {
 }
 
 pub struct CompQueue {
-    id: u16,
     iv: u16,
     state: QueueState,
     base: GuestAddr,
@@ -201,7 +196,6 @@ pub struct CompQueue {
 
 impl CompQueue {
     pub fn new(
-        id: u16,
         iv: u16,
         size: u32,
         base: GuestAddr,
@@ -210,7 +204,6 @@ impl CompQueue {
     ) -> Result<Self, QueueCreateErr> {
         Self::validate(base, size, ctx)?;
         Ok(Self {
-            id,
             iv,
             state: QueueState::new(size, 0, 0),
             base,

--- a/propolis/src/hw/nvme/queue.rs
+++ b/propolis/src/hw/nvme/queue.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Mutex;
 
-use super::bits::{self, RawSubmission, RawCompletion};
+use super::bits::{self, RawCompletion, RawSubmission};
 use crate::common::*;
 use crate::dispatch::DispCtx;
 use crate::hw::pci;
@@ -138,7 +138,7 @@ impl SubQueue {
         cqid: u16,
         size: u32,
         base: GuestAddr,
-        ctx: &DispCtx
+        ctx: &DispCtx,
     ) -> Result<Self, QueueCreateErr> {
         Self::validate(base, size, ctx)?;
         Ok(Self { id, cqid, state: QueueState::new(size, 0, 0), base })
@@ -166,10 +166,15 @@ impl SubQueue {
         self.cqid
     }
     fn entry_addr(&self, idx: u16) -> GuestAddr {
-        let res = self.base.0 + idx as u64 * std::mem::size_of::<RawSubmission>() as u64;
+        let res = self.base.0
+            + idx as u64 * std::mem::size_of::<RawSubmission>() as u64;
         GuestAddr(res)
     }
-    fn validate(base: GuestAddr, size: u32, ctx: &DispCtx) -> Result<(), QueueCreateErr> {
+    fn validate(
+        base: GuestAddr,
+        size: u32,
+        ctx: &DispCtx,
+    ) -> Result<(), QueueCreateErr> {
         if (base.0 & PAGE_OFFSET as u64) != 0 {
             return Err(QueueCreateErr::InvalidBaseAddr);
         }
@@ -201,7 +206,7 @@ impl CompQueue {
         size: u32,
         base: GuestAddr,
         ctx: &DispCtx,
-        hdl: pci::MsixHdl
+        hdl: pci::MsixHdl,
     ) -> Result<Self, QueueCreateErr> {
         Self::validate(base, size, ctx)?;
         Ok(Self {
@@ -210,7 +215,7 @@ impl CompQueue {
             state: QueueState::new(size, 0, 0),
             base,
             phase: 1,
-            hdl
+            hdl,
         })
     }
     pub fn notify_head(&mut self, idx: u16) -> Result<(), &'static str> {
@@ -240,10 +245,15 @@ impl CompQueue {
         }
     }
     fn entry_addr(&self, idx: u16) -> GuestAddr {
-        let res = self.base.0 + idx as u64 * std::mem::size_of::<RawCompletion>() as u64;
+        let res = self.base.0
+            + idx as u64 * std::mem::size_of::<RawCompletion>() as u64;
         GuestAddr(res)
     }
-    fn validate(base: GuestAddr, size: u32, ctx: &DispCtx) -> Result<(), QueueCreateErr> {
+    fn validate(
+        base: GuestAddr,
+        size: u32,
+        ctx: &DispCtx,
+    ) -> Result<(), QueueCreateErr> {
         if (base.0 & PAGE_OFFSET as u64) != 0 {
             return Err(QueueCreateErr::InvalidBaseAddr);
         }

--- a/propolis/src/hw/pci/bits.rs
+++ b/propolis/src/hw/pci/bits.rs
@@ -38,3 +38,7 @@ pub const CLASS_DISPLAY: u8 = 3;
 pub const CLASS_MULTIMEDIA: u8 = 4;
 pub const CLASS_MEMORY: u8 = 5;
 pub const CLASS_BRIDGE: u8 = 6;
+
+pub const SUBCLASS_NVM: u8 = 8;
+
+pub const PROGIF_ENTERPRISE_NVMHCI: u8 = 2;

--- a/propolis/src/hw/pci/bits.rs
+++ b/propolis/src/hw/pci/bits.rs
@@ -41,4 +41,4 @@ pub const CLASS_BRIDGE: u8 = 6;
 
 pub const SUBCLASS_NVM: u8 = 8;
 
-pub const PROGIF_ENTERPRISE_NVMHCI: u8 = 2;
+pub const PROGIF_ENTERPRISE_NVME: u8 = 2;

--- a/propolis/src/hw/virtio/block.rs
+++ b/propolis/src/hw/virtio/block.rs
@@ -205,6 +205,7 @@ impl BlockReq for Request {
             return None;
         }
         let res = match self.op {
+            BlockOp::Flush => return None,
             BlockOp::Read => self.chain.writable_buf(self.xfer_left),
             BlockOp::Write => self.chain.readable_buf(self.xfer_left),
         };


### PR DESCRIPTION
Basing off of @pfmooney's [work](https://github.com/pfmooney/propolis/commits/nvme-junks) this adds basic nvme emulation. We can boot an alpine image with it and have read/write working. There are still some missing gaps in terms of non-io commands.

Multiple I/O queues are supported along with attaching multiple namespaces with different underlying block devices to the same controller.