### PR TITLE
Accept crucible disks in instance ensure request

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -156,6 +156,7 @@ async fn new_instance(
             slot: Slot(disk_i),
             read_only: false,
             key: None,
+            gen: 0,
         });
         disk_i += 1;
     }

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -171,6 +171,7 @@ pub struct DiskRequest {
     pub slot: Slot,
     pub read_only: bool,
     pub key: Option<String>,
+    pub gen: u64,
 }
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -22,8 +22,11 @@ pub struct InstancePathParams {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceEnsureRequest {
     pub properties: InstanceProperties,
+
     #[serde(default)]
     pub nics: Vec<NetworkInterfaceRequest>,
+
+    #[serde(default)]
     pub disks: Vec<DiskRequest>,
 }
 

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -21,6 +21,7 @@ pub struct InstancePathParams {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceEnsureRequest {
     pub properties: InstanceProperties,
+    #[serde(default)]
     pub nics: Vec<NetworkInterfaceRequest>,
 }
 

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -6,6 +6,7 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
 use uuid::Uuid;
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
@@ -23,6 +24,7 @@ pub struct InstanceEnsureRequest {
     pub properties: InstanceProperties,
     #[serde(default)]
     pub nics: Vec<NetworkInterfaceRequest>,
+    pub disks: Vec<DiskRequest>,
 }
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
@@ -161,6 +163,15 @@ pub const DISK_FLAG_WRITE: u32 = 0b0000_0010;
 #[allow(dead_code)]
 pub const DISK_FLAG_READ_WRITE: u32 = DISK_FLAG_READ | DISK_FLAG_WRITE;
 type DiskFlags = u32;
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct DiskRequest {
+    pub name: String,
+    pub address: Vec<SocketAddr>,
+    pub slot: Slot,
+    pub read_only: bool,
+    pub key: Option<String>,
+}
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
 pub struct DiskAttachmentInfo {

--- a/propolis/src/hw/virtio/viona.rs
+++ b/propolis/src/hw/virtio/viona.rs
@@ -10,11 +10,11 @@ use crate::common::*;
 use crate::dispatch::{AsyncCtx, DispCtx};
 use crate::hw::pci;
 use crate::instance;
+use crate::migrate::Migrate;
 use crate::util::regmap::RegMap;
 use crate::util::self_arc::*;
 use crate::util::sys;
 use crate::vmm::VmmHdl;
-use crate::migrate::Migrate;
 
 use super::bits::*;
 use super::pci::{PciVirtio, PciVirtioState};

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -264,10 +264,11 @@ impl<'a> MachineInitializer<'a> {
             addresses,
             disk.read_only,
             disk.key.clone(),
+            Some(disk.gen),
         )?;
 
         info!(self.log, "Creating ChildRegister");
-        let creg = ChildRegister::new(&be, "backend-crucible".to_string());
+        let creg = ChildRegister::new(&be, None);
 
         // TODO: this assumes virtio, what about NVMe?
         info!(self.log, "Calling initialize_virtio_block");

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -19,6 +19,8 @@ use propolis::hw::virtio;
 use propolis::instance::Instance;
 use propolis::inventory::{ChildRegister, EntityID, Inventory};
 use propolis::vmm::{self, Builder, Machine, MachineCtx, Prot};
+use slog::info;
+use std::net::SocketAddr;
 
 use crate::serial::Serial;
 
@@ -95,6 +97,7 @@ impl RegisteredChipset {
 }
 
 pub struct MachineInitializer<'a> {
+    log: slog::Logger,
     machine: &'a Machine,
     mctx: &'a MachineCtx,
     disp: &'a Dispatcher,
@@ -103,12 +106,13 @@ pub struct MachineInitializer<'a> {
 
 impl<'a> MachineInitializer<'a> {
     pub fn new(
+        log: slog::Logger,
         machine: &'a Machine,
         mctx: &'a MachineCtx,
         disp: &'a Dispatcher,
         inv: &'a Inventory,
     ) -> Self {
-        MachineInitializer { machine, mctx, disp, inv }
+        MachineInitializer { log, machine, mctx, disp, inv }
     }
 
     pub fn initialize_rom<P: AsRef<std::path::Path>>(
@@ -232,6 +236,42 @@ impl<'a> MachineInitializer<'a> {
             .map_err(|e| -> std::io::Error { e.into() })?;
         chipset.device().pci_attach(bdf, viona);
         Ok(())
+    }
+
+    pub fn initialize_crucible(
+        &self,
+        chipset: &RegisteredChipset,
+        disk: &propolis_client::api::DiskRequest,
+        bdf: pci::Bdf,
+    ) -> Result<(), Error> {
+        // TODO: This is hacky. Why are we assuming the addresses are v4?
+        let addresses = disk
+            .address
+            .clone()
+            .into_iter()
+            .map(|a| {
+                if let SocketAddr::V4(v4) = a {
+                    v4
+                } else {
+                    panic!("no ipv6, apparently")
+                }
+            })
+            .collect();
+
+        info!(self.log, "Creating Crucible disk from {:#?}", addresses);
+        let be = propolis::block::CrucibleBackend::create(
+            self.disp,
+            addresses,
+            disk.read_only,
+            disk.key.clone(),
+        )?;
+
+        info!(self.log, "Creating ChildRegister");
+        let creg = ChildRegister::new(&be, "backend-crucible".to_string());
+
+        // TODO: this assumes virtio, what about NVMe?
+        info!(self.log, "Calling initialize_virtio_block");
+        self.initialize_virtio_block(chipset, bdf, be, creg)
     }
 
     pub fn initialize_fwcfg(

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -248,7 +248,7 @@ async fn instance_ensure(
     instance
         .initialize(|machine, mctx, disp, inv| {
             let init = MachineInitializer::new(
-                rqctx.log.new(o!()),
+                rqctx.log.clone(),
                 machine,
                 mctx,
                 disp,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -6,6 +6,7 @@ use dropshot::{
     ConfigDropshot, ConfigLogging, ConfigLoggingLevel, HttpServerStarter,
 };
 use propolis::usdt::register_probes;
+use slog::info;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -67,6 +68,7 @@ async fn main() -> anyhow::Result<()> {
             )?;
 
             let context = server::Context::new(config, log.new(slog::o!()));
+            info!(log, "Starting server...");
             let server = HttpServerStarter::new(
                 &config_dropshot,
                 server::api(),


### PR DESCRIPTION
Add disks to the InstanceEnsureRequest, and attach as crucible disks.
Disks that are specified in the server_context.config still get
attached.

Test by running three crucible downstairs and a propolis server, then:

```
./target/release/propolis-cli -s 127.0.0.1 -p 12400 new <your_vm_name> --crucible --crucible-target 127.0.0.1:3801 --crucible-target 127.0.0.1:3802 --crucible-target 127.0.0.1:3803
```

I'll fix the incorrect commit messages when I squash this.