### PR TITLE
Update crucible interface to support SocketAddr

### DIFF
--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -21,6 +21,9 @@ viona_api = { path = "../viona-api" }
 usdt = { version = "0.2.1", default-features = false }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
+# The crucible branch should be switched back to main when the Crucible PR
+# https://github.com/oxidecomputer/crucible/pull/143 is merged back to
+# crucible main.  This is here now to allow propolis with crucible to build.
 crucible = { git = "https://github.com/oxidecomputer/crucible", branch = "ipv6", optional = true }
 anyhow = "1"
 slog = "2.7"

--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -21,7 +21,7 @@ viona_api = { path = "../viona-api" }
 usdt = { version = "0.2.1", default-features = false }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-crucible = { git = "https://github.com/oxidecomputer/crucible", branch = "main", optional = true }
+crucible = { git = "https://github.com/oxidecomputer/crucible", branch = "ipv6", optional = true }
 anyhow = "1"
 slog = "2.7"
 serde = { version = "1" }

--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -21,10 +21,7 @@ viona_api = { path = "../viona-api" }
 usdt = { version = "0.2.1", default-features = false }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-# The crucible branch should be switched back to main when the Crucible PR
-# https://github.com/oxidecomputer/crucible/pull/143 is merged back to
-# crucible main.  This is here now to allow propolis with crucible to build.
-crucible = { git = "https://github.com/oxidecomputer/crucible", branch = "ipv6", optional = true }
+crucible = { git = "https://github.com/oxidecomputer/crucible", branch = "main", optional = true }
 anyhow = "1"
 slog = "2.7"
 serde = { version = "1" }

--- a/propolis/src/block/crucible.rs
+++ b/propolis/src/block/crucible.rs
@@ -2,7 +2,7 @@
 
 use std::collections::VecDeque;
 use std::io::{Error, ErrorKind, Result};
-use std::net::SocketAddrV4;
+use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Condvar, Mutex};
 
@@ -33,7 +33,7 @@ pub struct CrucibleBackend {
 impl CrucibleBackend {
     pub fn create(
         disp: &Dispatcher,
-        targets: Vec<SocketAddrV4>,
+        targets: Vec<SocketAddr>,
         read_only: bool,
         key: Option<String>,
         gen: Option<u64>,
@@ -44,7 +44,7 @@ impl CrucibleBackend {
 
     fn _create(
         disp: &Dispatcher,
-        targets: Vec<SocketAddrV4>,
+        targets: Vec<SocketAddr>,
         read_only: bool,
         key: Option<String>,
         gen: Option<u64>,

--- a/server/src/lib/config.rs
+++ b/server/src/lib/config.rs
@@ -1,7 +1,7 @@
 //! Describes a server config which may be parsed from a TOML file.
 
 use std::collections::{btree_map, BTreeMap};
-use std::net::SocketAddrV4;
+use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -146,7 +146,7 @@ impl BlockDevice {
                 Ok((be, child))
             }
             "crucible" => {
-                let targets: Vec<SocketAddrV4> = self
+                let targets: Vec<SocketAddr> = self
                     .options
                     .get("targets")
                     .ok_or_else(|| {
@@ -180,7 +180,7 @@ impl BlockDevice {
                                 )
                             })
                     })
-                    .collect::<Result<Vec<SocketAddrV4>, ParseError>>()?;
+                    .collect::<Result<Vec<SocketAddr>, ParseError>>()?;
 
                 let read_only: bool = || -> Option<bool> {
                     self.options.get("readonly")?.as_str()?.parse().ok()

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -19,7 +19,6 @@ use propolis::instance::Instance;
 use propolis::inventory::{ChildRegister, EntityID, Inventory};
 use propolis::vmm::{self, Builder, Machine, MachineCtx, Prot};
 use slog::info;
-use std::net::SocketAddr;
 
 use crate::serial::Serial;
 
@@ -266,19 +265,9 @@ impl<'a> MachineInitializer<'a> {
         disk: &propolis_client::api::DiskRequest,
         bdf: pci::Bdf,
     ) -> Result<(), Error> {
-        // TODO: This is hacky. Why are we assuming the addresses are v4?
         let addresses = disk
             .address
-            .clone()
-            .into_iter()
-            .map(|a| {
-                if let SocketAddr::V4(v4) = a {
-                    v4
-                } else {
-                    panic!("no ipv6, apparently")
-                }
-            })
-            .collect();
+            .clone();
 
         info!(self.log, "Creating Crucible disk from {:#?}", addresses);
         let be = propolis::block::CrucibleBackend::create(

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -265,9 +265,7 @@ impl<'a> MachineInitializer<'a> {
         disk: &propolis_client::api::DiskRequest,
         bdf: pci::Bdf,
     ) -> Result<(), Error> {
-        let addresses = disk
-            .address
-            .clone();
+        let addresses = disk.address.clone();
 
         info!(self.log, "Creating Crucible disk from {:#?}", addresses);
         let be = propolis::block::CrucibleBackend::create(

--- a/standalone/src/config.rs
+++ b/standalone/src/config.rs
@@ -1,5 +1,5 @@
 use std::collections::{btree_map, BTreeMap};
-use std::net::SocketAddrV4;
+use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -104,7 +104,7 @@ impl BlockDevice {
                 (be, creg)
             }
             "crucible" => {
-                let mut targets: Vec<SocketAddrV4> = Vec::new();
+                let mut targets: Vec<SocketAddr> = Vec::new();
 
                 for target in self
                     .options


### PR DESCRIPTION
This allows crucible downstairs targets to have either IPv4 or
IPv6 addresses.

This, once approved, will have to merge when the crucible side PR: 
https://github.com/oxidecomputer/crucible/pull/143 
Is pushed as well, as builds will fail otherwise.
