### PR TITLE
[client][server] NIC instantiation via HTTP API

### DIFF
--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -16,6 +16,7 @@ pub struct InstancePathParams {
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceEnsureRequest {
     pub properties: InstanceProperties,
+    pub nics: Vec<NetworkInterfaceRequest>,
 }
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
@@ -89,7 +90,7 @@ pub struct Instance {
     pub state: InstanceState,
 
     pub disks: Vec<DiskAttachment>,
-    pub nics: Vec<NicAttachment>,
+    pub nics: Vec<NetworkInterface>,
 }
 
 /// Describes how to connect to one or more storage agent services.
@@ -176,21 +177,26 @@ pub struct DiskAttachment {
     pub state: DiskAttachmentState,
 }
 
+/// A stable index which is translated by Propolis
+/// into a PCI BDF, visible to the guest.
+#[derive(Copy, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct PciSlot(pub u8);
+
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
-pub struct NicAttachmentInfo {
-    pub slot: u16,
+pub struct NetworkInterfaceRequest {
+    pub name: String,
+    pub slot: PciSlot,
 }
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
-pub enum NicAttachmentState {
-    Attached(NicAttachmentInfo),
+pub struct NetworkInterface {
+    pub name: String,
+    pub attachment: NetworkInterfaceAttachmentState,
+}
+
+#[derive(Clone, Deserialize, Serialize, JsonSchema)]
+pub enum NetworkInterfaceAttachmentState {
+    Attached(PciSlot),
     Detached,
     Faulted,
-}
-
-#[derive(Clone, Deserialize, Serialize, JsonSchema)]
-pub struct NicAttachment {
-    pub generation_id: u64,
-    pub nic_id: Uuid,
-    pub stat: NicAttachmentState,
 }

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -180,12 +180,12 @@ pub struct DiskAttachment {
 /// A stable index which is translated by Propolis
 /// into a PCI BDF, visible to the guest.
 #[derive(Copy, Clone, Deserialize, Serialize, JsonSchema)]
-pub struct PciSlot(pub u8);
+pub struct Slot(pub u8);
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
 pub struct NetworkInterfaceRequest {
     pub name: String,
-    pub slot: PciSlot,
+    pub slot: Slot,
 }
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
@@ -196,7 +196,7 @@ pub struct NetworkInterface {
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
 pub enum NetworkInterfaceAttachmentState {
-    Attached(PciSlot),
+    Attached(Slot),
     Detached,
     Faulted,
 }

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -149,8 +149,9 @@ fn slot_to_bdf(slot: api::PciSlot, ty: SlotType) -> Result<pci::Bdf> {
         SlotType::Disk if slot.0 <= 7 => Ok(pci::Bdf::new(0, slot.0 + 0x10, 0)),
         _ => Err(anyhow::anyhow!(
             "PCI Slot {} has no translation to BDF for type {:?}",
-            slot.0, ty
-        ))
+            slot.0,
+            ty
+        )),
     }
 }
 
@@ -236,12 +237,13 @@ async fn instance_ensure(
 
             // Attach devices which have been requested from the HTTP interface.
             for nic in &nics {
-                let bdf = slot_to_bdf(nic.slot, SlotType::NIC).map_err(|e| {
-                    Error::new(
-                        ErrorKind::InvalidData,
-                        format!("Cannot parse vnic PCI: {}", e),
-                    )
-                })?;
+                let bdf =
+                    slot_to_bdf(nic.slot, SlotType::NIC).map_err(|e| {
+                        Error::new(
+                            ErrorKind::InvalidData,
+                            format!("Cannot parse vnic PCI: {}", e),
+                        )
+                    })?;
                 init.initialize_vnic(&chipset, &nic.name, bdf)?;
             }
 

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -141,7 +141,7 @@ enum SlotType {
 // we'd like to assign a stable PCI slot, such that re-allocating these
 // devices on a new instance of propolis produces the same guest-visible
 // BDFs.
-fn slot_to_bdf(slot: api::PciSlot, ty: SlotType) -> Result<pci::Bdf> {
+fn slot_to_bdf(slot: api::Slot, ty: SlotType) -> Result<pci::Bdf> {
     match ty {
         // Slots for NICS: 0x08 -> 0x0F
         SlotType::NIC if slot.0 <= 7 => Ok(pci::Bdf::new(0, slot.0 + 0x8, 0)),

--- a/server/tests/integration_tests.rs
+++ b/server/tests/integration_tests.rs
@@ -82,6 +82,7 @@ fn create_ensure_request(
             memory: 256,
             vcpus: 2,
         },
+        nics: vec![],
     }
 }
 


### PR DESCRIPTION
Minimal API to request NICs over the HTTP API.

Unfinished things / open questions:
- Listing all attached NICs and their statuses. We *could* just store this info at the "server" layer, so we'd basically just return whatever information was requested previously. However, IMO it would be better to have a way of querying the device inventory to be able to return more dynamic device info.
- Assigning PCI slots. Currently, we're using a *super* hardcoded slot schema; feedback definitely welcome here.