### PR TITLE
Put blockdev and backingstore back together again

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -208,8 +208,7 @@ fn main() {
                     .unwrap_or(false);
 
                     let plain =
-                        block::PlainBdev::from_file(disk_path, readonly)
-                            .unwrap();
+                        block::PlainBdev::create(disk_path, readonly).unwrap();
 
                     let vioblk = hw::virtio::VirtioBlock::create(
                         0x100,
@@ -257,8 +256,7 @@ fn main() {
                     .unwrap_or(false);
 
                     let plain =
-                        block::PlainBdev::from_file(disk_path, readonly)
-                            .unwrap();
+                        block::PlainBdev::create(disk_path, readonly).unwrap();
                     let ns = hw::nvme::NvmeNs::create(plain.clone());
 
                     if let Err(e) =

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -208,7 +208,7 @@ fn main() {
                     .unwrap_or(false);
 
                     let plain =
-                        block::PlainBdev::create(disk_path, readonly).unwrap();
+                        block::FileBdev::create(disk_path, readonly).unwrap();
 
                     let vioblk = hw::virtio::VirtioBlock::create(
                         0x100,
@@ -256,7 +256,7 @@ fn main() {
                     .unwrap_or(false);
 
                     let plain =
-                        block::PlainBdev::create(disk_path, readonly).unwrap();
+                        block::FileBdev::create(disk_path, readonly).unwrap();
                     let ns = hw::nvme::NvmeNs::create(plain.clone());
 
                     if let Err(e) =

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -14,7 +14,7 @@ use crate::dispatch::{DispCtx, Dispatcher};
 use crate::vmm::{MemCtx, SubMapping};
 
 /// Type of operations which may be issued to a virtual block device.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum BlockOp {
     Flush,
     Read,
@@ -32,10 +32,13 @@ pub enum BlockResult {
 pub trait BlockReq: Send + Sync + 'static {
     /// Type of operation being issued.
     fn oper(&self) -> BlockOp;
+
     /// Offset within the block device, in bytes.
     fn offset(&self) -> usize;
+
     /// Returns the next region of memory within a request to a block device.
     fn next_buf(&mut self) -> Option<GuestRegion>;
+
     /// Signals to the device emulation that a block operation has been completed.
     fn complete(self, res: BlockResult, ctx: &DispCtx);
 }
@@ -59,50 +62,20 @@ pub trait BlockDev<R: BlockReq>: Send + Sync + 'static {
     fn inquire(&self) -> BlockInquiry;
 }
 
-/// Abstraction over an actual backing store
-pub trait BackingStore: Send + Sync + 'static {
-    /// Read from backing store and write into guest mapping
-    fn issue_read(
-        &self,
-        offset: usize,
-        sz: usize,
-        mapping: SubMapping,
-    ) -> Result<usize>;
-
-    /// Read from guest mapping and write into backing store
-    fn issue_write(
-        &self,
-        offset: usize,
-        sz: usize,
-        mapping: SubMapping,
-    ) -> Result<usize>;
-
-    /// Issue flush command to backing store
-    fn issue_flush(&self) -> Result<()>;
-
-    /// Is backing store read only?
-    fn is_ro(&self) -> bool;
-
-    /// return total length in bytes
-    fn len(&self) -> usize;
-
-    /// some backing stores may have block size requirements. optionally return a
-    /// block size in bytes.
-    fn block_size(&self) -> Option<usize>;
-}
-
-/// A block device implementation backed by an underlying file.
-pub struct FileBackingStore {
+/// Standard [`BlockDev`] implementation.
+pub struct PlainBdev<R: BlockReq> {
     fp: File,
     is_ro: bool,
-    len: usize,
+
+    block_size: usize,
+    sectors: usize,
+    reqs: Mutex<VecDeque<R>>,
+    cond: Condvar,
 }
 
-impl FileBackingStore {
-    pub fn from_path(
-        path: impl AsRef<Path>,
-        readonly: bool,
-    ) -> Result<FileBackingStore> {
+impl<R: BlockReq> PlainBdev<R> {
+    /// Creates a new block device from a device at `path`.
+    pub fn create(path: impl AsRef<Path>, readonly: bool) -> Result<Arc<Self>> {
         let p: &Path = path.as_ref();
 
         let meta = metadata(p)?;
@@ -111,88 +84,12 @@ impl FileBackingStore {
         let fp = OpenOptions::new().read(true).write(!is_ro).open(p)?;
         let len = fp.metadata().unwrap().len() as usize;
 
-        Ok(FileBackingStore { fp, is_ro, len })
-    }
-
-    pub fn get_file(&self) -> &File {
-        &self.fp
-    }
-}
-
-impl BackingStore for FileBackingStore {
-    fn issue_read(
-        &self,
-        offset: usize,
-        sz: usize,
-        mapping: SubMapping,
-    ) -> Result<usize> {
-        mapping.pread(&self.fp, sz, offset as i64)
-    }
-
-    fn issue_write(
-        &self,
-        offset: usize,
-        sz: usize,
-        mapping: SubMapping,
-    ) -> Result<usize> {
-        mapping.pwrite(&self.fp, sz, offset as i64)
-    }
-
-    fn issue_flush(&self) -> Result<()> {
-        let res = unsafe { libc::fdatasync(self.fp.as_raw_fd()) };
-
-        if res == -1 {
-            Err(Error::new(ErrorKind::Other, "file flush failed"))
-        } else {
-            Ok(())
-        }
-    }
-
-    fn is_ro(&self) -> bool {
-        self.is_ro
-    }
-
-    fn len(&self) -> usize {
-        self.len
-    }
-
-    fn block_size(&self) -> Option<usize> {
-        // Files do not have a block size requirement
-        None
-    }
-}
-
-/// Standard [`BlockDev`] implementation. Requires a backing store.
-pub struct PlainBdev<R: BlockReq, S: BackingStore> {
-    backing_store: S,
-    block_size: usize,
-    sectors: usize,
-    reqs: Mutex<VecDeque<R>>,
-    cond: Condvar,
-}
-
-impl<R: BlockReq> PlainBdev<R, FileBackingStore> {
-    pub fn from_file(
-        path: impl AsRef<Path>,
-        readonly: bool,
-    ) -> Result<Arc<PlainBdev<R, FileBackingStore>>> {
-        let backing_store = FileBackingStore::from_path(path, readonly)?;
-        let plain_bdev = PlainBdev::create(backing_store)?;
-
-        Ok(plain_bdev)
-    }
-}
-
-impl<R: BlockReq, S: BackingStore> PlainBdev<R, S> {
-    /// Creates a new block device from a device at `path`.
-    pub fn create(backing_store: S) -> Result<Arc<Self>> {
-        let len = backing_store.len();
-        let block_size = backing_store.block_size().unwrap_or(512);
-
         let this = Self {
-            backing_store,
-            block_size,
-            sectors: len / block_size,
+            fp: fp,
+            is_ro,
+
+            block_size: 512,
+            sectors: len / 512,
             reqs: Mutex::new(VecDeque::new()),
             cond: Condvar::new(),
         };
@@ -217,102 +114,100 @@ impl<R: BlockReq, S: BackingStore> PlainBdev<R, S> {
         }
     }
 
-    /// Match against individual BlockReqs and call appropriate processing functions.
+    /// Gather all buffers from the request and pass as a group to the appropriate processing function.
     fn process_request(&self, req: &mut R, ctx: &DispCtx) -> BlockResult {
         let mem = ctx.mctx.memctx();
 
-        let mut offset = req.offset();
+        let offset = req.offset();
+
+        let mut bufs = vec![];
 
         while let Some(buf) = req.next_buf() {
-            let sz = buf.1;
-
-            let result = match req.oper() {
-                BlockOp::Read => {
-                    self.process_read_request(offset, sz, &mem, buf)
-                }
-                BlockOp::Write => self.process_write_request(offset, &mem, buf),
-                BlockOp::Flush => self.process_flush(),
-            };
-
-            // If any BlockReq in this IO request fail, inform the guest that
-            // their IO request failed.
-            match result {
-                BlockResult::Success => {} // ok
-                BlockResult::Failure => {
-                    return BlockResult::Failure;
-                }
-                BlockResult::Unsupported => {
-                    return BlockResult::Unsupported;
-                }
-            };
-
-            offset += sz;
+            bufs.push(buf);
         }
 
-        BlockResult::Success
-    }
-
-    /// Delegate a block device read to BlockReqBackingStore.
-    fn process_read_request(
-        &self,
-        offset: usize,
-        sz: usize,
-        mem: &MemCtx,
-        buf: GuestRegion,
-    ) -> BlockResult {
-        if let Some(mapping) = mem.writable_region(&buf) {
-            let nread = self.backing_store.issue_read(offset, sz, mapping);
-            match nread {
-                Ok(nread) => {
-                    assert_eq!(nread as usize, sz);
-                    BlockResult::Success
-                }
-                Err(_) => {
-                    // TODO: Error writing to guest memory
-                    BlockResult::Failure
-                }
+        let result = match req.oper() {
+            BlockOp::Read => self.process_rw_request(true, offset, &mem, bufs),
+            BlockOp::Write => {
+                self.process_rw_request(false, offset, &mem, bufs)
             }
-        } else {
-            // TODO: Error getting writable region
-            BlockResult::Failure
+            BlockOp::Flush => self.process_flush(),
+        };
+
+        match result {
+            Ok(status) => status,
+            Err(_) => BlockResult::Failure,
         }
     }
 
-    /// Delegate a block device write to BlockReqBackingStore.
-    fn process_write_request(
+    /// Delegate a block device read or write to the file.
+    fn process_rw_request(
         &self,
+        is_read: bool,
         offset: usize,
         mem: &MemCtx,
-        buf: GuestRegion,
-    ) -> BlockResult {
-        let sz = buf.1;
+        bufs: Vec<GuestRegion>,
+    ) -> Result<BlockResult> {
+        let mappings: Vec<SubMapping> = bufs
+            .iter()
+            .map(|buf| {
+                if is_read {
+                    mem.writable_region(buf).unwrap()
+                } else {
+                    mem.readable_region(buf).unwrap()
+                }
+            })
+            .collect();
 
-        if let Some(mapping) = mem.readable_region(&buf) {
-            let nwritten = self.backing_store.issue_write(offset, sz, mapping);
-            match nwritten {
-                Ok(nwritten) => {
-                    assert_eq!(nwritten as usize, sz);
-                    BlockResult::Success
+        let total_size: usize = mappings.iter().map(|x| x.len()).sum();
+
+        let nbytes = {
+            let mut nbytes = 0;
+
+            for mapping in mappings {
+                let inner_nbytes = if is_read {
+                    mapping.pread(
+                        &self.fp,
+                        mapping.len(),
+                        (offset + nbytes) as i64,
+                    )?
+                } else {
+                    mapping.pwrite(
+                        &self.fp,
+                        mapping.len(),
+                        (offset + nbytes) as i64,
+                    )?
+                };
+
+                if inner_nbytes != mapping.len() {
+                    println!(
+                        "{} at offset {} of size {} incomplete! only {} bytes",
+                        if is_read { "read" } else { "write" },
+                        offset + nbytes,
+                        mapping.len(),
+                        inner_nbytes,
+                    );
+                    return Ok(BlockResult::Failure);
                 }
-                Err(_) => {
-                    // TODO: Error reading from guest memory
-                    BlockResult::Failure
-                }
+
+                nbytes += inner_nbytes;
             }
-        } else {
-            // TODO: Error getting readable region
-            BlockResult::Failure
-        }
+
+            nbytes
+        };
+
+        assert_eq!(nbytes as usize, total_size);
+        Ok(BlockResult::Success)
     }
 
-    /// Send flush to BlockReqBackingStore
-    fn process_flush(&self) -> BlockResult {
-        match self.backing_store.issue_flush() {
-            Ok(()) => BlockResult::Success,
-            Err(_) => {
-                // TODO: encapsulated error here from BlockReqBackingStore here?
-                BlockResult::Failure
-            }
+    /// Send flush to the file
+    fn process_flush(&self) -> Result<BlockResult> {
+        let res = unsafe { libc::fdatasync(self.fp.as_raw_fd()) };
+
+        if res == -1 {
+            Err(Error::new(ErrorKind::Other, "file flush failed"))
+        } else {
+            Ok(BlockResult::Success)
         }
     }
 
@@ -337,7 +232,7 @@ impl<R: BlockReq, S: BackingStore> PlainBdev<R, S> {
     }
 }
 
-impl<R: BlockReq, S: BackingStore> BlockDev<R> for PlainBdev<R, S> {
+impl<R: BlockReq> BlockDev<R> for PlainBdev<R> {
     fn enqueue(&self, req: R) {
         self.reqs.lock().unwrap().push_back(req);
         self.cond.notify_all();
@@ -347,7 +242,231 @@ impl<R: BlockReq, S: BackingStore> BlockDev<R> for PlainBdev<R, S> {
         BlockInquiry {
             total_size: self.sectors as u64,
             block_size: self.block_size as u32,
-            writable: !self.backing_store.is_ro(),
+            writable: !self.is_ro,
         }
     }
 }
+
+/*
+#[cfg(test)]
+mod test {
+    use std::collections::VecDeque;
+    use std::fs::File;
+    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::sync::mpsc;
+    use std::thread;
+
+    use tempfile::tempdir;
+
+    use crate::block::{BlockOp, BlockDev, BlockReq, PlainBdev, BlockResult};
+    use crate::vmm::mapping::{GuardSpace, Prot};
+    use crate::common::{GuestAddr, GuestRegion};
+    use crate::{DispCtx, Dispatcher, VcpuHdl};
+
+    pub struct TestBlockReq {
+        op: BlockOp,
+        offset: usize,
+        len: usize,
+        bufs: VecDeque<GuestRegion>,
+        send: mpsc::SyncSender<u64>,
+    }
+
+    impl BlockReq for TestBlockReq {
+        fn oper(&self) -> BlockOp {
+            self.op
+        }
+
+        fn offset(&self) -> usize {
+            self.offset
+        }
+
+        fn next_buf(&mut self) -> Option<GuestRegion> {
+            self.bufs.pop_front()
+        }
+
+        fn complete(self, _res: BlockResult, _ctx: &DispCtx) {
+            self.send.send(0).expect("send failed!");
+        }
+    }
+
+    impl TestBlockReq {
+        fn read(offset: usize, bufs: VecDeque<GuestRegion>) -> (mpsc::Receiver<u64>, TestBlockReq) {
+            let (send, recv) = mpsc::sync_channel(1);
+            (recv, TestBlockReq {
+                op: BlockOp::Read,
+                offset,
+                len: 0,
+                bufs,
+                send,
+            })
+        }
+
+        fn write(offset: usize, bufs: VecDeque<GuestRegion>) -> (mpsc::Receiver<u64>, TestBlockReq) {
+            let (send, recv) = mpsc::sync_channel(1);
+            (recv, TestBlockReq {
+                op: BlockOp::Write,
+                offset,
+                len: 0,
+                bufs,
+                send,
+            })
+        }
+
+        fn flush() -> (mpsc::Receiver<u64>, TestBlockReq) {
+            let (send, recv) = mpsc::sync_channel(1);
+            (recv, TestBlockReq {
+                op: BlockOp::Flush,
+                offset: 0,
+                len: 0,
+                bufs: VecDeque::new(),
+                send,
+            })
+        }
+    }
+
+
+    #[test]
+    fn test_plainbdev() {
+        /*
+         * Test the following:
+         * - seed a 512 byte file with a known pattern
+         * - read that file into four mappings
+         * - verify that the known pattern was read correctly into those four mappings
+         * - write another known pattern into another mapping
+         * - write from that mapping into the file
+         * - verify that the file received the full write
+         */
+        let dir = tempdir().expect("cannot create tempdir!");
+        let file_path = dir.path().join("disk.img");
+
+        let mut file =
+            File::create(file_path.clone()).expect("cannot create tempfile!");
+        file.set_len(512).unwrap();
+
+        let bdev =
+            PlainBdev::create(file_path.clone(), false)
+                .expect("could not create FileBackingStore!");
+
+        let inquiry = bdev.inquire();
+        assert_eq!(512, inquiry.total_size * inquiry.block_size as u64);
+
+        /// XXX: Dispatcher context and `bdev.start_dispatch` required for this to work
+
+        let guard_len = 4096;
+        let mut guard = GuardSpace::new(guard_len).unwrap();
+        let vmm = crate::vmm::mapping::tests::test_vmm(guard_len as u64);
+        let mapping = guard
+            .mapping(guard_len, Prot::READ | Prot::WRITE, &vmm, 0)
+            .unwrap();
+
+        // write into file
+        file.seek(SeekFrom::Start(0)).expect("seek failed!");
+        file.write(&vec![0; 128][..]).expect("write failed!");
+        file.write(&vec![1; 128][..]).expect("write failed!");
+        file.write(&vec![2; 128][..]).expect("write failed!");
+        file.write(&vec![3; 128][..]).expect("write failed!");
+
+        // read into mappings
+        let (read_recv, read_req) = TestBlockReq::read(0, VecDeque::from(vec![
+            GuestRegion(GuestAddr(25), 7),
+            GuestRegion(GuestAddr(75), 256),
+            GuestRegion(GuestAddr(1350), 128),
+            GuestRegion(GuestAddr(2048), 121),
+        ]));
+        bdev.enqueue(read_req);
+        let (flush_recv, flush_req) = TestBlockReq::flush();
+        bdev.enqueue(flush_req);
+
+        let _ = read_recv.recv();
+        let _ = flush_recv.recv();
+
+        // verify mapping[0] only got zeros
+        let mut bytes = vec![100; 7];
+        mapping
+            .as_ref()
+            .subregion(25, 7)
+            .unwrap()
+            .read_bytes(&mut bytes[..])
+            .unwrap();
+        assert_eq!(&bytes, &vec![0u8; 7]);
+
+        // verify mapping[1] got zeros, ones, and twos
+        // 000000011111111111111111111111122222222
+        // ^      ^                       ^      ^
+        // 7      128                     256    263
+        //
+        let mut bytes = vec![100; 256];
+        mapping
+            .as_ref()
+            .subregion(75, 256)
+            .unwrap()
+            .read_bytes(&mut bytes[..])
+            .unwrap();
+
+        let mut expected = vec![0u8; 128 - 7];
+        expected.append(&mut vec![1u8; 128]);
+        expected.append(&mut vec![2u8; 7]);
+        assert_eq!(bytes, expected);
+
+        // verify mapping[2] got twos and threes
+        // 222222222222223333333
+        // ^             ^     ^
+        // 263           384   391
+        let mut bytes = vec![100; 128];
+        mapping
+            .as_ref()
+            .subregion(1350, 128)
+            .unwrap()
+            .read_bytes(&mut bytes[..])
+            .unwrap();
+
+        let mut expected = vec![2u8; 384 - 263];
+        expected.append(&mut vec![3u8; 391 - 384]);
+        assert_eq!(bytes, expected);
+
+        // verify mapping[3] got threes
+        let mut bytes = vec![100; 121];
+        mapping
+            .as_ref()
+            .subregion(2048, 121)
+            .unwrap()
+            .read_bytes(&mut bytes[..])
+            .unwrap();
+
+        let expected = vec![3u8; 121];
+        assert_eq!(bytes, expected);
+
+        // write into file
+
+        let mut bytes = vec![100u8; 512];
+        mapping
+            .as_ref()
+            .subregion(3072, 512)
+            .unwrap()
+            .write_bytes(&mut bytes[..])
+            .unwrap();
+
+        let (write_recv, write_req) = TestBlockReq::write(0, VecDeque::from(vec![
+            GuestRegion(GuestAddr(3072), 512),
+        ]));
+        bdev.enqueue(write_req);
+        let (flush_recv, flush_req) = TestBlockReq::flush();
+        bdev.enqueue(flush_req);
+
+        let _ = write_recv.recv();
+        let _ = flush_recv.recv();
+
+        // verify write to file
+
+        let mut file = File::open(file_path).expect("cannot open tempfile!");
+
+        let mut buffer = vec![0; 512];
+        file.seek(SeekFrom::Start(0)).expect("seek failed!");
+        file.read(&mut buffer[..]).expect("buffer read failed!");
+        assert_eq!(buffer, vec![100u8; 512]);
+
+        drop(file);
+        dir.close().expect("could not close dir!");
+    }
+}
+*/

--- a/propolis/src/block.rs
+++ b/propolis/src/block.rs
@@ -148,16 +148,20 @@ impl<R: BlockReq> PlainBdev<R> {
         mem: &MemCtx,
         bufs: Vec<GuestRegion>,
     ) -> Result<BlockResult> {
-        let mappings: Vec<SubMapping> = bufs
+        let mappings: Option<Vec<SubMapping>> = bufs
             .iter()
             .map(|buf| {
                 if is_read {
-                    mem.writable_region(buf).unwrap()
+                    mem.writable_region(buf)
                 } else {
-                    mem.readable_region(buf).unwrap()
+                    mem.readable_region(buf)
                 }
             })
             .collect();
+
+        let mappings = mappings.ok_or_else(|| {
+            Error::new(ErrorKind::Other, "getting a region failed!")
+        })?;
 
         let total_size: usize = mappings.iter().map(|x| x.len()).sum();
 

--- a/propolis/src/vmm/mapping.rs
+++ b/propolis/src/vmm/mapping.rs
@@ -518,11 +518,11 @@ impl<'a> SubMapping<'a> {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use tempfile::tempfile;
 
-    fn test_vmm(len: u64) -> VmmFile {
+    pub fn test_vmm(len: u64) -> VmmFile {
         let file = tempfile().unwrap();
         file.set_len(len).unwrap();
         unsafe { VmmFile::new(file) }

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -217,7 +217,7 @@ impl<'a> MachineInitializer<'a> {
         bdf: pci::Bdf,
         readonly: bool,
     ) -> Result<(), Error> {
-        let plain = block::PlainBdev::create(path.as_ref(), readonly)?;
+        let plain = block::FileBdev::create(path.as_ref(), readonly)?;
 
         let vioblk = virtio::VirtioBlock::create(
             0x100,

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -217,7 +217,7 @@ impl<'a> MachineInitializer<'a> {
         bdf: pci::Bdf,
         readonly: bool,
     ) -> Result<(), Error> {
-        let plain = block::PlainBdev::from_file(path.as_ref(), readonly)?;
+        let plain = block::PlainBdev::create(path.as_ref(), readonly)?;
 
         let vioblk = virtio::VirtioBlock::create(
             0x100,


### PR DESCRIPTION
Instead of 3 layers:

    - device (virtio, nvme)
    - blockdev (plainbdev)
    - backing store (file, crucible, etc)

Fold into 2 layers:

    - device (virtio, nvme)
    - blockdev (plainbdev)
    
I've also committed a commented out test that would work if there was a mock / test Dispatcher.