### PR TITLE
Flatten virtio emulation structure

### DIFF
--- a/propolis/src/hw/virtio/mod.rs
+++ b/propolis/src/hw/virtio/mod.rs
@@ -10,18 +10,27 @@ pub mod viona;
 
 use crate::common::*;
 use crate::dispatch::DispCtx;
-use queue::{VirtQueue, VirtQueues};
+use queue::VirtQueue;
 
-pub use block::VirtioBlock;
+pub use block::PciVirtioBlock;
+pub use viona::PciVirtioViona;
 
-trait VirtioDevice: Send + Sync + 'static + Entity {
-    fn device_cfg_rw(&self, ro: RWOp);
-    fn device_get_features(&self) -> u32;
-    fn device_set_features(&self, feat: u32);
+pub trait VirtioDevice: Send + Sync + 'static + Entity {
+    /// Read/write device-specific virtio configuration space
+    fn cfg_rw(&self, ro: RWOp);
+    /// Get the device-specific virtio feature bits
+    fn get_features(&self) -> u32;
+    /// Set the device-specific virtio feature bits
+    fn set_features(&self, feat: u32);
+    /// Service driver notification for a given virtqueue
     fn queue_notify(&self, vq: &Arc<VirtQueue>, ctx: &DispCtx);
-    fn queues(&self) -> &VirtQueues;
 
     #[allow(unused_variables)]
+    /// Device-wide reset actions during virtio reset
+    fn reset(&self, ctx: &DispCtx) {}
+
+    #[allow(unused_variables)]
+    /// Notification of virtqueue configuration change
     fn queue_change(
         &self,
         vq: &Arc<VirtQueue>,

--- a/propolis/src/hw/virtio/queue.rs
+++ b/propolis/src/hw/virtio/queue.rs
@@ -561,7 +561,7 @@ pub struct MapInfo {
     pub used_addr: u64,
 }
 
-pub(super) struct VirtQueues {
+pub struct VirtQueues {
     queues: Vec<Arc<VirtQueue>>,
     size: NonZeroU16,
     num: NonZeroU16,

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -205,15 +205,14 @@ impl<'a> MachineInitializer<'a> {
         be_register: ChildRegister,
     ) -> Result<(), Error> {
         let be_info = backend.info();
-        let vioblk = virtio::VirtioBlock::create(0x100, be_info);
+        let vioblk = virtio::PciVirtioBlock::new(0x100, be_info);
         let id = self
             .inv
             .register(&vioblk, format!("vioblk-{}", bdf), None)
             .map_err(|e| -> std::io::Error { e.into() })?;
         let _ = self.inv.register_child(be_register, id).unwrap();
 
-        let blk = vioblk.inner_dev::<virtio::block::VirtioBlock>();
-        backend.attach(blk, self.disp);
+        backend.attach(vioblk.clone(), self.disp);
         chipset.device().pci_attach(bdf, vioblk);
 
         Ok(())
@@ -226,7 +225,7 @@ impl<'a> MachineInitializer<'a> {
         bdf: pci::Bdf,
     ) -> Result<(), Error> {
         let hdl = self.machine.get_hdl();
-        let viona = virtio::viona::VirtioViona::create(vnic_name, 0x100, &hdl)?;
+        let viona = virtio::PciVirtioViona::new(vnic_name, 0x100, &hdl)?;
         let _id = self
             .inv
             .register(&viona, format!("viona-{}", bdf), None)

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -212,7 +212,7 @@ fn main() {
                     let (backend, creg) = config.block_dev(block_dev);
 
                     let info = backend.info();
-                    let vioblk = hw::virtio::VirtioBlock::create(0x100, info);
+                    let vioblk = hw::virtio::PciVirtioBlock::new(0x100, info);
                     let id = inv
                         .register(&vioblk, format!("vioblk-{}", name), None)
                         .map_err(|e| -> std::io::Error { e.into() })?;
@@ -220,9 +220,8 @@ fn main() {
                         .register_child(creg, id)
                         .map_err(|e| -> std::io::Error { e.into() })?;
 
-                    let blk =
-                        vioblk.inner_dev::<hw::virtio::block::VirtioBlock>();
-                    backend.attach(blk as Arc<dyn block::Device>, disp);
+                    backend
+                        .attach(vioblk.clone() as Arc<dyn block::Device>, disp);
 
                     chipset.pci_attach(bdf.unwrap(), vioblk);
                 }
@@ -230,10 +229,9 @@ fn main() {
                     let vnic_name =
                         dev.options.get("vnic").unwrap().as_str().unwrap();
 
-                    let viona = hw::virtio::viona::VirtioViona::create(
-                        vnic_name, 0x100, &hdl,
-                    )
-                    .unwrap();
+                    let viona =
+                        hw::virtio::PciVirtioViona::new(vnic_name, 0x100, &hdl)
+                            .unwrap();
                     inv.register(&viona, format!("viona-{}", name), None)
                         .map_err(|e| -> std::io::Error { e.into() })?;
                     chipset.pci_attach(bdf.unwrap(), viona);


### PR DESCRIPTION
This flattens the data structures involved in emulating virtio devices.  The intent is to make migration of state easier by providing access to all data associated with a given device, rather than having it be hidden inside "inner" types.