### PR TITLE
NVMe: Use bitstruct for defining/manipulating controller "registers" and other structures.

### DIFF
--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 #       See https://github.com/rust-lang/libc/pull/2383
 libc = { git = "https://github.com/rust-lang/libc.git", rev = "796459785" }
 bitflags = "1.2"
+bitstruct = "0.1"
 byteorder = "1"
 lazy_static = "1.4"
 num_enum = "0.5"

--- a/propolis/src/hw/nvme/admin.rs
+++ b/propolis/src/hw/nvme/admin.rs
@@ -138,25 +138,12 @@ impl NvmeCtrl {
                 _ => cmds::Completion::generic_err(STS_INVALID_NS),
             },
             IDENT_CNS_CONTROLLER => {
-                let ident = bits::IdentifyController {
-                    vid: self.vendor_id,
-                    ssvid: self.vendor_id,
-                    // TODO: fill out serial number
-                    // TODO: move to const somewhere
-                    ieee: [0xA8, 0x40, 0x25], // Oxide OUI
-                    sqes: size_of::<bits::RawSubmission>() as u8,
-                    cqes: size_of::<bits::RawCompletion>() as u8,
-                    nn: self.num_ns(),
-                    // bit 0 indicates volatile write cache is present
-                    vwc: 1,
-                    ..Default::default()
-                };
                 assert!(size_of::<bits::IdentifyController>() <= PAGE_SIZE);
                 let buf = cmd
                     .data(ctx.mctx.memctx())
                     .next()
                     .expect("missing prp entry for ident response");
-                assert!(ctx.mctx.memctx().write(buf.0, &ident));
+                assert!(ctx.mctx.memctx().write(buf.0, &self.ident));
                 cmds::Completion::success()
             }
             // We currently present NVMe version 1.0 in which CNS is a 1-bit field

--- a/propolis/src/hw/nvme/bits.rs
+++ b/propolis/src/hw/nvme/bits.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 
+use bitstruct::bitstruct;
+
 /// A Submission Queue Entry as represented in memory.
 ///
 /// See NVMe 1.0e Section 4.2 Submission Queue Entry - Command Format
