### PR TITLE
Async access to machine state during migration

### DIFF
--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -126,6 +126,7 @@ pub enum InstanceState {
     Stopping,
     Stopped,
     Rebooting,
+    Migrating,
     Repairing,
     Failed,
     Destroyed,

--- a/propolis/src/dispatch/mod.rs
+++ b/propolis/src/dispatch/mod.rs
@@ -102,6 +102,11 @@ impl Dispatcher {
         self.async_disp.release_contexts();
     }
 
+    /// Release a specific task running in the dispatcher from its quiesce points.
+    pub(crate) fn release_one(&self, id: CtxId) {
+        self.async_disp.release_context(id);
+    }
+
     /// Shutdown the dispatcher.  This will quiesce and stop all managed work
     /// (sync threads and async tasks).  New work cannot be started in the
     /// dispatcher after this point.

--- a/propolis/src/instance.rs
+++ b/propolis/src/instance.rs
@@ -81,6 +81,9 @@ impl State {
             },
             State::Boot => match target {
                 None | Some(State::Run) => State::Run,
+                Some(State::Migrate(MigrateRole::Destination)) => {
+                    State::Migrate(MigrateRole::Destination)
+                }
                 _ => State::Quiesce,
             },
             State::Run => match target {

--- a/propolis/src/instance.rs
+++ b/propolis/src/instance.rs
@@ -93,7 +93,11 @@ impl State {
                 Some(State::Migrate(role)) => State::Migrate(role),
                 _ => State::Quiesce,
             },
-            State::Migrate(role) => State::Migrate(*role),
+            State::Migrate(role) => match target {
+                Some(State::Run) => State::Run,
+                Some(State::Halt) | Some(State::Destroy) => State::Halt,
+                _ => State::Migrate(*role),
+            },
             State::Halt => State::Destroy,
             State::Reset => State::Boot,
             State::Destroy => State::Destroy,

--- a/propolis/src/instance.rs
+++ b/propolis/src/instance.rs
@@ -96,13 +96,7 @@ impl State {
                 Some(State::Migrate(role)) => State::Migrate(role),
                 _ => State::Quiesce,
             },
-            // Once the migration is done, the source machine is destroyed...
-            State::Migrate(MigrateRole::Source) => State::Destroy,
-            // whereas the destination machine is permitted to continue running
-            State::Migrate(MigrateRole::Destination) => match target {
-                None | Some(State::Run) => State::Run,
-                _ => State::Quiesce,
-            },
+            State::Migrate(role) => State::Migrate(*role),
             State::Halt => State::Destroy,
             State::Reset => State::Boot,
             State::Destroy => State::Destroy,

--- a/propolis/src/instance.rs
+++ b/propolis/src/instance.rs
@@ -60,12 +60,6 @@ impl State {
             // Halt can only go to destroy (covered above), nothing else
             (State::Halt, _) => false,
 
-            // A source instance can only be destroyed once the migration
-            // is complete, so disallow any other transition.
-            // TODO: Support rolling back a migration?
-            (State::Migrate(MigrateRole::Source), State::Destroy) => true,
-            (State::Migrate(MigrateRole::Source), _) => false,
-
             // XXX: more exclusions?
             (_, _) => true,
         }

--- a/server/src/lib/migrate/destination.rs
+++ b/server/src/lib/migrate/destination.rs
@@ -20,6 +20,14 @@ pub async fn migrate(
     conn: Upgraded,
     log: slog::Logger,
 ) -> Result<()> {
+    {
+        // TODO: Not exactly the right error
+        let ctx =
+            async_context.dispctx().await.ok_or(MigrateError::SourceNotInitialized)?;
+        let machine = ctx.mctx;
+        let _vmm_hdl = machine.hdl();
+    }
+
     let mut proto = DestinationProtocol {
         migrate_context,
         instance,

--- a/server/src/lib/migrate/destination.rs
+++ b/server/src/lib/migrate/destination.rs
@@ -50,7 +50,9 @@ pub async fn migrate(
 
 struct DestinationProtocol {
     migrate_context: Arc<MigrateContext>,
+    #[allow(dead_code)]
     instance: Arc<Instance>,
+    #[allow(dead_code)]
     async_context: AsyncCtx,
     conn: Framed<Upgraded, codec::LiveMigrationFramer>,
     log: slog::Logger,

--- a/server/src/lib/migrate/destination.rs
+++ b/server/src/lib/migrate/destination.rs
@@ -22,8 +22,10 @@ pub async fn migrate(
 ) -> Result<()> {
     {
         // TODO: Not exactly the right error
-        let ctx =
-            async_context.dispctx().await.ok_or(MigrateError::SourceNotInitialized)?;
+        let ctx = async_context
+            .dispctx()
+            .await
+            .ok_or(MigrateError::InstanceNotInitialized)?;
         let machine = ctx.mctx;
         let _vmm_hdl = machine.hdl();
     }

--- a/server/src/lib/migrate/source.rs
+++ b/server/src/lib/migrate/source.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use hyper::upgrade::Upgraded;
 use propolis::dispatch::AsyncCtx;
-use propolis::instance::Instance;
+use propolis::instance::{Instance, ReqState};
 use slog::info;
 use tokio_util::codec::Framed;
 
@@ -34,7 +34,7 @@ pub async fn migrate(
     proto.arch_state().await?;
     proto.ram_pull().await?;
     proto.finish().await?;
-    proto.end();
+    proto.end()?;
     Ok(())
 }
 
@@ -105,8 +105,10 @@ impl SourceProtocol {
         Ok(())
     }
 
-    fn end(&mut self) {
+    fn end(&mut self) -> Result<()> {
+        self.instance.set_target_state(ReqState::Halt)?;
         info!(self.log, "Source Migration Successful");
+        Ok(())
     }
 
     async fn read_msg(&mut self) -> Result<codec::Message> {

--- a/server/src/lib/migrate/source.rs
+++ b/server/src/lib/migrate/source.rs
@@ -41,6 +41,7 @@ pub async fn migrate(
 struct SourceProtocol {
     migrate_context: Arc<MigrateContext>,
     instance: Arc<Instance>,
+    #[allow(dead_code)]
     async_context: AsyncCtx,
     conn: Framed<Upgraded, codec::LiveMigrationFramer>,
     log: slog::Logger,

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -129,6 +129,7 @@ fn propolis_to_api_state(
         PropolisState::Boot => ApiState::Starting,
         PropolisState::Run => ApiState::Running,
         PropolisState::Quiesce => ApiState::Stopping,
+        PropolisState::Migrate(_) => ApiState::Migrating,
         PropolisState::Halt => ApiState::Stopped,
         PropolisState::Reset => ApiState::Rebooting,
         PropolisState::Destroy => ApiState::Destroyed,


### PR DESCRIPTION
Based atop https://github.com/oxidecomputer/propolis/pull/88. This is a sketch of how to reconcile the async context we're in as part of propolis-server with propolis core.

This adds a new 'Migrating' state as part of the internal propolis state machine [1]. As part of transitioning to that state, we allow specifying a `CtxId` representing an `AsyncCtx` object associated with an async task. This lets us quiesce any other tasks but explicitly allow the migrate task to access the Instance's `DispCtx` to obtain the underlying `MachineCtx` and vmm handles.

There's still a question of how to get access to the inventory.

[1] This will also need corresponding changes in omicron once its propolis dep is updated.