### PR TITLE
Read Crucible disks from a JSON file

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,3 +18,5 @@ structopt = "0.3"
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.14"
 uuid = "0.8"
+serde = "1.0"
+serde_json = "1.0"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -147,10 +147,6 @@ async fn new_instance(
         vcpus,
     };
 
-    for disk in &disks {
-        assert_eq!(disk.address.len(), 3);
-    }
-
     let request = InstanceEnsureRequest {
         properties,
         // TODO: Allow specifying NICs

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -185,6 +185,15 @@ async fn instance_ensure(
         ));
     }
 
+    for disk in &disks {
+        if disk.address.len() != 3 {
+            return Err(HttpError::for_bad_request(
+                None,
+                "Crucible requires three targets per disk".to_string(),
+            ));
+        }
+    }
+
     // Handle requsts to an instance that has already been initialized.
     let mut context = server_context.context.lock().await;
     if let Some(ctx) = &*context {


### PR DESCRIPTION
Change the cli so that it reads Crucible disks from a JSON file instead
of trying to construct them out of command line arguments.