### PR TITLE
Avoid interrupt level assertion on guest reboot

### DIFF
--- a/propolis/src/hw/ps2ctrl.rs
+++ b/propolis/src/hw/ps2ctrl.rs
@@ -284,10 +284,26 @@ impl PS2Ctrl {
                 && state.aux_port.has_output(),
         );
     }
+    fn reset(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.pri_port.reset();
+        state.aux_port.reset();
+        state.resp = None;
+        state.cmd_prefix = None;
+        state.ctrl_cfg = CtrlCfg::default();
+        state.ctrl_out_port = CtrlOutPort::default();
+        for b in state.ram.iter_mut() {
+            *b = 0;
+        }
+        self.update_intr(&mut state);
+    }
 }
 impl Entity for PS2Ctrl {
     fn type_name(&self) -> &'static str {
         "lpc-ps2ctrl"
+    }
+    fn reset(&self, _ctx: &DispCtx) {
+        PS2Ctrl::reset(self);
     }
     fn migrate(&self) -> Option<&dyn Migrate> {
         Some(self)
@@ -652,6 +668,10 @@ impl PS2Mouse {
     fn reset(&mut self) {
         // XXX  what should the defaults be?
         self.buf.clear();
+        self.cur_cmd = None;
+        self.status = PS2MStatus::empty();
+        self.resolution = 0;
+        self.sample_rate = 10;
     }
     fn has_output(&self) -> bool {
         !self.buf.is_empty()

--- a/propolis/src/hw/ps2ctrl.rs
+++ b/propolis/src/hw/ps2ctrl.rs
@@ -492,6 +492,7 @@ impl PS2Kbd {
     }
     fn reset(&mut self) {
         // XXX  what should the defaults be?
+        self.cur_cmd = None;
         self.enabled = true;
         self.led_status = 0;
         self.typematic = 0;

--- a/propolis/src/hw/uart/lpc.rs
+++ b/propolis/src/hw/uart/lpc.rs
@@ -4,7 +4,6 @@ use super::base::Uart;
 use crate::chardev::*;
 use crate::common::*;
 use crate::dispatch::DispCtx;
-use crate::instance;
 use crate::intr_pins::{IntrPin, LegacyPin};
 use crate::migrate::Migrate;
 use crate::pio::{PioBus, PioFn};
@@ -139,15 +138,8 @@ impl Entity for LpcUart {
     fn type_name(&self) -> &'static str {
         "lpc-uart"
     }
-    fn state_transition(
-        &self,
-        next: instance::State,
-        _target: Option<instance::State>,
-        _ctx: &DispCtx,
-    ) {
-        if next == instance::State::Reset {
-            self.reset();
-        }
+    fn reset(&self, _ctx: &DispCtx) {
+        LpcUart::reset(self);
     }
     fn migrate(&self) -> Option<&dyn Migrate> {
         Some(self)

--- a/propolis/src/hw/virtio/viona.rs
+++ b/propolis/src/hw/virtio/viona.rs
@@ -217,6 +217,7 @@ impl Entity for PciVirtioViona {
         &self,
         next: instance::State,
         target: Option<instance::State>,
+        _phase: instance::TransitionPhase,
         ctx: &DispCtx,
     ) {
         match next {

--- a/propolis/src/inventory.rs
+++ b/propolis/src/inventory.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 use thiserror::Error;
 
 use crate::dispatch::DispCtx;
-use crate::instance::State;
+use crate::instance::{State, TransitionPhase};
 use crate::migrate::Migrate;
 
 /// Errors returned while registering or deregistering from [`Inventory`].
@@ -457,12 +457,17 @@ pub trait Entity: Send + Sync + 'static {
         &self,
         next: State,
         target: Option<State>,
+        phase: TransitionPhase,
         ctx: &DispCtx,
     ) {
     }
     /// Function dedicated to `State::Reset` event delivery so implementers do
     /// not need to create a more verbose `state_transition` implementation for
     /// emulating device reset.
+    ///
+    /// This is called as part of `TransitionPhase::Pre`.  Entities which
+    /// require logic in the `Post` phase should do so via the
+    /// `state_transition` hook.
     #[allow(unused_variables)]
     fn reset(&self, ctx: &DispCtx) {}
     #[allow(unused_variables)]


### PR DESCRIPTION
When the in-kernel state is reinitialized during a reboot, all existing interrupt pin level state is discarded (from both the ATPIC and IOAPIC).  This means that any userspace-emulated devices with asserted bits at reinit time will encounter troubling de-asserting them, since the userspace state has become inconsistent with the now-cleared kernel state.  As a fix for now, I'm splitting up the event transitions into `Pre` and `Post` phases, so all of the device emulation can complete its reset before we reinitialize the in-kernel state.  I also noticed that the PS2 controller (which happened to be the device holding an asserted pin over reboot) wasn't wired up for state reset at all.