### PR TITLE
Add migration endpoints to propolis-server

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -370,7 +370,7 @@ async fn main() -> anyhow::Result<()> {
                 uuid.unwrap_or_else(Uuid::new_v4),
                 vcpus,
                 memory,
-                disks
+                disks,
             )
             .await?
         }
@@ -383,14 +383,7 @@ async fn main() -> anyhow::Result<()> {
             let dst_addr = SocketAddr::new(dst_server, dst_port);
             let dst_client = Client::new(dst_addr, log.clone());
             let dst_uuid = dst_uuid.unwrap_or_else(Uuid::new_v4);
-            migrate_instance(
-                client,
-                dst_client,
-                name,
-                addr,
-                dst_uuid,
-            )
-            .await?
+            migrate_instance(client, dst_client, name, addr, dst_uuid).await?
         }
     }
 

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -34,7 +34,7 @@ pub struct InstanceEnsureRequest {
 pub struct InstanceEnsureResponse {}
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct InstanceMigrateStartRequest {
+pub struct InstanceMigrateInitiateRequest {
     pub src_addr: String,
     pub src_uuid: Uuid,
 }

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -28,14 +28,18 @@ pub struct InstanceEnsureRequest {
 
     #[serde(default)]
     pub disks: Vec<DiskRequest>,
+
+    pub migrate: Option<InstanceMigrateInitiateRequest>,
 }
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
-pub struct InstanceEnsureResponse {}
+pub struct InstanceEnsureResponse {
+    pub migrate: Option<InstanceMigrateInitiateResponse>,
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceMigrateInitiateRequest {
-    pub src_addr: String,
+    pub src_addr: SocketAddr,
     pub src_uuid: Uuid,
 }
 

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -49,6 +49,28 @@ pub struct InstanceMigrateStartRequest {
     pub migration_id: Uuid,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct InstanceMigrateStatusRequest {
+    pub migration_id: Uuid,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct InstanceMigrateStatusResponse {
+    pub state: MigrationState,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize, JsonSchema)]
+pub enum MigrationState {
+    Sync,
+    Ram,
+    Pause,
+    RamDirty,
+    Device,
+    Arch,
+    Resume,
+    Finish,
+}
+
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceGetResponse {
     pub instance: Instance,

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -40,6 +40,11 @@ pub struct InstanceMigrateInitiateRequest {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct InstanceMigrateInitiateResponse {
+    pub migration_id: Uuid,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceMigrateStartRequest {
     pub migration_id: Uuid,
 }

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -59,7 +59,18 @@ pub struct InstanceMigrateStatusResponse {
     pub state: MigrationState,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize, JsonSchema)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    JsonSchema,
+)]
 pub enum MigrationState {
     Sync,
     Ram,

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -33,6 +33,12 @@ pub struct InstanceEnsureRequest {
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceEnsureResponse {}
 
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct InstanceMigrateStartRequest {
+    pub src_addr: String,
+    pub src_uuid: Uuid,
+}
+
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceGetResponse {
     pub instance: Instance,

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -39,6 +39,11 @@ pub struct InstanceMigrateInitiateRequest {
     pub src_uuid: Uuid,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct InstanceMigrateStartRequest {
+    pub migration_id: Uuid,
+}
+
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceGetResponse {
     pub instance: Instance,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -157,4 +157,25 @@ impl Client {
         let body = Body::from(serde_json::to_string(&state).unwrap());
         self.put_no_response(path, Some(body)).await
     }
+
+    /// Initiate a migration from the specified source instance
+    pub async fn instance_migrate_initiate(
+        &self,
+        id: Uuid,
+        src_uuid: Uuid,
+        src_addr: String,
+    ) -> Result<(), Error> {
+        let path = format!(
+            "http://{}/instances/{}/migrate/initiate",
+            self.address, id
+        );
+        let body = Body::from(
+            serde_json::to_string(&api::InstanceMigrateInitiateRequest {
+                src_addr,
+                src_uuid,
+            })
+            .unwrap(),
+        );
+        self.put_no_response(path, Some(body)).await
+    }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -178,4 +178,21 @@ impl Client {
         );
         self.put(path, Some(body)).await
     }
+
+    /// Get the status of an ongoing migration
+    pub async fn instance_migrate_status(
+        &self,
+        id: Uuid,
+        migration_id: Uuid,
+    ) -> Result<api::InstanceMigrateStatusResponse, Error> {
+        let path =
+            format!("http://{}/instances/{}/migrate/status", self.address, id);
+        let body = Body::from(
+            serde_json::to_string(&api::InstanceMigrateStatusRequest {
+                migration_id,
+            })
+            .unwrap(),
+        );
+        self.get(path, Some(body)).await
+    }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -164,7 +164,7 @@ impl Client {
         id: Uuid,
         src_uuid: Uuid,
         src_addr: String,
-    ) -> Result<(), Error> {
+    ) -> Result<api::InstanceMigrateInitiateResponse, Error> {
         let path = format!(
             "http://{}/instances/{}/migrate/initiate",
             self.address, id
@@ -176,6 +176,6 @@ impl Client {
             })
             .unwrap(),
         );
-        self.put_no_response(path, Some(body)).await
+        self.put(path, Some(body)).await
     }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -158,27 +158,6 @@ impl Client {
         self.put_no_response(path, Some(body)).await
     }
 
-    /// Initiate a migration from the specified source instance
-    pub async fn instance_migrate_initiate(
-        &self,
-        id: Uuid,
-        src_uuid: Uuid,
-        src_addr: String,
-    ) -> Result<api::InstanceMigrateInitiateResponse, Error> {
-        let path = format!(
-            "http://{}/instances/{}/migrate/initiate",
-            self.address, id
-        );
-        let body = Body::from(
-            serde_json::to_string(&api::InstanceMigrateInitiateRequest {
-                src_addr,
-                src_uuid,
-            })
-            .unwrap(),
-        );
-        self.put(path, Some(body)).await
-    }
-
     /// Get the status of an ongoing migration
     pub async fn instance_migrate_status(
         &self,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,6 +18,7 @@ doc = false
 
 [dependencies]
 anyhow = "1.0"
+const_format = "0.2"
 # dropshot = "0.6"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
 futures = "0.3"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,6 +29,7 @@ tokio-tungstenite = "0.14"
 toml = "0.5"
 serde = "1.0"
 serde_derive = "1.0"
+serde_json = "1.0"
 slog = "2.7"
 structopt = { version = "0.3", default-features = false }
 propolis = { path = "../propolis", features = ["crucible"], default-features = false }

--- a/server/src/lib/lib.rs
+++ b/server/src/lib/lib.rs
@@ -2,5 +2,6 @@
 
 pub mod config;
 mod initializer;
+mod migrate;
 mod serial;
 pub mod server;

--- a/server/src/lib/migrate.rs
+++ b/server/src/lib/migrate.rs
@@ -391,7 +391,7 @@ pub async fn dest_initiate(
     let conn = hyper::upgrade::on(res).await?;
 
     let migrate_context = Arc::new(MigrateContext {
-        migration_id: migration_id.clone(),
+        migration_id,
         state: RwLock::new(MigrationState::Sync),
     });
 

--- a/server/src/lib/migrate.rs
+++ b/server/src/lib/migrate.rs
@@ -157,7 +157,7 @@ pub async fn source_start(
 pub async fn dest_initiate(
     rqctx: Arc<RequestContext<Context>>,
     _instance_id: Uuid,
-    migrate_info: api::InstanceMigrateStartRequest,
+    migrate_info: api::InstanceMigrateInitiateRequest,
 ) -> Result<(), MigrateError> {
     // Create a new log context for the migration
     let log = rqctx.log.new(o!(

--- a/server/src/lib/migrate.rs
+++ b/server/src/lib/migrate.rs
@@ -270,6 +270,7 @@ pub async fn source_start(
 }
 
 async fn dest_migrate_task(
+    _rqctx: Arc<RequestContext<Context>>,
     migrate_context: Arc<MigrateContext>,
     mut conn: Upgraded,
     log: slog::Logger,
@@ -401,8 +402,11 @@ pub async fn dest_initiate(
     // We've successfully negotiated a migration protocol w/ the source.
     // Now, we spawn a new task to handle the actual migration over the upgraded socket
     let mctx = migrate_context.clone();
+    let task_rqctx = rqctx.clone();
     let task = tokio::spawn(async move {
-        if let Err(e) = dest_migrate_task(mctx, conn, log.clone()).await {
+        if let Err(e) =
+            dest_migrate_task(task_rqctx, mctx, conn, log.clone()).await
+        {
             error!(log, "Migrate Task Failed: {}", e);
             return;
         }

--- a/server/src/lib/migrate.rs
+++ b/server/src/lib/migrate.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+use dropshot::{HttpError, HttpResponseOk, RequestContext};
+use hyper::{Body, Response};
+use propolis_client::api;
+use slog::{info, o};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::server::Context;
+
+/// Errors which may occur during the course of a migration
+#[derive(Error, Debug)]
+pub enum MigrateError {}
+
+impl Into<HttpError> for MigrateError {
+    fn into(self) -> HttpError {
+        HttpError::for_internal_error(format!("migration failed: {}", self))
+    }
+}
+
+/// Begin the migration process (source-side).
+///
+///This will attempt to upgrade the given HTTP request to a `propolis-migrate`
+/// connection and begin the migration in a separate task.
+pub async fn source_start(
+    rqctx: Arc<RequestContext<Context>>,
+    instance_id: Uuid,
+) -> Result<Response<Body>, HttpError> {
+    todo!()
+}
+
+/// Initiate a migration to the given source instance.
+///
+/// This will attempt to send an HTTP request, along with a request to upgrade
+/// it to a `propolis-migrate` connection, to the given source instance. Once
+/// we've successfully established the connection, we can begin the migration
+/// process (destination-side).
+pub async fn dest_initiate(
+    rqctx: Arc<RequestContext<Context>>,
+    instance_id: Uuid,
+    migrate_info: api::InstanceMigrateStartRequest,
+) -> Result<HttpResponseOk<()>, MigrateError> {
+    // Create a new log context for the migration
+    let log =
+        rqctx.log.new(o!("migrate_src_addr" => migrate_info.src_addr.clone()));
+
+    // TODO: https
+    // TODO: We need to make sure the src_addr is a valid target
+    // TODO: will src_uuid be different than dst_uuid (i.e. instance_id)?
+    let src_migrate_url = format!(
+        "http://{}/instances/{}/migrate/start",
+        migrate_info.src_addr, migrate_info.src_uuid
+    );
+    info!(log, "Begin migration"; "src_migrate_url" => &src_migrate_url);
+
+    todo!()
+}

--- a/server/src/lib/migrate.rs
+++ b/server/src/lib/migrate.rs
@@ -1,17 +1,61 @@
 use std::sync::Arc;
 
 use dropshot::{HttpError, HttpResponseOk, RequestContext};
-use hyper::{Body, Response};
+use hyper::{header, Body, Response, StatusCode};
 use propolis_client::api;
-use slog::{info, o};
+use slog::{error, info, o};
 use thiserror::Error;
 use uuid::Uuid;
 
 use crate::server::Context;
 
+/// Our migration protocol version
+const MIGRATION_PROTOCOL_VERION: usize = 0;
+
+/// Our migration protocol encoding
+const MIGRATION_PROTOCOL_ENCODING: ProtocolEncoding = ProtocolEncoding::Ron;
+
+/// The concatenated migration protocol-encoding-version string
+const MIGRATION_PROTOCOL_STR: &'static str = const_format::concatcp!(
+    "propolis-migrate-",
+    encoding_str(MIGRATION_PROTOCOL_ENCODING),
+    "/",
+    MIGRATION_PROTOCOL_VERION
+);
+
+/// Supported encoding formats
+enum ProtocolEncoding {
+    Ron,
+}
+
+/// Small helper function to stringify ProtocolEncoding
+const fn encoding_str(e: ProtocolEncoding) -> &'static str {
+    match e {
+        ProtocolEncoding::Ron => "ron",
+    }
+}
+
 /// Errors which may occur during the course of a migration
 #[derive(Error, Debug)]
-pub enum MigrateError {}
+pub enum MigrateError {
+    #[error("{0}")]
+    Http(#[from] hyper::Error),
+
+    #[error("couldn't establish migration connection to source instance")]
+    Initiate,
+
+    #[error("the source ({0}) and destination ({1}) instances are incompatible for migration")]
+    Incompatible(String, String),
+}
+
+impl MigrateError {
+    fn incompatible(src_protocol: &str) -> MigrateError {
+        MigrateError::Incompatible(
+            src_protocol.to_string(),
+            MIGRATION_PROTOCOL_STR.to_string(),
+        )
+    }
+}
 
 impl Into<HttpError> for MigrateError {
     fn into(self) -> HttpError {
@@ -54,5 +98,43 @@ pub async fn dest_initiate(
     );
     info!(log, "Begin migration"; "src_migrate_url" => &src_migrate_url);
 
-    todo!()
+    // Build upgrade request to the source instance
+    let req = hyper::Request::builder()
+        .uri(src_migrate_url)
+        .header(header::CONNECTION, "upgrade")
+        // TODO: move to constant
+        .header(header::UPGRADE, MIGRATION_PROTOCOL_STR)
+        .body(Body::empty())
+        .unwrap();
+
+    // Kick off the request
+    let res = hyper::Client::new().request(req).await?;
+    if res.status() != StatusCode::SWITCHING_PROTOCOLS
+    {
+        error!(
+            log,
+            "source instance failed to switch protocols: {}",
+            res.status()
+        );
+        return Err(MigrateError::Initiate);
+    }
+    let src_protocol = res
+        .headers()
+        .get(header::UPGRADE)
+        .and_then(|hv| hv.to_str().ok())
+        .ok_or_else(|| MigrateError::incompatible("<unknown>"))?;
+
+    // TODO: improve "negotiation"
+    if src_protocol != MIGRATION_PROTOCOL_STR {
+        error!(log, "incompatible with source instance provided protocol ({})", src_protocol);
+        return Err(MigrateError::incompatible(src_protocol));
+    }
+
+    // Now co-opt the socket for the migration protocol
+    let conn = hyper::upgrade::on(res).await?;
+
+    // Good to go, ready to migrate from the source via `conn`
+    // TODO: wrap in a tokio codec::Framed or such
+
+    Ok(HttpResponseOk(()))
 }

--- a/server/src/lib/migrate.rs
+++ b/server/src/lib/migrate.rs
@@ -223,7 +223,7 @@ pub async fn source_start(
         return Err(MigrateError::incompatible(src_protocol, dst_protocol));
     }
 
-    let upgrade = hyper::upgrade::on(&mut *request);
+    let upgrade = hyper::upgrade::on(request);
     let instance = context.instance.clone();
 
     let migrate_context = Arc::new(MigrateContext {

--- a/server/src/lib/migrate.rs
+++ b/server/src/lib/migrate.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use dropshot::{HttpError, HttpResponseOk, RequestContext};
-use hyper::{header, Body, Response, StatusCode};
+use hyper::{Body, Method, Response, StatusCode, header};
 use propolis_client::api;
 use slog::{error, info, o};
 use thiserror::Error;
@@ -158,6 +158,7 @@ pub async fn dest_initiate(
     // Build upgrade request to the source instance
     let dst_protocol = MIGRATION_PROTOCOL_STR;
     let req = hyper::Request::builder()
+        .method(Method::PUT)
         .uri(src_migrate_url)
         .header(header::CONNECTION, "upgrade")
         // TODO: move to constant

--- a/server/src/lib/migrate.rs
+++ b/server/src/lib/migrate.rs
@@ -235,6 +235,9 @@ pub async fn source_start(
     // Now, we spawn a new task to handle the actual migration over the upgraded socket
     let mctx = migrate_context.clone();
     let task = tokio::spawn(async move {
+        // We have to await on the HTTP upgrade future in a new
+        // task because it won't complete until the response is
+        // sent, i.e., the outer function returns the 101 Resposne.
         let conn = match upgrade.await {
             Ok(upgraded) => upgraded,
             Err(e) => {

--- a/server/src/lib/migrate.rs
+++ b/server/src/lib/migrate.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use dropshot::{HttpError, HttpResponseOk, RequestContext};
+use dropshot::{HttpError, RequestContext};
 use hyper::{Body, Method, Response, StatusCode, header};
 use propolis_client::api;
 use slog::{error, info, o};
@@ -139,7 +139,7 @@ pub async fn dest_initiate(
     rqctx: Arc<RequestContext<Context>>,
     instance_id: Uuid,
     migrate_info: api::InstanceMigrateStartRequest,
-) -> Result<HttpResponseOk<()>, MigrateError> {
+) -> Result<(), MigrateError> {
     // Create a new log context for the migration
     let log = rqctx.log.new(o!(
         "migrate_role" => "destination",
@@ -199,5 +199,5 @@ pub async fn dest_initiate(
     // Good to go, ready to migrate from the source via `conn`
     // TODO: wrap in a tokio codec::Framed or such
 
-    Ok(HttpResponseOk(()))
+    Ok(())
 }

--- a/server/src/lib/migrate.rs
+++ b/server/src/lib/migrate.rs
@@ -256,7 +256,7 @@ pub async fn dest_initiate(
     rqctx: Arc<RequestContext<Context>>,
     _instance_id: Uuid,
     migrate_info: api::InstanceMigrateInitiateRequest,
-) -> Result<(), MigrateError> {
+) -> Result<api::InstanceMigrateInitiateResponse, MigrateError> {
     // Create a new UUID to refer to this migration across both the source
     // and destination instances
     let migration_id = Uuid::new_v4();
@@ -345,7 +345,8 @@ pub async fn dest_initiate(
     });
 
     // Save active migration task handle
-    *migrate_task = Some(MigrateTask { migration_id, task });
+    *migrate_task =
+        Some(MigrateTask { migration_id: migration_id.clone(), task });
 
-    Ok(())
+    Ok(api::InstanceMigrateInitiateResponse { migration_id })
 }

--- a/server/src/lib/migrate.rs
+++ b/server/src/lib/migrate.rs
@@ -143,11 +143,16 @@ async fn source_migrate_task(
     }
 
     // Random state demonstration
-    migrate_context.set_state(MigrationState::Resume).await;
+    migrate_context.set_state(MigrationState::Arch).await;
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
     for x in 10..20 {
         conn.write_u32(x).await.map_err(|_| MigrateError::Protocol)?;
     }
+
+    // More random state demonstration
+    migrate_context.set_state(MigrationState::Resume).await;
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
     migrate_context.set_state(MigrationState::Finish).await;
 
@@ -277,12 +282,17 @@ async fn dest_migrate_task(
 
     // Random state demonstration
     migrate_context.set_state(MigrationState::Device).await;
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
     for x in 10..20 {
         let read = conn.read_u32().await.map_err(|_| MigrateError::Protocol)?;
         info!(log, "Dest Read: {:?}", read);
         assert_eq!(read, x);
     }
+
+    // More random state demonstration
+    migrate_context.set_state(MigrationState::Resume).await;
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
     migrate_context.set_state(MigrationState::Finish).await;
 

--- a/server/src/lib/migrate.rs
+++ b/server/src/lib/migrate.rs
@@ -79,9 +79,6 @@ pub enum MigrateError {
     #[error("expected connection upgrade")]
     UpgradeExpected,
 
-    #[error("destination instance already initialized")]
-    DestinationAlreadyInitialized,
-
     #[error("source instance is not initialized")]
     SourceNotInitialized,
 
@@ -112,7 +109,6 @@ impl Into<HttpError> for MigrateError {
             MigrateError::Http(_)
             | MigrateError::Initiate
             | MigrateError::Incompatible(_, _)
-            | MigrateError::DestinationAlreadyInitialized
             | MigrateError::SourceNotInitialized => {
                 HttpError::for_internal_error(msg)
             }
@@ -327,11 +323,6 @@ pub async fn dest_initiate(
         "migrate_src_addr" => migrate_info.src_addr.clone()
     ));
     info!(log, "Migration Destination");
-
-    let context = rqctx.context().context.lock().await;
-    if context.is_some() {
-        return Err(MigrateError::DestinationAlreadyInitialized);
-    }
 
     let mut migrate_task = rqctx.context().migrate_task.lock().await;
 

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -921,7 +921,7 @@ async fn instance_migrate_start(
 }]
 async fn instance_migrate_status(
     rqctx: Arc<RequestContext<Context>>,
-    path_params: Path<api::InstancePathParams>,
+    _path_params: Path<api::InstancePathParams>,
     request: TypedBody<api::InstanceMigrateStatusRequest>,
 ) -> Result<HttpResponseOk<api::InstanceMigrateStatusResponse>, HttpError> {
     let migration_id = request.into_inner().migration_id;

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -83,6 +83,7 @@ pub(crate) struct InstanceContext {
     serial: Arc<Serial<LpcUart>>,
     state_watcher: watch::Receiver<StateChange>,
     serial_task: Option<SerialTask>,
+    pub migrate_task: Option<migrate::MigrateSourceTask>,
 }
 
 /// Contextual information accessible from HTTP callbacks.
@@ -472,6 +473,7 @@ async fn instance_ensure(
         serial: Arc::new(com1.unwrap()),
         state_watcher: rx,
         serial_task: None,
+        migrate_task: None,
     });
 
     Ok(HttpResponseCreated(api::InstanceEnsureResponse {}))

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -883,11 +883,13 @@ async fn instance_migrate_initiate(
     rqctx: Arc<RequestContext<Context>>,
     path_params: Path<api::InstancePathParams>,
     request: TypedBody<api::InstanceMigrateStartRequest>,
-) -> Result<HttpResponseOk<()>, HttpError> {
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let instance_id = path_params.into_inner().instance_id;
     migrate::dest_initiate(rqctx, instance_id, request.into_inner())
         .await
-        .map_err(Into::into)
+        .map_err(<_ as Into<HttpError>>::into)?;
+
+    Ok(HttpResponseUpdatedNoContent {})
 }
 
 #[endpoint {

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -889,13 +889,14 @@ async fn instance_migrate_initiate(
     rqctx: Arc<RequestContext<Context>>,
     path_params: Path<api::InstancePathParams>,
     request: TypedBody<api::InstanceMigrateInitiateRequest>,
-) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+) -> Result<HttpResponseOk<api::InstanceMigrateInitiateResponse>, HttpError> {
     let instance_id = path_params.into_inner().instance_id;
-    migrate::dest_initiate(rqctx, instance_id, request.into_inner())
+    let res = migrate::dest_initiate(rqctx, instance_id, request.into_inner())
         .await
         .map_err(<_ as Into<HttpError>>::into)?;
 
-    Ok(HttpResponseUpdatedNoContent {})
+    // TODO: Replace with HTTP Accepted 202
+    Ok(HttpResponseOk(res))
 }
 
 #[endpoint {

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -2,8 +2,9 @@
 
 use anyhow::Result;
 use dropshot::{
-    endpoint, ApiDescription, HttpError, HttpResponseCreated, HttpResponseOk,
-    HttpResponseUpdatedNoContent, Path, RequestContext, TypedBody,
+    endpoint, ApiDescription, HttpError, HttpResponseAccepted,
+    HttpResponseCreated, HttpResponseOk, HttpResponseUpdatedNoContent, Path,
+    RequestContext, TypedBody,
 };
 use futures::future::Fuse;
 use futures::{FutureExt, SinkExt, StreamExt};
@@ -889,14 +890,13 @@ async fn instance_migrate_initiate(
     rqctx: Arc<RequestContext<Context>>,
     path_params: Path<api::InstancePathParams>,
     request: TypedBody<api::InstanceMigrateInitiateRequest>,
-) -> Result<HttpResponseOk<api::InstanceMigrateInitiateResponse>, HttpError> {
+) -> Result<HttpResponseAccepted<api::InstanceMigrateInitiateResponse>, HttpError>
+{
     let instance_id = path_params.into_inner().instance_id;
-    let res = migrate::dest_initiate(rqctx, instance_id, request.into_inner())
+    migrate::dest_initiate(rqctx, instance_id, request.into_inner())
         .await
-        .map_err(<_ as Into<HttpError>>::into)?;
-
-    // TODO: Replace with HTTP Accepted 202
-    Ok(HttpResponseOk(res))
+        .map_err(<_ as Into<HttpError>>::into)
+        .map(HttpResponseAccepted)
 }
 
 #[endpoint {

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -915,6 +915,22 @@ async fn instance_migrate_start(
         .map_err(Into::into)
 }
 
+#[endpoint {
+    method = GET,
+    path = "/instances/{instance_id}/migrate/status"
+}]
+async fn instance_migrate_status(
+    rqctx: Arc<RequestContext<Context>>,
+    path_params: Path<api::InstancePathParams>,
+    request: TypedBody<api::InstanceMigrateStatusRequest>,
+) -> Result<HttpResponseOk<api::InstanceMigrateStatusResponse>, HttpError> {
+    let migration_id = request.into_inner().migration_id;
+    migrate::migrate_status(rqctx, migration_id)
+        .await
+        .map_err(Into::into)
+        .map(HttpResponseOk)
+}
+
 /// Returns a Dropshot [`ApiDescription`] object to launch a server.
 pub fn api() -> ApiDescription<Context> {
     let mut api = ApiDescription::new();
@@ -927,5 +943,6 @@ pub fn api() -> ApiDescription<Context> {
     api.register(instance_serial_detach).unwrap();
     api.register(instance_migrate_initiate).unwrap();
     api.register(instance_migrate_start).unwrap();
+    api.register(instance_migrate_status).unwrap();
     api
 }

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -76,10 +76,10 @@ struct StateChange {
 }
 
 // All context for a single propolis instance.
-struct InstanceContext {
+pub(crate) struct InstanceContext {
     // The instance, which may or may not be instantiated.
     instance: Arc<Instance>,
-    properties: api::InstanceProperties,
+    pub properties: api::InstanceProperties,
     serial: Arc<Serial<LpcUart>>,
     state_watcher: watch::Receiver<StateChange>,
     serial_task: Option<SerialTask>,
@@ -87,7 +87,7 @@ struct InstanceContext {
 
 /// Contextual information accessible from HTTP callbacks.
 pub struct Context {
-    context: Mutex<Option<InstanceContext>>,
+    pub(crate) context: Mutex<Option<InstanceContext>>,
     config: Config,
     log: Logger,
 }

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -901,9 +901,13 @@ async fn instance_migrate_initiate(
 async fn instance_migrate_start(
     rqctx: Arc<RequestContext<Context>>,
     path_params: Path<api::InstancePathParams>,
+    request: TypedBody<api::InstanceMigrateStartRequest>,
 ) -> Result<Response<Body>, HttpError> {
     let instance_id = path_params.into_inner().instance_id;
-    migrate::source_start(rqctx, instance_id).await.map_err(Into::into)
+    let migration_id = request.into_inner().migration_id;
+    migrate::source_start(rqctx, instance_id, migration_id)
+        .await
+        .map_err(Into::into)
 }
 
 /// Returns a Dropshot [`ApiDescription`] object to launch a server.

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -83,12 +83,12 @@ pub(crate) struct InstanceContext {
     serial: Arc<Serial<LpcUart>>,
     state_watcher: watch::Receiver<StateChange>,
     serial_task: Option<SerialTask>,
-    pub migrate_task: Option<migrate::MigrateSourceTask>,
 }
 
 /// Contextual information accessible from HTTP callbacks.
 pub struct Context {
     pub(crate) context: Mutex<Option<InstanceContext>>,
+    pub(crate) migrate_task: Mutex<Option<migrate::MigrateTask>>,
     config: Config,
     log: Logger,
 }
@@ -96,7 +96,12 @@ pub struct Context {
 impl Context {
     /// Creates a new server context object.
     pub fn new(config: Config, log: Logger) -> Self {
-        Context { context: Mutex::new(None), config, log }
+        Context {
+            context: Mutex::new(None),
+            migrate_task: Mutex::new(None),
+            config,
+            log,
+        }
     }
 }
 
@@ -473,7 +478,6 @@ async fn instance_ensure(
         serial: Arc::new(com1.unwrap()),
         state_watcher: rx,
         serial_task: None,
-        migrate_task: None,
     });
 
     Ok(HttpResponseCreated(api::InstanceEnsureResponse {}))

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -78,7 +78,7 @@ struct StateChange {
 // All context for a single propolis instance.
 pub(crate) struct InstanceContext {
     // The instance, which may or may not be instantiated.
-    instance: Arc<Instance>,
+    pub instance: Arc<Instance>,
     pub properties: api::InstanceProperties,
     serial: Arc<Serial<LpcUart>>,
     state_watcher: watch::Receiver<StateChange>,

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -2,9 +2,8 @@
 
 use anyhow::Result;
 use dropshot::{
-    endpoint, ApiDescription, HttpError, HttpResponseAccepted,
-    HttpResponseCreated, HttpResponseOk, HttpResponseUpdatedNoContent, Path,
-    RequestContext, TypedBody,
+    endpoint, ApiDescription, HttpError, HttpResponseCreated, HttpResponseOk,
+    HttpResponseUpdatedNoContent, Path, RequestContext, TypedBody,
 };
 use futures::future::Fuse;
 use futures::{FutureExt, SinkExt, StreamExt};
@@ -81,7 +80,7 @@ pub(crate) struct InstanceContext {
     // The instance, which may or may not be instantiated.
     pub instance: Arc<Instance>,
     pub properties: api::InstanceProperties,
-    serial: Arc<Serial<LpcUart>>,
+    serial: Option<Arc<Serial<LpcUart>>>,
     state_watcher: watch::Receiver<StateChange>,
     serial_task: Option<SerialTask>,
 }
@@ -227,7 +226,9 @@ async fn instance_ensure(
             ));
         }
 
-        return Ok(HttpResponseCreated(api::InstanceEnsureResponse {}));
+        return Ok(HttpResponseCreated(api::InstanceEnsureResponse {
+            migrate: None,
+        }));
     }
 
     const MB: usize = 1024 * 1024;
@@ -253,11 +254,66 @@ async fn instance_ensure(
         HttpError::for_internal_error(format!("Cannot build instance: {}", err))
     })?;
 
+    let (tx, rx) = watch::channel(StateChange {
+        gen: 0,
+        state: propolis::instance::State::Initialize,
+    });
+
+    instance.on_transition(Box::new(move |next_state, _inv, ctx| {
+        match next_state {
+            propolis::instance::State::Boot => {
+                // Set vCPUs to their proper boot (INIT) state
+                for mut vcpu in ctx.mctx.vcpus() {
+                    vcpu.reboot_state().unwrap();
+                    vcpu.activate().unwrap();
+                    // Set BSP to start up
+                    if vcpu.is_bsp() {
+                        vcpu.set_run_state(bhyve_api::VRS_RUN).unwrap();
+                        vcpu.set_reg(
+                            bhyve_api::vm_reg_name::VM_REG_GUEST_RIP,
+                            0xfff0,
+                        )
+                        .unwrap();
+                    }
+                }
+            }
+            _ => {}
+        }
+        let last = (*tx.borrow()).clone();
+        let _ = tx.send(StateChange { gen: last.gen + 1, state: next_state });
+    }));
+
+    // Is this part of a migration?
+    if let Some(migrate_request) = request.migrate {
+        // We stop short of the usual intialization routines because this is
+        // a migrate request and so we should try to establish a connection
+        // with the source instance.
+
+        // Save the created Instance in the server's context as-is.
+        // We'll update it as part of the migration process later.
+        *context = Some(InstanceContext {
+            instance,
+            properties,
+            serial: None,
+            state_watcher: rx,
+            serial_task: None,
+        });
+        drop(context);
+
+        let res = migrate::dest_initiate(rqctx, instance_id, migrate_request)
+            .await
+            .map_err(<_ as Into<HttpError>>::into)?;
+        // TODO: This should be HttpResponseAccepted
+        return Ok(HttpResponseCreated(api::InstanceEnsureResponse {
+            migrate: Some(res),
+        }));
+    }
+
     // Initialize (some) of the instance's hardware.
     //
     // This initialization may be refactored to be client-controlled,
     // but it is currently hard-coded for simplicity.
-    let mut com1: Option<Serial<LpcUart>> = None;
+    let mut com1: Option<Arc<Serial<LpcUart>>> = None;
 
     instance
         .initialize(|machine, mctx, disp, inv| {
@@ -271,7 +327,7 @@ async fn instance_ensure(
             init.initialize_rom(server_context.config.get_bootrom())?;
             init.initialize_kernel_devs(lowmem, highmem)?;
             let chipset = init.initialize_chipset()?;
-            com1 = Some(init.initialize_uart(&chipset)?);
+            com1 = Some(Arc::new(init.initialize_uart(&chipset)?));
             init.initialize_ps2(&chipset)?;
             init.initialize_qemu_debug_port()?;
 
@@ -442,46 +498,18 @@ async fn instance_ensure(
             ))
         })?;
 
-    let (tx, rx) = watch::channel(StateChange {
-        gen: 0,
-        state: propolis::instance::State::Initialize,
-    });
     instance.print();
-
-    instance.on_transition(Box::new(move |next_state, _inv, ctx| {
-        match next_state {
-            propolis::instance::State::Boot => {
-                // Set vCPUs to their proper boot (INIT) state
-                for mut vcpu in ctx.mctx.vcpus() {
-                    vcpu.reboot_state().unwrap();
-                    vcpu.activate().unwrap();
-                    // Set BSP to start up
-                    if vcpu.is_bsp() {
-                        vcpu.set_run_state(bhyve_api::VRS_RUN).unwrap();
-                        vcpu.set_reg(
-                            bhyve_api::vm_reg_name::VM_REG_GUEST_RIP,
-                            0xfff0,
-                        )
-                        .unwrap();
-                    }
-                }
-            }
-            _ => {}
-        }
-        let last = (*tx.borrow()).clone();
-        let _ = tx.send(StateChange { gen: last.gen + 1, state: next_state });
-    }));
 
     // Save the newly created instance in the server's context.
     *context = Some(InstanceContext {
         instance,
         properties,
-        serial: Arc::new(com1.unwrap()),
+        serial: com1,
         state_watcher: rx,
         serial_task: None,
     });
 
-    Ok(HttpResponseCreated(api::InstanceEnsureResponse {}))
+    Ok(HttpResponseCreated(api::InstanceEnsureResponse { migrate: None }))
 }
 
 #[endpoint {
@@ -741,6 +769,16 @@ async fn instance_serial(
         ));
     }
 
+    let serial = context
+        .serial
+        .as_ref()
+        .ok_or_else(|| {
+            HttpError::for_internal_error(
+                "Instance present but serial not initialized".to_string(),
+            )
+        })?
+        .clone();
+
     let request = &mut *rqctx.request.lock().await;
 
     if !request
@@ -799,7 +837,6 @@ async fn instance_serial(
     let (detach_ch, detach_recv) = oneshot::channel();
 
     let upgrade_fut = upgrade::on(request);
-    let serial = context.serial.clone();
     let ws_log = rqctx.log.new(o!());
     let err_log = ws_log.clone();
     let actx = context.instance.disp.async_ctx();
@@ -882,26 +919,14 @@ async fn instance_serial_detach(
     Ok(HttpResponseUpdatedNoContent {})
 }
 
+// This endpoint is meant to only be called during a migration from the destination
+// instance to the source instance as part of the HTTP connection upgrade used to
+// establish the migration link. We don't actually want this exported via OpenAPI
+// clients.
 #[endpoint {
     method = PUT,
-    path = "/instances/{instance_id}/migrate/initiate"
-}]
-async fn instance_migrate_initiate(
-    rqctx: Arc<RequestContext<Context>>,
-    path_params: Path<api::InstancePathParams>,
-    request: TypedBody<api::InstanceMigrateInitiateRequest>,
-) -> Result<HttpResponseAccepted<api::InstanceMigrateInitiateResponse>, HttpError>
-{
-    let instance_id = path_params.into_inner().instance_id;
-    migrate::dest_initiate(rqctx, instance_id, request.into_inner())
-        .await
-        .map_err(<_ as Into<HttpError>>::into)
-        .map(HttpResponseAccepted)
-}
-
-#[endpoint {
-    method = PUT,
-    path = "/instances/{instance_id}/migrate/start"
+    path = "/instances/{instance_id}/migrate/start",
+    unpublished = true,
 }]
 async fn instance_migrate_start(
     rqctx: Arc<RequestContext<Context>>,
@@ -941,7 +966,6 @@ pub fn api() -> ApiDescription<Context> {
     api.register(instance_state_put).unwrap();
     api.register(instance_serial).unwrap();
     api.register(instance_serial_detach).unwrap();
-    api.register(instance_migrate_initiate).unwrap();
     api.register(instance_migrate_start).unwrap();
     api.register(instance_migrate_status).unwrap();
     api

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -798,7 +798,7 @@ async fn instance_serial(
 
     let (detach_ch, detach_recv) = oneshot::channel();
 
-    let upgrade_fut = upgrade::on(&mut *request);
+    let upgrade_fut = upgrade::on(request);
     let serial = context.serial.clone();
     let ws_log = rqctx.log.new(o!());
     let err_log = ws_log.clone();

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -882,7 +882,7 @@ async fn instance_serial_detach(
 async fn instance_migrate_initiate(
     rqctx: Arc<RequestContext<Context>>,
     path_params: Path<api::InstancePathParams>,
-    request: TypedBody<api::InstanceMigrateStartRequest>,
+    request: TypedBody<api::InstanceMigrateInitiateRequest>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let instance_id = path_params.into_inner().instance_id;
     migrate::dest_initiate(rqctx, instance_id, request.into_inner())


### PR DESCRIPTION
This adds the endpoints described in [RFD 71](https://rfd.shared.oxide.computer/rfd/0071) along with a first pass for some of the setup.

**New Endpoints:**
1. `/instances/{src-uuid}/migrate/start` — This is the endpoint called by the new (destination) propolis-server instance when its ready to begin the migration process. This request requires no body as we'll perform an HTTP upgrade to reuse the underlying TCP socket as a bidirectional channel to perform the migration over.
2. `/instances/{src-uuid}/migrate/status` — This endpoint allows querying either the source or destination on the current progress of a migration.

**Modified Endpoints:**
1. `/instances/{dst-uuid}` — This is the existing "ensure" endpoint, which has been extended with an optional blob describing a source VM from which a new VM will be populated.