@@ -153,39 +155,315 @@ pub struct RawCompletion {
 
 // Register bits
 
-/// Controller Capabilities - Command Sets Supported (CAP.CSS)
-///
-/// Bit 37 of CAP register which indicates NVM command set support.
-///
-/// See NVMe 1.0e Section 3.1.1 Offset 00h: CAP - Controller Capabilities
-pub const CAP_CCS: u64 = 1 << 37;
+bitstruct! {
+    /// Representation of the Controller Capabilities (CAP) register.
+    ///
+    /// See NVMe 1.0e Section 3.1.1 Offset 00h: CAP - Controller Capabilities
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct Capabilities(pub u64) {
+        /// Maximum Queue Entries Supported (MQES)
+        ///
+        /// The maximum individual queue size that the controller supports.
+        /// This is a 0's based value and the minimum value is 1 (indicating a
+        /// max size of 2).
+        pub mqes: u16 = 0..16;
 
-/// Controller Capabilities - Contiguous Queues Required (CAP.CQR)
-///
-/// Bit 16 of CAP register which indicates that the controller requires
-/// all I/O Submission and Completion Queues to be physically contiguous.
-///
-/// See NVMe 1.0e Section 3.1.1 Offset 00h: CAP - Controller Capabilities
-pub const CAP_CQR: u64 = 1 << 16;
+        /// Contiguous Queues Required  (CQR)
+        ///
+        /// Whether or not the controller requires I/O Completion/Submission
+        /// Queues to be physically contiguous.
+        pub cqr: bool = 16;
 
-/// Controller Configuration - Enable (CC.EN)
-///
-/// Bit 0 of CC register. When set to 1, the the controller should begin
-/// process commands based on Submission Queue Tail doorbell writes.
-/// When cleared to 0, the controller shall not process commands nor post
-/// completion queue entries. Transitioning from 1 to 0 indicates a
-/// (Controller) Reset.
-///
-/// See NVMe 1.0e Section 3.1.5 Offset 14h: CC - Controller Configuration
-pub const CC_EN: u32 = 0x1;
+        /// Arbitration Mechanism Supported (AMS)
+        ///
+        /// Whether or not the controller supports Weighted Round Robin with Urgent.
+        pub ams_roundrobin: bool = 17;
 
-/// Controller Status - Ready (CSTS.RDY)
-///
-/// Bit 0 of CSTS register. Controller sets to 1 when it is ready to accept
-/// Submission Queue Tail doorbell writes after CC.EN is set to 1.
-///
-/// See NVMe 1.0e Section 3.1.6 Offset 14h: CSTS - Controller Status
-pub const CSTS_RDY: u32 = 0x1;
+        /// Arbitration Mechanism Supported (AMS)
+        ///
+        /// Whether or not the controller supports a vendor specific arbitration mechanism.
+        pub ams_vendor: bool = 18;
+
+        /// Reserved
+        reserved1: u8 = 19..24;
+
+        /// Timeout (TO)
+        ///
+        /// The worst case time that host software shall wait for the controller to become ready.
+        /// Specified as TO * 500ms
+        pub to: u8 = 24..32;
+
+        /// Doorbell Stride (DSTRD)
+        ///
+        /// Size between each completion/submission queue doorbell. Specified as 2^(2 + DSTRD) bytes.
+        pub dstrd: u8 = 32..36;
+
+        /// Reserved
+        reserved2: u8 = 36;
+
+        /// Command Sets Supported (CSS)
+        ///
+        /// Whether or not the controller supports NVM I/O command set.
+        pub css_nvm: bool = 37;
+
+        /// Command Sets Supported (CSS)
+        ///
+        /// Reserved bits for indicating other supported I/O command sets.
+        css_reserved: u8 = 38..45;
+
+        /// Reserved
+        reserved3: u8 = 45..48;
+
+        /// Memory Page Size Minimum (MPSMIN)
+        ///
+        /// The minimum host memory page size the controller supports.
+        /// Specified as 2^(12 + MPSMIN) bytes.
+        pub mpsmin: u8 = 48..52;
+
+        /// Memory Page Size Maximum (MPSMAX)
+        ///
+        /// The maximum host memory page size the controller supports.
+        /// Specified as 2^(12 + MPSMAX) bytes.
+        pub mpsmax: u8 = 52..56;
+
+        /// Reserved
+        reserved4: u8 = 56..64;
+    }
+}
+
+bitstruct! {
+    /// Representation of the Controller Configuration (CC) register.
+    ///
+    /// See NVMe 1.0e Section 3.1.5 Offset 14h: CC - Controller Configuration
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct Configuration(pub u32) {
+        /// Enable (EN)
+        ///
+        /// When set to 1, the controller shall begin to process commands based
+        /// on Submission Queue Tail Doorbell writes. When cleared to 0, the
+        /// controller shall not process commands nor post completion queue
+        /// entries. Transitioning from 1 to 0 indicates a Controller Reset.
+        pub enabled: bool = 0;
+
+        /// Reserved
+        reserved1: u8 = 1..4;
+
+        /// I/O Command Set Selected (CSS)
+        ///
+        /// The I/O Command Set selected by the host. Must be a supported
+        /// command set as indicated by CAP.CSS. This field shall only be
+        /// changed when the controller is disabled.
+        pub css: IOCommandSet = 4..7;
+
+        /// Memory Page Size (MPS)
+        ///
+        /// The host memory page size, respecting CAP.MPSMIN/MAX.
+        /// Specified as 2^(12 + MPS) bytes.
+        pub mps: u8 = 7..11;
+
+        /// Arbitration Mechanism Selected (AMS)
+        ///
+        /// The Arbitration Mechanism selected by the host. Must be a supportedd
+        /// mechanism as indicated by CAP.AMS. This field shall only be changed
+        /// when the controller is disabled.
+        pub ams: ArbitrationMechanism = 11..14;
+
+        /// Shutdown Notification (SHN)
+        ///
+        /// Host writes to this field to indicate shutdown processing.
+        pub shn: ShutdownNotification = 14..16;
+
+        /// I/O Submission Queue Entry Size (IOSQES)
+        ///
+        /// Defines the I/O Submission Queue Entry size.
+        /// Specified as 2^IOSQES bytes.
+        pub iosqes: u8 = 16..20;
+
+        /// I/O Completion Queue Entry Size (IOCQES)
+        ///
+        /// Defines the I/O Completion Queue Entry size.
+        /// Specified as 2^IOCQES bytes.
+        pub iocqes: u8 = 20..24;
+
+        /// Reserved
+        reserved2: u8 = 24..32;
+    }
+}
+
+// Selected IO Command Set
+#[derive(Clone, Copy, Debug)]
+pub enum IOCommandSet {
+    Nvm,
+    Reserved(u8),
+}
+
+impl bitstruct::FromRaw<u8, IOCommandSet> for Configuration {
+    fn from_raw(raw: u8) -> IOCommandSet {
+        match raw {
+            0b000 => IOCommandSet::Nvm,
+            0b001..=0b111 => IOCommandSet::Reserved(raw),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl bitstruct::IntoRaw<u8, IOCommandSet> for Configuration {
+    fn into_raw(target: IOCommandSet) -> u8 {
+        match target {
+            IOCommandSet::Nvm => 0b000,
+            IOCommandSet::Reserved(raw) => raw,
+        }
+    }
+}
+
+/// Arbitration Mechanisms
+#[derive(Clone, Copy, Debug)]
+pub enum ArbitrationMechanism {
+    RoundRobin,
+    WeightedRoundRobinWithUrgent,
+    Reserved(u8),
+    Vendor,
+}
+
+impl bitstruct::FromRaw<u8, ArbitrationMechanism> for Configuration {
+    fn from_raw(raw: u8) -> ArbitrationMechanism {
+        match raw {
+            0b000 => ArbitrationMechanism::RoundRobin,
+            0b001 => ArbitrationMechanism::WeightedRoundRobinWithUrgent,
+            0b010..=0b110 => ArbitrationMechanism::Reserved(raw),
+            0b111 => ArbitrationMechanism::Vendor,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl bitstruct::IntoRaw<u8, ArbitrationMechanism> for Configuration {
+    fn into_raw(target: ArbitrationMechanism) -> u8 {
+        match target {
+            ArbitrationMechanism::RoundRobin => 0b000,
+            ArbitrationMechanism::WeightedRoundRobinWithUrgent => 0b001,
+            ArbitrationMechanism::Reserved(raw) => raw,
+            ArbitrationMechanism::Vendor => 0b111,
+        }
+    }
+}
+
+/// Shutdown Notification Values
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ShutdownNotification {
+    None,
+    Normal,
+    Abrupt,
+    Reserved,
+}
+
+impl bitstruct::FromRaw<u8, ShutdownNotification> for Configuration {
+    fn from_raw(raw: u8) -> ShutdownNotification {
+        match raw {
+            0b00 => ShutdownNotification::None,
+            0b01 => ShutdownNotification::Normal,
+            0b10 => ShutdownNotification::Abrupt,
+            0b11 => ShutdownNotification::Reserved,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl bitstruct::IntoRaw<u8, ShutdownNotification> for Configuration {
+    fn into_raw(target: ShutdownNotification) -> u8 {
+        match target {
+            ShutdownNotification::None => 0b00,
+            ShutdownNotification::Normal => 0b01,
+            ShutdownNotification::Abrupt => 0b10,
+            ShutdownNotification::Reserved => 0b11,
+        }
+    }
+}
+
+bitstruct! {
+    /// Representation of the Controller Status (CSTS) register.
+    ///
+    /// See NVMe 1.0e Section 3.1.6 Offset 1Ch: CSTS - Controller Status
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct Status(pub u32) {
+        /// Ready (RDY)
+        ///
+        /// Controller sets this field to 1 to indicate it is ready to accept
+        /// Submission Queue Tail Doorbell writes.
+        pub ready: bool = 0;
+
+        /// Controller Fatal Status (CFS)
+        ///
+        /// Controller sets this field to 1 when a fatal error occurs.
+        pub cfs: bool = 1;
+
+        /// Shutdown Status (SHST)
+        ///
+        /// Indicates the current shutdown processing state.
+        pub shst: ShutdownStatus = 2..4;
+
+        /// Reserved
+        reserved: u32 = 4..32;
+    }
+}
+
+/// Shutdown Status
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ShutdownStatus {
+    Normal,
+    Processing,
+    Complete,
+    Reserved,
+}
+
+impl bitstruct::FromRaw<u8, ShutdownStatus> for Status {
+    fn from_raw(raw: u8) -> ShutdownStatus {
+        match raw {
+            0b00 => ShutdownStatus::Normal,
+            0b01 => ShutdownStatus::Processing,
+            0b10 => ShutdownStatus::Complete,
+            0b11 => ShutdownStatus::Reserved,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl bitstruct::IntoRaw<u8, ShutdownStatus> for Status {
+    fn into_raw(target: ShutdownStatus) -> u8 {
+        match target {
+            ShutdownStatus::Normal => 0b00,
+            ShutdownStatus::Processing => 0b01,
+            ShutdownStatus::Complete => 0b10,
+            ShutdownStatus::Reserved => 0b11,
+        }
+    }
+}
+
+bitstruct! {
+    /// Representation of the Admin Queue Attributes (AQA) register.
+    ///
+    /// See NVMe 1.0e Section 3.1.7 Offset 24h: AQA - Admin Queue Attributes
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct AdminQueueAttrs(pub u32) {
+        /// Admin Submission Queue Size (ASQS)
+        ///
+        /// Defines the size of the Admin Submission Queue as a 0's
+        /// based value.
+        pub asqs: u16 = 0..12;
+
+        /// Reserved
+        reserved1: u8 = 12..16;
+
+        /// Admin Completion Queue Size (ACQS)
+        ///
+        /// Defines the size of the Admin Completion Queue as a 0's
+        /// based value.
+        pub acqs: u16 = 16..28;
+
+        /// Reserved
+        reserved2: u8 = 28..32;
+    }
+}
 
 // Version definitions
 

--- a/propolis/src/hw/nvme/bits.rs
+++ b/propolis/src/hw/nvme/bits.rs
@@ -737,6 +737,26 @@ pub struct PowerStateDescriptor {
     pub _resv: [u8; 16],
 }
 
+bitstruct! {
+    /// Queue Entry Size Required & Maximum (both Completion & Submission)
+    ///
+    /// Defines the required and maximum Queue entry sizes when using the NVM Command Set.
+    #[derive(Copy, Clone)]
+    pub struct NvmQueueEntrySize(pub u8) {
+        /// The required (minimum) Queue Entry Size.
+        ///
+        /// Specified as 2^required bytes. It shall be 6 (64 bytes).
+        pub required: u8 = 0..4;
+
+        /// The maximum Queue Entry Size and is >= the required size.
+        ///
+        /// Specified as 2^required bytes.
+        /// The recommended maximum is 6 (64 bytes) for standad NVM Command Set.
+        /// Controllers with proprietary extensions may support a larger size.
+        pub maximum: u8 = 4..8;
+    }
+}
+
 /// Identify Controller Data Structure
 ///
 /// Describes the characteristics of the controller.
@@ -853,7 +873,7 @@ pub struct IdentifyController {
     /// The recommended maximum SQES is 6 (64 bytes) for standard NVM Command Set.
     /// Controllers with proprietary extensions may support a larger size.
     /// Both the required and maximum SQES values are in bytes and reported as powers of two (2^n).
-    pub sqes: u8,
+    pub sqes: NvmQueueEntrySize,
     /// Completion Queue Entry Size (CQES)
     ///
     /// Defines the required and maximum Completion Queue entry sizes when using the NVM Command Set.
@@ -863,7 +883,7 @@ pub struct IdentifyController {
     /// The recommended maximum CQES is 4 (16 bytes) for standard NVM Command Set.
     /// Controllers with proprietary extensions may support a larger size.
     /// Both the required and maximum CQES values are in bytes and reported as powers of two (2^n).
-    pub cqes: u8,
+    pub cqes: NvmQueueEntrySize,
     /// Reserved - Bytes 515:514
     pub _resv3: [u8; 2],
     /// Number of Namespaces (NN)
@@ -948,8 +968,8 @@ impl Default for IdentifyController {
             elpe: 0,
             npss: 0,
             avscc: 0,
-            sqes: 0,
-            cqes: 0,
+            sqes: NvmQueueEntrySize(0),
+            cqes: NvmQueueEntrySize(0),
             nn: 0,
             oncs: 0,
             fuses: 0,

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::convert::TryInto;
-use std::mem;
+use std::mem::size_of;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::common::*;
@@ -307,10 +307,10 @@ impl PciNvme {
 
         // We have unit tests that these are 16 and 64 bytes, respectively
         // But just make sure as we specify these as powers of 2 in places
-        debug_assert_eq!(mem::size_of::<RawCompletion>().count_ones(), 1);
-        debug_assert_eq!(mem::size_of::<RawSubmission>().count_ones(), 1);
-        let cqes = mem::size_of::<RawCompletion>().trailing_zeros() as u8;
-        let sqes = mem::size_of::<RawSubmission>().trailing_zeros() as u8;
+        debug_assert!(size_of::<RawCompletion>().is_power_of_two());
+        debug_assert!(size_of::<RawSubmission>().is_power_of_two());
+        let cqes = size_of::<RawCompletion>().trailing_zeros() as u8;
+        let sqes = size_of::<RawSubmission>().trailing_zeros() as u8;
 
         // Initialize the Identify structure returned when the host issues
         // an Identify Controller command.

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -195,7 +195,7 @@ impl NvmeCtrl {
         ctx: &DispCtx,
     ) -> Result<(), NvmeError> {
         if (sqid as usize) >= MAX_NUM_QUEUES {
-            return Err(NvmeError::InvalidSubQueue(cqid));
+            return Err(NvmeError::InvalidSubQueue(sqid));
         }
         if (cqid as usize) >= MAX_NUM_QUEUES
             || self.cqs[cqid as usize].is_none()
@@ -203,7 +203,7 @@ impl NvmeCtrl {
             return Err(NvmeError::InvalidCompQueue(cqid));
         }
         if self.sqs[sqid as usize].is_some() {
-            return Err(NvmeError::SubQueueAlreadyExists(cqid));
+            return Err(NvmeError::SubQueueAlreadyExists(sqid));
         }
         let sq = SubQueue::new(sqid, cqid, size, base, ctx)?;
         self.sqs[sqid as usize] = Some(Arc::new(Mutex::new(sq)));

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -424,6 +424,16 @@ impl PciNvme {
             state.reset();
         }
 
+        let shutdown = new.shn() != ShutdownNotification::None;
+        if shutdown && state.ctrl.csts.shst() == ShutdownStatus::Normal {
+            // Host has indicated to shutdown
+            // TODO: Cleanup properly but for now just immediately indicate
+            //       we're done shutting down.
+            state.ctrl.csts.set_shst(ShutdownStatus::Complete);
+        } else if !shutdown && state.ctrl.csts.shst() != ShutdownStatus::Normal {
+            state.ctrl.csts.set_shst(ShutdownStatus::Normal);
+        }
+
         Ok(())
     }
 

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -366,12 +366,7 @@ impl PciNvme {
         let csts = Status(0);
 
         let state = NvmeCtrl {
-            ctrl: CtrlState {
-                cap,
-                cc,
-                csts,
-                ..Default::default()
-            },
+            ctrl: CtrlState { cap, cc, csts, ..Default::default() },
             msix_hdl: None,
             cqs: Default::default(),
             sqs: Default::default(),
@@ -430,7 +425,8 @@ impl PciNvme {
             // TODO: Cleanup properly but for now just immediately indicate
             //       we're done shutting down.
             state.ctrl.csts.set_shst(ShutdownStatus::Complete);
-        } else if !shutdown && state.ctrl.csts.shst() != ShutdownStatus::Normal {
+        } else if !shutdown && state.ctrl.csts.shst() != ShutdownStatus::Normal
+        {
             state.ctrl.csts.set_shst(ShutdownStatus::Normal);
         }
 

--- a/propolis/src/hw/nvme/queue.rs
+++ b/propolis/src/hw/nvme/queue.rs
@@ -228,7 +228,7 @@ pub struct SubQueue {
     id: QueueId,
 
     /// The ID of the corresponding Completion Queue.
-    cqid: u16,
+    cqid: QueueId,
 
     /// Queue state such as the size and current head/tail entry pointers.
     state: QueueState<SubmissionQueueType>,


### PR DESCRIPTION
Pulled in the [`bitstruct`](https://github.com/dancrossnyc/rust-bitstruct) crate to define the controller register structures. Now instead of one-off fields we've added in an ad-hoc way, we can manipulate the corresponding registers in a way that follows directly from the spec. Makes manipulating the parts we need a lot more clear than twiddling the individual bits. Also fixed a few spots where I got it wrong previously.

As a new example, the last commit also adds a first stab at handling shutdown notifications (aka linux won't hang a bit anymore during shutdown as the driver fruitlessly spun waiting for us to say we finished with shutdown processing).

