### PR TITLE
Arbitrary nvme block sizes + various fixes

### DIFF
--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -27,10 +27,10 @@ slog = "2.7"
 serde = { version = "1" }
 serde_arrays = "0.1"
 erased-serde = "0.3"
+rand = "0.8"
 
 [dev-dependencies]
 crossbeam-channel = "0.5"
-rand = "0.8"
 tempfile = "3.2"
 slog-term = "2.7"
 slog-async = "2.7"

--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -27,13 +27,13 @@ slog = "2.7"
 serde = { version = "1" }
 serde_arrays = "0.1"
 erased-serde = "0.3"
-rand = "0.8"
 
 [dev-dependencies]
 crossbeam-channel = "0.5"
 tempfile = "3.2"
 slog-term = "2.7"
 slog-async = "2.7"
+rand = "0.8"
 
 [features]
 default = ["dtrace-probes"]

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -470,8 +470,7 @@ impl PciNvme {
 
         // Initialize the Identify structure returned when the  host issues
         // an Identify Namespace command.
-        let total_bytes = binfo.total_size * binfo.block_size as u64;
-        let nsze = total_bytes / (binfo.block_size as u64);
+        let nsze = binfo.total_size;
         let mut ns_ident = bits::IdentifyNamespace {
             // No thin provisioning so nsze == ncap == nuse
             nsze,

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -232,11 +232,12 @@ impl<'a> MachineInitializer<'a> {
         &self,
         chipset: &RegisteredChipset,
         bdf: pci::Bdf,
+        name: String,
         backend: Arc<dyn block::Backend>,
         be_register: ChildRegister,
     ) -> Result<(), Error> {
         let be_info = backend.info();
-        let nvme = nvme::PciNvme::create(0x1de, 0x1000, be_info);
+        let nvme = nvme::PciNvme::create(0x1de, 0x1000, name, be_info);
         let id = self.inv.register_instance(&nvme, bdf.to_string())?;
         let _ = self.inv.register_child(be_register, id).unwrap();
 
@@ -298,7 +299,13 @@ impl<'a> MachineInitializer<'a> {
             }
             "nvme" => {
                 info!(self.log, "Calling initialize_nvme_block");
-                self.initialize_nvme_block(chipset, bdf, be, creg)
+                self.initialize_nvme_block(
+                    chipset,
+                    bdf,
+                    disk.name.clone(),
+                    be,
+                    creg,
+                )
             }
             _ => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -391,7 +391,11 @@ async fn instance_ensure(
                             })?;
 
                         init.initialize_nvme_block(
-                            &chipset, bdf, backend, creg,
+                            &chipset,
+                            bdf,
+                            block_dev_name.to_string(),
+                            backend,
+                            creg,
                         )?;
                     }
                     "pci-virtio-viona" => {

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -243,7 +243,12 @@ fn main() {
                     let bdf = bdf.unwrap();
 
                     let info = backend.info();
-                    let nvme = hw::nvme::PciNvme::create(0x1de, 0x1000, info);
+                    let nvme = hw::nvme::PciNvme::create(
+                        0x1de,
+                        0x1000,
+                        block_dev.to_string(),
+                        info,
+                    );
 
                     let id = inv.register_instance(&nvme, bdf.to_string())?;
                     let _be_id = inv.register_child(creg, id)?;


### PR DESCRIPTION
Support arbitrary block sizes in nvme code, otherwise defining a
crucible volume with 4k blocks causes kernel panics.

In the cli, use Ctrl-A to send a raw Ctrl-C, otherwise Ctrl-C kills the
cli.

In nvme, use a random alphanumeric serial number, otherwise Linux kernel
complains that multiple devices share the same (null) serial number.

In server, parse nvme in hardcoded server toml too.

In crucible, log errors if they happen.