### PR TITLE
update for nightly-2021-11-24

### DIFF
--- a/propolis/src/lib.rs
+++ b/propolis/src/lib.rs
@@ -1,6 +1,10 @@
 #![allow(clippy::style)]
-// Pull in asm!() support for USDT
+// Pull in asm!() and asm_sym!() support for USDT
 #![cfg_attr(feature = "dtrace-probes", feature(asm))]
+#![cfg_attr(
+    all(feature = "dtrace-probes", target_os = "macos"),
+    feature(asm_sym)
+)]
 // Pull in `assert_matches` for tests
 #![cfg_attr(test, feature(assert_matches))]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2021-11-24"
 profile = "default"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,5 +1,9 @@
 // Required for USDT
 #![cfg_attr(feature = "dtrace-probes", feature(asm))]
+#![cfg_attr(
+    all(feature = "dtrace-probes", target_os = "macos"),
+    feature(asm_sym)
+)]
 
 use anyhow::anyhow;
 use dropshot::{

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -1,5 +1,9 @@
 // Required for USDT
 #![cfg_attr(feature = "dtrace-probes", feature(asm))]
+#![cfg_attr(
+    all(feature = "dtrace-probes", target_os = "macos"),
+    feature(asm_sym)
+)]
 
 extern crate pico_args;
 extern crate propolis;


### PR DESCRIPTION
We're moving omicron and all dependents past the asm_sym flag day. See https://github.com/oxidecomputer/omicron/pull/448

Note that this will not build on macos until https://github.com/oxidecomputer/crucible/pull/127 has been merged