### PR TITLE
Pass multiple buffers to backing store

### DIFF
--- a/propolis/src/vmm/mapping.rs
+++ b/propolis/src/vmm/mapping.rs
@@ -518,11 +518,11 @@ impl<'a> SubMapping<'a> {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use tempfile::tempfile;
 
-    fn test_vmm(len: u64) -> VmmFile {
+    pub fn test_vmm(len: u64) -> VmmFile {
         let file = tempfile().unwrap();
         file.set_len(len).unwrap();
         unsafe { VmmFile::new(file) }


### PR DESCRIPTION
Pass multiple buffers to backing store during request processing instead of one at a time. This allows backing stores to decide whether or not to fulfill this as a single request or multiple ones.

Also adds a test for FileBackingStore.