### PR TITLE
Use preadv/pwritev to efficiently handle multiple mappings at once.

### DIFF
--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -9,7 +9,9 @@ edition = "2018"
 
 [dependencies]
 #libc = "0.2"
-libc = { git = "https://github.com/rust-lang/libc.git" }
+# TODO: Switch back to "0.2" once a new release is published
+#       See https://github.com/rust-lang/libc/pull/2383
+libc = { git = "https://github.com/rust-lang/libc.git", rev = "796459785" }
 bitflags = "1.2"
 byteorder = "1"
 lazy_static = "1.4"

--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libc = "0.2"
+#libc = "0.2"
+libc = { git = "https://github.com/rust-lang/libc.git" }
 bitflags = "1.2"
 byteorder = "1"
 lazy_static = "1.4"

--- a/scripts/nvme-trace.d
+++ b/scripts/nvme-trace.d
@@ -40,7 +40,7 @@ propolis$target:::nvme_write_complete
     this->cid = args[0];
     this->elapsed = timestamp - io[this->cid].ts;
     this->elapsed_us = this->elapsed / 1000;
-    @time[io[this->cid].op] = quantize(this->elapsed_us);
+    @time[strjoin(io[this->cid].op, " (us)")] = quantize(this->elapsed_us);
     printf("%s(cid=%u) %d blocks from LBA 0x%x in %uus\n",
            io[this->cid].op, this->cid, io[this->cid].nlb, io[this->cid].slba, this->elapsed_us);
 }


### PR DESCRIPTION
Illumos, like linux, has vectored versions of pread/pwrite which we can use here instead of calling pread/pwrite in a loop. Using preadv/pwritev saves us a couple of roundtrips.

In fact, with #39 we can see the improvement in latency just simply booting/shutting down a guest off an file-backed nvme storage:

<details>
 <summary>Before:</summary>

```console
  write (us)                                            
           value  ------------- Distribution ------------- count    
               8 |                                         0        
              16 |@@@@@@@                                  25       
              32 |@@@@@@                                   21       
              64 |@@@@@@@@@@@@@@@@@@@@@@                   73       
             128 |@@@@                                     13       
             256 |@                                        3        
             512 |                                         0        

  read (us)                                            
           value  ------------- Distribution ------------- count    
               4 |                                         0        
               8 |@@@@@                                    197      
              16 |@@@@@@@@@@@                              405      
              32 |@@@@@@@@@@@@@@@@@@@                      713      
              64 |@@                                       96       
             128 |@@                                       77       
             256 |@                                        39       
             512 |                                         11       
            1024 |                                         1        
            2048 |                                         0        
            4096 |                                         2        
            8192 |                                         0
```
</details>

<details>
 <summary>After:</summary>

```console
  write (us)                                            
           value  ------------- Distribution ------------- count    
               8 |                                         0        
              16 |@@@@@@@@@@@@@@@@@@@@@@@@@@               89       
              32 |@@@@@@                                   20       
              64 |@@@@@@@                                  24       
             128 |@                                        3        
             256 |                                         0        

  read (us)                                             
           value  ------------- Distribution ------------- count    
               4 |                                         0        
               8 |@@@@@@@@@@@@@@@                          570      
              16 |@@@@@@@@@@@@@@@@@                        659      
              32 |@@@@@                                    180      
              64 |@@@                                      105      
             128 |                                         19       
             256 |                                         6        
             512 |                                         1        
            1024 |                                         1        
            2048 |                                         0
```
</details>