### PR TITLE
Create new BlockDevBackingStore abstraction

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -194,8 +194,14 @@ fn main() {
                     .unwrap_or(false);
 
                     let plain: Arc<
-                        block::PlainBdev<hw::virtio::block::Request, block::FileBlockDevBackingStore>,
-                    > = block::create_file_backed_block_device(disk_path, readonly).unwrap();
+                        block::PlainBdev<
+                            hw::virtio::block::Request,
+                            block::FileBlockDevBackingStore,
+                        >,
+                    > = block::create_file_backed_block_device(
+                        disk_path, readonly,
+                    )
+                    .unwrap();
 
                     let vioblk = hw::virtio::VirtioBlock::create(
                         0x100,
@@ -243,8 +249,10 @@ fn main() {
                         dev.options.get("readonly")?.as_str()?.parse().ok()
                     }()
                     .unwrap_or(false);
-                    let plain =
-                        block::create_file_backed_block_device(disk_path, readonly).unwrap();
+                    let plain = block::create_file_backed_block_device(
+                        disk_path, readonly,
+                    )
+                    .unwrap();
                     let ns = hw::nvme::NvmeNs::create(plain.clone());
 
                     if let Err(e) =

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -193,7 +193,9 @@ fn main() {
                     }()
                     .unwrap_or(false);
 
-                    let plain = block::PlainBdev::from_file(disk_path, readonly) .unwrap();
+                    let plain =
+                        block::PlainBdev::from_file(disk_path, readonly)
+                            .unwrap();
 
                     let vioblk = hw::virtio::VirtioBlock::create(
                         0x100,
@@ -242,7 +244,9 @@ fn main() {
                     }()
                     .unwrap_or(false);
 
-                    let plain = block::PlainBdev::from_file(disk_path, readonly).unwrap();
+                    let plain =
+                        block::PlainBdev::from_file(disk_path, readonly)
+                            .unwrap();
                     let ns = hw::nvme::NvmeNs::create(plain.clone());
 
                     if let Err(e) =

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -193,10 +193,7 @@ fn main() {
                     }()
                     .unwrap_or(false);
 
-                    let plain = block::create_file_backed_block_device(
-                        disk_path, readonly,
-                    )
-                    .unwrap();
+                    let plain = block::PlainBdev::from_file(disk_path, readonly) .unwrap();
 
                     let vioblk = hw::virtio::VirtioBlock::create(
                         0x100,
@@ -244,10 +241,8 @@ fn main() {
                         dev.options.get("readonly")?.as_str()?.parse().ok()
                     }()
                     .unwrap_or(false);
-                    let plain = block::create_file_backed_block_device(
-                        disk_path, readonly,
-                    )
-                    .unwrap();
+
+                    let plain = block::PlainBdev::from_file(disk_path, readonly).unwrap();
                     let ns = hw::nvme::NvmeNs::create(plain.clone());
 
                     if let Err(e) =

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -193,12 +193,7 @@ fn main() {
                     }()
                     .unwrap_or(false);
 
-                    let plain: Arc<
-                        block::PlainBdev<
-                            hw::virtio::block::Request,
-                            block::FileBlockDevBackingStore,
-                        >,
-                    > = block::create_file_backed_block_device(
+                    let plain = block::create_file_backed_block_device(
                         disk_path, readonly,
                     )
                     .unwrap();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -194,8 +194,8 @@ fn main() {
                     .unwrap_or(false);
 
                     let plain: Arc<
-                        block::PlainBdev<hw::virtio::block::Request>,
-                    > = block::PlainBdev::create(disk_path, readonly).unwrap();
+                        block::PlainBdev<hw::virtio::block::Request, block::FileBlockDevBackingStore>,
+                    > = block::create_file_backed_block_device(disk_path, readonly).unwrap();
 
                     let vioblk = hw::virtio::VirtioBlock::create(
                         0x100,
@@ -244,7 +244,7 @@ fn main() {
                     }()
                     .unwrap_or(false);
                     let plain =
-                        block::PlainBdev::create(disk_path, readonly).unwrap();
+                        block::create_file_backed_block_device(disk_path, readonly).unwrap();
                     let ns = hw::nvme::NvmeNs::create(plain.clone());
 
                     if let Err(e) =

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -152,9 +152,7 @@ impl<R: BlockReq, S: BlockDevBackingStore> PlainBdev<R, S> {
         Ok(Arc::new(this))
     }
 
-    /*
-     * Consume enqueued requests and process them. Signal completion when done.
-     */
+    // Consume enqueued requests and process them. Signal completion when done.
     fn process_loop(&self, ctx: &mut DispCtx) {
         let mut reqs = self.reqs.lock().unwrap();
         loop {
@@ -171,9 +169,7 @@ impl<R: BlockReq, S: BlockDevBackingStore> PlainBdev<R, S> {
         }
     }
 
-    /*
-     * Match against individual BlockReqs and call appropriate processing functions.
-     */
+    // Match against individual BlockReqs and call appropriate processing functions.
     fn process_request(&self, req: &mut R, ctx: &DispCtx) -> BlockResult {
         let mem = ctx.mctx.memctx();
 
@@ -210,9 +206,7 @@ impl<R: BlockReq, S: BlockDevBackingStore> PlainBdev<R, S> {
         BlockResult::Success
     }
 
-    /*
-     * Read from BlockReqBackingStore and write into VM memory.
-     */
+    // Read from BlockReqBackingStore and write into VM memory.
     fn process_read_request(
         &self,
         offset: usize,
@@ -238,9 +232,7 @@ impl<R: BlockReq, S: BlockDevBackingStore> PlainBdev<R, S> {
         }
     }
 
-    /*
-     * Read from VM memory and write to BlockReqBackingStore.
-     */
+    // Read from VM memory and write to BlockReqBackingStore.
     fn process_write_request(
         &self,
         offset: usize,
@@ -267,9 +259,7 @@ impl<R: BlockReq, S: BlockDevBackingStore> PlainBdev<R, S> {
         }
     }
 
-    /*
-     * Send flush to BlockReqBackingStore
-     */
+    // Send flush to BlockReqBackingStore
     fn process_flush(&self) -> BlockResult {
         match self.backing_store.issue_flush() {
             Ok(()) => BlockResult::Success,

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -189,8 +189,8 @@ impl<R: BlockReq, S: BlockDevBackingStore> PlainBdev<R, S> {
     pub fn create(backing_store: S) -> Result<Arc<Self>> {
         let len = backing_store.len();
         let block_size = match backing_store.block_size() {
-            Some(v) => { v }
-            None => { 512 }
+            Some(v) => v,
+            None => 512,
         };
 
         let this = Self {

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -206,7 +206,8 @@ impl<R: BlockReq, S: BlockDevBackingStore> PlainBdev<R, S> {
                 BlockOp::Flush => self.process_flush(),
             };
 
-            // TODO: should all BlockReq be attempted instead of returning early?
+            // If any BlockReq in this IO request fail, inform the guest that
+            // their IO request failed.
             match result {
                 BlockResult::Success => {} // ok
                 BlockResult::Failure => {

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -89,7 +89,6 @@ impl FileBlockDevBackingStore {
         let is_ro = readonly || meta.permissions().readonly();
 
         let fp = OpenOptions::new().read(true).write(!is_ro).open(p)?;
-        let is_ro = readonly || meta.permissions().readonly();
         let len = fp.metadata().unwrap().len() as usize;
 
         Ok(FileBlockDevBackingStore { fp, is_ro, len })

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -156,6 +156,18 @@ pub struct PlainBdev<R: BlockReq, S: BlockDevBackingStore> {
     cond: Condvar,
 }
 
+impl<R: BlockReq> PlainBdev<R, FileBlockDevBackingStore> {
+    pub fn from_file(
+        path: impl AsRef<Path>,
+        readonly: bool,
+    ) -> Result<Arc<PlainBdev<R, FileBlockDevBackingStore>>> {
+        let backing_store = FileBlockDevBackingStore::from_path(path, readonly)?;
+        let plain_bdev = PlainBdev::create(backing_store)?;
+
+        Ok(plain_bdev)
+    }
+}
+
 impl<R: BlockReq, S: BlockDevBackingStore> PlainBdev<R, S> {
     /// Creates a new block device from a device at `path`.
     pub fn create(backing_store: S) -> Result<Arc<Self>> {
@@ -324,15 +336,4 @@ impl<R: BlockReq, S: BlockDevBackingStore> BlockDev<R> for PlainBdev<R, S> {
             writable: !self.backing_store.is_ro(),
         }
     }
-}
-
-pub fn create_file_backed_block_device<R: BlockReq>(
-    path: impl AsRef<Path>,
-    readonly: bool,
-) -> Result<Arc<PlainBdev<R, FileBlockDevBackingStore>>> {
-    let backing_store = FileBlockDevBackingStore::from_path(path, readonly)?;
-    let plain_bdev =
-        PlainBdev::<R, FileBlockDevBackingStore>::create(backing_store)?;
-
-    Ok(plain_bdev)
 }

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -61,8 +61,18 @@ pub trait BlockDev<R: BlockReq>: Send + Sync + 'static {
 
 /// Abstraction over an actual backing store
 pub trait BlockDevBackingStore: Send + Sync + 'static {
-    fn issue_read(&self, offset: usize, sz: usize, mapping: SubMapping) -> Result<usize>;
-    fn issue_write(&self, offset: usize, sz: usize, mapping: SubMapping) -> Result<usize>;
+    fn issue_read(
+        &self,
+        offset: usize,
+        sz: usize,
+        mapping: SubMapping,
+    ) -> Result<usize>;
+    fn issue_write(
+        &self,
+        offset: usize,
+        sz: usize,
+        mapping: SubMapping,
+    ) -> Result<usize>;
     fn issue_flush(&self) -> Result<()>;
 
     fn is_ro(&self) -> bool;
@@ -100,11 +110,21 @@ impl FileBlockDevBackingStore {
 }
 
 impl BlockDevBackingStore for FileBlockDevBackingStore {
-    fn issue_read(&self, offset: usize, sz: usize, mapping: SubMapping) -> Result<usize> {
+    fn issue_read(
+        &self,
+        offset: usize,
+        sz: usize,
+        mapping: SubMapping,
+    ) -> Result<usize> {
         mapping.pread(&self.fp, sz, offset as i64)
     }
 
-    fn issue_write(&self, offset: usize, sz: usize, mapping: SubMapping) -> Result<usize> {
+    fn issue_write(
+        &self,
+        offset: usize,
+        sz: usize,
+        mapping: SubMapping,
+    ) -> Result<usize> {
         mapping.pwrite(&self.fp, sz, offset as i64)
     }
 

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -176,8 +176,7 @@ impl<R: BlockReq> PlainBdev<R, FileBackingStore> {
         path: impl AsRef<Path>,
         readonly: bool,
     ) -> Result<Arc<PlainBdev<R, FileBackingStore>>> {
-        let backing_store =
-            FileBackingStore::from_path(path, readonly)?;
+        let backing_store = FileBackingStore::from_path(path, readonly)?;
         let plain_bdev = PlainBdev::create(backing_store)?;
 
         Ok(plain_bdev)

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -102,6 +102,7 @@ impl FileBlockDevBackingStore {
 impl BlockDevBackingStore for FileBlockDevBackingStore {
     fn issue_read(&self, offset: usize, sz: usize) -> Result<Vec<u8>> {
         let mut vec = Vec::<u8>::with_capacity(sz);
+        vec.resize(sz, 0);
 
         let nread = unsafe {
             libc::pread(
@@ -368,6 +369,8 @@ fn read_from_vm_memory(mem: &MemCtx, buf: GuestRegion) -> Result<Vec<u8>> {
 
     if let Some(mapping) = mem.readable_region(&buf) {
         let mut bytes = Vec::<u8>::with_capacity(sz);
+        bytes.resize(sz, 0);
+
         match mapping.read_bytes(&mut bytes[..]) {
             Ok(nread) => {
                 assert_eq!(nread as usize, bytes.len());

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -281,7 +281,7 @@ impl<R: BlockReq, S: BlockDevBackingStore> PlainBdev<R, S> {
                     BlockResult::Success
                 }
                 Err(_) => {
-                    // TODO: Error writing to guest memory
+                    // TODO: Error reading from guest memory
                     BlockResult::Failure
                 }
             }

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -161,7 +161,8 @@ impl<R: BlockReq> PlainBdev<R, FileBlockDevBackingStore> {
         path: impl AsRef<Path>,
         readonly: bool,
     ) -> Result<Arc<PlainBdev<R, FileBlockDevBackingStore>>> {
-        let backing_store = FileBlockDevBackingStore::from_path(path, readonly)?;
+        let backing_store =
+            FileBlockDevBackingStore::from_path(path, readonly)?;
         let plain_bdev = PlainBdev::create(backing_store)?;
 
         Ok(plain_bdev)

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -92,7 +92,7 @@ impl FileBlockDevBackingStore {
         let is_ro = readonly || meta.permissions().readonly();
         let len = fp.metadata().unwrap().len() as usize;
 
-        Ok(FileBlockDevBackingStore { fp: fp, is_ro: is_ro, len: len })
+        Ok(FileBlockDevBackingStore { fp, is_ro, len })
     }
 
     pub fn get_file(&self) -> &File {

--- a/propolis/src/vmm/mapping.rs
+++ b/propolis/src/vmm/mapping.rs
@@ -545,7 +545,7 @@ mod tests {
 
         let input: u64 = 0xDEADBEEF;
         mapping.as_ref().write(&input).unwrap();
-        let output = mapping.as_ref().read().unwrap();
+        let output: u64 = mapping.as_ref().read().unwrap();
         assert_eq!(input, output);
     }
 

--- a/propolis/src/vmm/mapping.rs
+++ b/propolis/src/vmm/mapping.rs
@@ -545,7 +545,7 @@ mod tests {
 
         let input: u64 = 0xDEADBEEF;
         mapping.as_ref().write(&input).unwrap();
-        let output: u64 = mapping.as_ref().read().unwrap();
+        let output = mapping.as_ref().read().unwrap();
         assert_eq!(input, output);
     }
 

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -208,7 +208,7 @@ impl<'a> MachineInitializer<'a> {
         bdf: pci::Bdf,
         readonly: bool,
     ) -> Result<(), Error> {
-        let plain = block::PlainBdev::create(path.as_ref(), readonly)?;
+        let plain = block::create_file_backed_block_device(path.as_ref(), readonly)?;
 
         let vioblk = virtio::VirtioBlock::create(
             0x100,

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -208,8 +208,7 @@ impl<'a> MachineInitializer<'a> {
         bdf: pci::Bdf,
         readonly: bool,
     ) -> Result<(), Error> {
-        let plain =
-            block::create_file_backed_block_device(path.as_ref(), readonly)?;
+        let plain = block::PlainBdev::from_file(path.as_ref(), readonly)?;
 
         let vioblk = virtio::VirtioBlock::create(
             0x100,

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -208,7 +208,8 @@ impl<'a> MachineInitializer<'a> {
         bdf: pci::Bdf,
         readonly: bool,
     ) -> Result<(), Error> {
-        let plain = block::create_file_backed_block_device(path.as_ref(), readonly)?;
+        let plain =
+            block::create_file_backed_block_device(path.as_ref(), readonly)?;
 
         let vioblk = virtio::VirtioBlock::create(
             0x100,


### PR DESCRIPTION
Separate ideas of BlockDev and BlockDevBackingStore:

- BlockDev is the API of a virtualized block device.
- BlockDevBackingStore fulfils the requests sent to the BlockDev.

PlainBdev does the same thing that it did before, except now requests are fulfilled by a supplied BlockDevBackingStore. New backing stores now only need to implement a new BlockDevBackingStore trait and hand it to a PlainBDev. Parts of PlainBdev that interacted with a file have been pulled out into a new FileBlockDevBackingStore.

Functionally, this only represents a refactor. The next work will implement a BlockDevBackingStore for Crucible.

There's a few TODOs here but I wanted to get some comments on this path forward with a PR.