### PR TITLE
fix break that will be caused by merging #182

### DIFF
--- a/propolis/src/block/crucible.rs
+++ b/propolis/src/block/crucible.rs
@@ -50,8 +50,12 @@ impl CrucibleBackend {
         gen: Option<u64>,
     ) -> anyhow::Result<Arc<Self>, crucible::CrucibleError> {
         // spawn Crucible tasks
-        let opts =
-            crucible::CrucibleOpts { target: targets, lossy: false, key };
+        let opts = crucible::CrucibleOpts {
+            target: targets,
+            lossy: false,
+            key,
+            ..Default::default()
+        };
         let guest = Arc::new(crucible::Guest::new());
 
         let guest_copy = guest.clone();


### PR DESCRIPTION
Crucible PR https://github.com/oxidecomputer/crucible/pull/182 will
break compilation for propolis because new CrucibleOpts fields were
added there. Add the Default line here so that this doesn't happen in
the future, but Default was also derived for CrucibleOpts in that PR.
Unfortunately, these have to go in at the same time.