### PR TITLE
[block] Allow PlainBdevs to be explicitly read-only

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -185,9 +185,14 @@ fn main() {
                     let disk_path =
                         dev.options.get("disk").unwrap().as_str().unwrap();
 
+                    let readonly: bool = || -> Option<bool> {
+                        dev.options.get("readonly")?.as_str()?.parse().ok()
+                    }()
+                    .unwrap_or(false);
+
                     let plain: Arc<
                         block::PlainBdev<hw::virtio::block::Request>,
-                    > = block::PlainBdev::create(disk_path).unwrap();
+                    > = block::PlainBdev::create(disk_path, readonly).unwrap();
 
                     let vioblk = hw::virtio::VirtioBlock::create(
                         0x100,

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -67,13 +67,14 @@ pub struct PlainBdev<R: BlockReq> {
     reqs: Mutex<VecDeque<R>>,
     cond: Condvar,
 }
+
 impl<R: BlockReq> PlainBdev<R> {
     /// Creates a new block device from a device at `path`.
-    pub fn create(path: impl AsRef<Path>) -> Result<Arc<Self>> {
+    pub fn create(path: impl AsRef<Path>, readonly: bool) -> Result<Arc<Self>> {
         let p: &Path = path.as_ref();
 
         let meta = metadata(p)?;
-        let is_ro = meta.permissions().readonly();
+        let is_ro = readonly || meta.permissions().readonly();
 
         let fp = OpenOptions::new().read(true).write(!is_ro).open(p)?;
         let is_raw = fp.metadata()?.file_type().is_char_device();

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -206,8 +206,9 @@ impl<'a> MachineInitializer<'a> {
         chipset: &RegisteredChipset,
         path: P,
         bdf: pci::Bdf,
+        readonly: bool,
     ) -> Result<(), Error> {
-        let plain = block::PlainBdev::create(path.as_ref())?;
+        let plain = block::PlainBdev::create(path.as_ref(), readonly)?;
 
         let vioblk = virtio::VirtioBlock::create(
             0x100,

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -163,7 +163,7 @@ async fn instance_ensure(
         // If properties match, we return Ok. Otherwise, we could attempt to
         // update the instance.
         //
-        // TODO: The intial implementation does not modify any properties,
+        // TODO: The initial implementation does not modify any properties,
         // but we plausibly could do so - need to work out which properties
         // can be changed without rebooting.
         if ctx.properties != properties {
@@ -213,6 +213,8 @@ async fn instance_ensure(
                 let driver = &dev.driver as &str;
                 match driver {
                     "pci-virtio-block" => {
+                        let readonly: bool =
+                            dev.get("readonly").unwrap_or(false);
                         let path = dev.get_string("disk").ok_or_else(|| {
                             Error::new(
                                 ErrorKind::InvalidData,
@@ -226,7 +228,7 @@ async fn instance_ensure(
                                     "Cannot parse disk PCI",
                                 )
                             })?;
-                        init.initialize_block(&chipset, path, bdf)?;
+                        init.initialize_block(&chipset, path, bdf, readonly)?;
                     }
                     "pci-virtio-viona" => {
                         let name = dev.get_string("vnic").ok_or_else(|| {


### PR DESCRIPTION
This command is particularly useful when mounting a
PlainBdev on a read-only filesystem, or in a situation
where the caller wants to ensure that modifications
cannot be made.