### PR TITLE
Accept migration UUID as part of API request.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -311,7 +311,11 @@ async fn migrate_instance(
         // TODO: Handle migrating NICs & disks
         nics: vec![],
         disks: vec![],
-        migrate: Some(InstanceMigrateInitiateRequest { src_addr, src_uuid }),
+        migrate: Some(InstanceMigrateInitiateRequest {
+            migration_id: Uuid::new_v4(),
+            src_addr,
+            src_uuid,
+        }),
     };
 
     // Initiate the migration via the destination instance

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -39,6 +39,7 @@ pub struct InstanceEnsureResponse {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceMigrateInitiateRequest {
+    pub migration_id: Uuid,
     pub src_addr: SocketAddr,
     pub src_uuid: Uuid,
 }

--- a/server/src/lib/migrate/mod.rs
+++ b/server/src/lib/migrate/mod.rs
@@ -252,9 +252,7 @@ pub async fn dest_initiate(
     _instance_id: Uuid,
     migrate_info: api::InstanceMigrateInitiateRequest,
 ) -> Result<api::InstanceMigrateInitiateResponse, MigrateError> {
-    // Create a new UUID to refer to this migration across both the source
-    // and destination instances
-    let migration_id = Uuid::new_v4();
+    let migration_id = migrate_info.migration_id;
 
     // Create a new log context for the migration
     let log = rqctx.log.new(o!(


### PR DESCRIPTION
Instead of generating the common migration UUID used across both the source and destination propolis instances, we have the initiator pass it in. This lets us thread the same ID used as part of the nexus migration saga to the destination sled agent and then on to the individual propolis instances. This should allow us to easily correlate migration events and logs across the different moving parts involved.