### PR TITLE
Initialize backing stores separately from devices

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -11,6 +11,9 @@ struct Top {
 
     #[serde(default, rename = "dev")]
     devices: BTreeMap<String, Device>,
+
+    #[serde(default, rename = "backing_store")]
+    backing_stores: BTreeMap<String, BackingStore>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -24,6 +27,15 @@ struct Main {
 #[derive(Deserialize, Debug)]
 pub struct Device {
     pub driver: String,
+
+    #[serde(flatten, default)]
+    pub options: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct BackingStore {
+    #[serde(default, rename = "type")]
+    pub bstype: String,
 
     #[serde(flatten, default)]
     pub options: BTreeMap<String, toml::Value>,
@@ -47,6 +59,9 @@ impl Config {
     }
     pub fn devs(&self) -> IterDevs {
         IterDevs { inner: self.inner.devices.iter() }
+    }
+    pub fn backing_stores(&self) -> btree_map::Iter<String, BackingStore> {
+        self.inner.backing_stores.iter()
     }
 }
 pub struct IterDevs<'a> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -246,13 +246,12 @@ fn main() {
 
                     let backing_store = backing_stores
                         .remove(&backing_store.to_string())
-                        .expect(
-                            format!(
+                        .unwrap_or_else(|| {
+                            panic!(
                                 "could not find backing store {}!",
                                 backing_store
                             )
-                            .as_str(),
-                        );
+                        });
 
                     let plain =
                         block::PlainBdev::create(backing_store).unwrap();
@@ -304,7 +303,12 @@ fn main() {
 
                     let backing_store = backing_stores
                         .remove(&backing_store.to_string())
-                        .unwrap();
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "could not find backing store {}!",
+                                backing_store
+                            )
+                        });
 
                     let plain =
                         block::PlainBdev::create(backing_store).unwrap();


### PR DESCRIPTION
Initialize backing stores separately from devices, and refer to them by name in device init instead.

Before:

    [dev.block0]
    driver = "pci-virtio-block"
    disk = "/home/james/disk.img"
    pci-path = "0.4.0"

After:

    [backing_store.bootimg]
    type = "file"
    path = "/home/james/disk.img"

    [dev.block0]
    driver = "pci-virtio-block"
    backing_store = "bootimg"
    pci-path = "0.4.0"

The code initializing backing stores now lives in one place. An equivalent change should happen for the server code at some point too (in server/src/lib/server.rs and server/src/lib/initializer.rs).