### PR TITLE
Threading migration through instance state machine.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -318,6 +318,14 @@ async fn migrate_instance(
         }),
     };
 
+    // Get the source instance ready
+    src_client
+        .instance_state_put(src_uuid, InstanceStateRequested::MigrateStart)
+        .await
+        .with_context(|| {
+            anyhow!("failed to place src instance in migrate start state")
+        })?;
+
     // Initiate the migration via the destination instance
     let migration_id = dst_client
         .instance_ensure(&request)

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -115,6 +115,7 @@ pub enum InstanceStateRequested {
     Run,
     Stop,
     Reboot,
+    MigrateStart,
 }
 
 /// Current state of an Instance.

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -893,7 +893,7 @@ impl Migrate for PciNvme {
         Box::new(migrate::PciNvmeStateV1 { pci: self.pci_state.export() })
     }
 
-    fn pause(&self, _ctx: &DispCtx) {
+    fn pause(&self, _ctx: &DispCtx) -> BoxFuture<'static, ()> {
         let mut ctrl = self.state.lock().unwrap();
 
         // Stop responding to any requests
@@ -921,14 +921,6 @@ impl Migrate for PciNvme {
             // there's a permit available.
             notify.notify_one();
         }
-    }
-
-    fn paused(&self) -> BoxFuture<'static, ()> {
-        let ctrl = self.state.lock().unwrap();
-        assert!(ctrl.paused);
-
-        let reqs_notifier = ctrl.reqs_notifier.lock().unwrap();
-        let notify = Arc::clone(reqs_notifier.as_ref().unwrap());
 
         Box::pin(async move { notify.notified().await })
     }

--- a/propolis/src/hw/nvme/queue.rs
+++ b/propolis/src/hw/nvme/queue.rs
@@ -496,9 +496,7 @@ impl CompQueue {
     /// If the value was true, it will also get reset to false.
     pub fn kick(&self) -> bool {
         let mut state = self.state.inner.lock().unwrap();
-        let old_kick = state.kick;
-        state.kick = false;
-        old_kick
+        std::mem::replace(&mut state.kick, false)
     }
 
     /// Returns the number of SQ's associated with this Completion Queue.

--- a/propolis/src/hw/nvme/requests.rs
+++ b/propolis/src/hw/nvme/requests.rs
@@ -226,6 +226,7 @@ fn complete_block_req(
     cqe_permit.push_completion(cid, comp, ctx);
 
     if reqs_outstanding.fetch_sub(1, Ordering::Release) == 1 {
+        std::sync::atomic::fence(Ordering::Acquire);
         if let Some(notifier) = &*reqs_notifier.lock().unwrap() {
             notifier.notify_one();
         }

--- a/propolis/src/instance.rs
+++ b/propolis/src/instance.rs
@@ -166,7 +166,7 @@ struct Inner {
     suspend_info: Option<(SuspendKind, SuspendSource)>,
     drive_thread: Option<JoinHandle<()>>,
     machine: Option<Arc<Machine>>,
-    inv: Inventory,
+    inv: Arc<Inventory>,
     transition_funcs: Vec<Box<TransitionFunc>>,
     migrate_ctx: Option<CtxId>,
 }
@@ -197,7 +197,7 @@ impl Instance {
                 suspend_info: None,
                 drive_thread: None,
                 machine: Some(machine),
-                inv: Inventory::new(),
+                inv: Arc::new(Inventory::new()),
                 transition_funcs: Vec::new(),
                 migrate_ctx: None,
             }),
@@ -579,6 +579,12 @@ impl Instance {
     pub fn print(&self) {
         let state = self.inner.lock().unwrap();
         state.inv.print()
+    }
+
+    /// Return the [`Inventory`] describing the device tree of this Instance.s
+    pub fn inv(&self) -> Arc<Inventory> {
+        let state = self.inner.lock().unwrap();
+        Arc::clone(&state.inv)
     }
 }
 

--- a/propolis/src/instance.rs
+++ b/propolis/src/instance.rs
@@ -328,7 +328,15 @@ impl Instance {
         }
     }
 
+    /// Ask the instance to pause in prepartion for a migration.
     ///
+    /// This will ask the instance to transition to the Migrate Pause
+    /// state. As part of that, we'll walk through the device inventory
+    /// asking each to stop servicing guest requests. The instance will
+    /// wait while the caller has the opportunity to monitor the progress
+    /// of each device. The instance expects the caller to inform when it
+    /// should complete the transition to the Migrate Pause state via the
+    /// passed in Receiver.
     pub fn migrate_pause(
         &self,
         migrate_ctx_id: CtxId,

--- a/propolis/src/instance.rs
+++ b/propolis/src/instance.rs
@@ -3,29 +3,17 @@
 #![allow(unused)]
 
 use std::io;
-use std::sync::{mpsc, Arc, Condvar, Mutex, MutexGuard};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
 
 use crate::dispatch::*;
-use crate::inventory::{self, Entity, Inventory, Order};
+use crate::inventory::{self, Inventory};
 use crate::vcpu::VcpuRunFunc;
 use crate::vmm::*;
 
-use futures::future;
 use slog::{self, Drain};
 use thiserror::Error;
 use tokio::runtime::Handle;
-use tokio::task;
-use tokio::time::timeout;
-
-/// Possible errors during migration
-#[derive(Debug, Error)]
-pub enum MigrateError {
-    /// We failed to pause some devices on the Instance
-    #[error("failed to pause devices on instance")]
-    PauseDevices { failed: Vec<Arc<dyn Entity>> },
-}
 
 /// The role of an instance during a migration.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -42,9 +30,6 @@ pub enum MigratePhase {
 
     /// Wind down the instance and give devices a chance to complete in-flight requests.
     Pause,
-
-    /// We encountered an error during the migration.
-    Error,
 }
 
 /// States of operation for an instance.
@@ -135,9 +120,6 @@ impl State {
             State::Migrate(role, phase) => match target {
                 Some(State::Run) => State::Run,
                 Some(State::Halt) | Some(State::Destroy) => State::Halt,
-                Some(State::Migrate(role, MigratePhase::Error)) => {
-                    State::Migrate(role, MigratePhase::Error)
-                }
                 _ => State::Migrate(*role, *phase),
             },
             State::Halt => State::Destroy,
@@ -200,7 +182,7 @@ struct Inner {
     inv: Arc<Inventory>,
     transition_funcs: Vec<Box<TransitionFunc>>,
     migrate_ctx: Option<CtxId>,
-    migrate_err: Option<MigrateError>,
+    pause_chan: Option<std::sync::mpsc::Receiver<()>>,
 }
 
 /// A single virtual machine.
@@ -232,7 +214,7 @@ impl Instance {
                 inv: Arc::new(Inventory::new()),
                 transition_funcs: Vec::new(),
                 migrate_ctx: None,
-                migrate_err: None,
+                pause_chan: None,
             }),
             cv: Condvar::new(),
             disp,
@@ -346,14 +328,12 @@ impl Instance {
         }
     }
 
-    /// Attempt to pause the instance.
     ///
-    /// This method will block until the state transition is completed,
-    /// we encounter an error or the instance is destroyed.
     pub fn migrate_pause(
         &self,
         migrate_ctx_id: CtxId,
-    ) -> Result<bool, TransitionError> {
+        pause_chan: std::sync::mpsc::Receiver<()>,
+    ) -> Result<(), TransitionError> {
         let mut inner = self.inner.lock().unwrap();
 
         // Make sure the Instance is in the appropriate state
@@ -378,42 +358,12 @@ impl Instance {
         // Stash the migrate context and pause channel so that
         // `drive_state` can access them
         inner.migrate_ctx = Some(migrate_ctx_id);
+        inner.pause_chan = Some(pause_chan);
 
-        // Kick off the state transition.
         self.set_target_state_locked(
             &mut inner,
             State::Migrate(MigrateRole::Source, MigratePhase::Pause),
-        )?;
-
-        // Now wait til we complete the transition, encounter an error
-        // or the instance is destroyed.
-        inner = self
-            .cv
-            .wait_while(inner, |state| match state.state_current {
-                State::Destroy
-                | State::Migrate(
-                    MigrateRole::Source,
-                    MigratePhase::Pause | MigratePhase::Error,
-                ) => false,
-                _ => true,
-            })
-            .unwrap();
-
-        match inner.state_current {
-            State::Migrate(MigrateRole::Source, MigratePhase::Pause) => {
-                Ok(true)
-            }
-            State::Migrate(_, MigratePhase::Error) | State::Destroy => {
-                Ok(false)
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    /// Returns the last encountered Migration error, if any.
-    pub fn migrate_error(&self) -> Option<MigrateError> {
-        let mut inner = self.inner.lock().unwrap();
-        inner.migrate_err.take()
+        )
     }
 
     pub(crate) fn trigger_suspend(
@@ -515,7 +465,7 @@ impl Instance {
     ) {
         self.disp.with_ctx(|ctx| {
             // Allow any entity to act on the new state
-            inner.inv.for_each_node(Order::Pre, |_id, rec| {
+            inner.inv.for_each_node(inventory::Order::Pre, |_id, rec| {
                 let ent = rec.entity();
 
                 // Entities using the `reset` shortcut will be notified of the
@@ -524,6 +474,17 @@ impl Instance {
                 // reinitialized.
                 if state == State::Reset && phase == TransitionPhase::Pre {
                     ent.reset(ctx);
+                }
+
+                // Inform each entity to stop servicing the guest and
+                // complete or cancel any outstanding requests.
+                if state
+                    == State::Migrate(MigrateRole::Source, MigratePhase::Pause)
+                    && phase == TransitionPhase::Pre
+                {
+                    if let Some(migrate) = ent.migrate() {
+                        migrate.pause(ctx);
+                    }
                 }
 
                 ent.state_transition(state, target, phase, ctx);
@@ -608,77 +569,15 @@ impl Instance {
                     inner.suspend_info = None;
                 }
                 State::Migrate(MigrateRole::Source, MigratePhase::Pause) => {
-                    // Ask each device to pause and collect the resulting
-                    // futures together
-                    let mut pause_futs = vec![];
-                    inner.inv.for_each_node(Order::Pre, |_id, rec| {
-                        let log = self
-                            .disp
-                            .logger()
-                            .new(slog::o!("device" => rec.name().to_owned()));
-                        let ent = rec.entity();
-                        if let Some(migrate) = ent.migrate() {
-                            self.disp.with_ctx(|ctx| {
-                                let ent = Arc::clone(&ent);
-                                let pause = migrate.pause(ctx);
-                                // Wrap the future in a timeout so that we aren't waiting
-                                // indefinitely for a device.
-                                let pause = async move {
-                                    // TODO: want to do better than a hardcoded timeout
-                                    let to = Duration::from_secs(2);
-                                    if let Err(_) = timeout(to, pause).await {
-                                        slog::error!(
-                                            log,
-                                            "Timed out pausing device"
-                                        );
-                                        return Err(ent);
-                                    }
-                                    slog::info!(log, "Paused device");
-                                    Ok(())
-                                };
-                                pause_futs.push(task::spawn(pause));
-                            });
-                        } else {
-                            slog::warn!(log, "No migrate handler");
-                        }
-                    });
-
-                    // Spawn a separate task to join and await all the devices
-                    // that will inform us when done via a channel
-                    let (pause_done_tx, pause_done_rx) = mpsc::channel();
-                    task::spawn(async move {
-                        let res = future::join_all(pause_futs).await;
-                        pause_done_tx.send(res);
-                    });
-
-                    // Now, just wait for the devices to finish pausing (or error)
-                    let res =
-                        pause_done_rx.recv().expect("migrate pause channel");
-
-                    // Collect any errors together
-                    let pause_failed = res
-                        .into_iter()
-                        // Hoist out any JoinError
-                        .collect::<Result<Vec<_>, _>>()
-                        .expect("device pause join task")
-                        .into_iter()
-                        .filter(Result::is_err)
-                        .map(Result::unwrap_err)
-                        .collect::<Vec<_>>();
-
-                    if !pause_failed.is_empty() {
-                        // Pausing some of the devices failed,
-                        // let's stash the error and indicate we've failed.
-                        assert!(inner.migrate_err.is_none());
-                        inner.migrate_err = Some(MigrateError::PauseDevices {
-                            failed: pause_failed,
-                        });
-
-                        inner.state_target = Some(State::Migrate(
-                            MigrateRole::Source,
-                            MigratePhase::Error,
-                        ));
-                    }
+                    // Give an opportunity to migration requestor to take
+                    // action before quiescing the instance.
+                    // Drop the `inner` lock so that it may access instance
+                    // in the meanwhile.
+                    let pause_chan =
+                        inner.pause_chan.take().expect("migrate pause channel");
+                    drop(inner);
+                    pause_chan.recv().expect("migrate pause recv");
+                    inner = self.inner.lock().unwrap();
                 }
                 _ => {}
             }
@@ -740,7 +639,7 @@ impl Instance {
         state.inv.print()
     }
 
-    /// Return the [`Inventory`] describing the device tree of this Instance.
+    /// Return the [`Inventory`] describing the device tree of this Instance.s
     pub fn inv(&self) -> Arc<Inventory> {
         let state = self.inner.lock().unwrap();
         Arc::clone(&state.inv)

--- a/propolis/src/inventory.rs
+++ b/propolis/src/inventory.rs
@@ -474,6 +474,7 @@ pub trait Entity: Send + Sync + 'static {
     fn child_register(&self) -> Option<Vec<ChildRegister>> {
         None
     }
+
     fn migrate(&self) -> Option<&dyn Migrate> {
         None
     }

--- a/propolis/src/inventory.rs
+++ b/propolis/src/inventory.rs
@@ -480,6 +480,12 @@ pub trait Entity: Send + Sync + 'static {
     }
 }
 
+impl std::fmt::Debug for dyn Entity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Entity ({})", self.type_name())
+    }
+}
+
 pub struct ChildRegister {
     ent: Arc<dyn Entity>,
     ent_any: Arc<dyn Any + Send + Sync + 'static>,

--- a/propolis/src/migrate.rs
+++ b/propolis/src/migrate.rs
@@ -10,12 +10,9 @@ pub trait Migrate: Send + Sync + 'static {
     /// guest and attempt to cancel or complete any pending operations.
     ///
     /// The device isn't necessarily expected to complete the pause
-    /// operation within this call but should instead return a future
-    /// indicating such via the `paused` method.
-    fn pause(&self, _ctx: &DispCtx) {}
-
-    /// Return a future indicating when the device has finished pausing.
-    fn paused(&self) -> BoxFuture<'static, ()> {
+    /// operation within this call but must instead return a future
+    /// indicating when the operation is complete.
+    fn pause(&self, _ctx: &DispCtx) -> BoxFuture<'static, ()> {
         Box::pin(future::ready(()))
     }
 }

--- a/propolis/src/migrate.rs
+++ b/propolis/src/migrate.rs
@@ -10,7 +10,7 @@ pub trait Migrate: Send + Sync + 'static {
     /// requests. The returned future should become ready
     /// once the device has stopped servicing the guest and
     /// any pending operations have been completed or cancelled.
-    fn pause(&self, _ctx: &DispCtx) -> BoxFuture<()> {
+    fn pause(&self, _ctx: &DispCtx) -> BoxFuture<'static, ()> {
         Box::pin(future::ready(()))
     }
 }

--- a/propolis/src/migrate.rs
+++ b/propolis/src/migrate.rs
@@ -1,7 +1,16 @@
 use crate::dispatch::DispCtx;
 
 use erased_serde::Serialize;
+use futures::future::{self, BoxFuture};
 
 pub trait Migrate: Send + Sync + 'static {
     fn export(&self, ctx: &DispCtx) -> Box<dyn Serialize>;
+
+    /// Called when the device should stop servicing any guest
+    /// requests. The returned future should become ready
+    /// once the device has stopped servicing the guest and
+    /// any pending operations have been completed or cancelled.
+    fn pause(&self, _ctx: &DispCtx) -> BoxFuture<()> {
+        Box::pin(future::ready(()))
+    }
 }

--- a/propolis/src/migrate.rs
+++ b/propolis/src/migrate.rs
@@ -6,11 +6,16 @@ use futures::future::{self, BoxFuture};
 pub trait Migrate: Send + Sync + 'static {
     fn export(&self, ctx: &DispCtx) -> Box<dyn Serialize>;
 
-    /// Called when the device should stop servicing any guest
-    /// requests. The returned future should become ready
-    /// once the device has stopped servicing the guest and
-    /// any pending operations have been completed or cancelled.
-    fn pause(&self, _ctx: &DispCtx) -> BoxFuture<'static, ()> {
+    /// Called to indicate the device should stop servicing the
+    /// guest and attempt to cancel or complete any pending operations.
+    ///
+    /// The device isn't necessarily expected to complete the pause
+    /// operation within this call but should instead return a future
+    /// indicating such via the `paused` method.
+    fn pause(&self, _ctx: &DispCtx) {}
+
+    /// Return a future indicating when the device has finished pausing.
+    fn paused(&self) -> BoxFuture<'static, ()> {
         Box::pin(future::ready(()))
     }
 }

--- a/propolis/src/migrate.rs
+++ b/propolis/src/migrate.rs
@@ -10,9 +10,12 @@ pub trait Migrate: Send + Sync + 'static {
     /// guest and attempt to cancel or complete any pending operations.
     ///
     /// The device isn't necessarily expected to complete the pause
-    /// operation within this call but must instead return a future
-    /// indicating when the operation is complete.
-    fn pause(&self, _ctx: &DispCtx) -> BoxFuture<'static, ()> {
+    /// operation within this call but should instead return a future
+    /// indicating such via the `paused` method.
+    fn pause(&self, _ctx: &DispCtx) {}
+
+    /// Return a future indicating when the device has finished pausing.
+    fn paused(&self) -> BoxFuture<'static, ()> {
         Box::pin(future::ready(()))
     }
 }

--- a/server/src/lib/migrate/destination.rs
+++ b/server/src/lib/migrate/destination.rs
@@ -4,14 +4,12 @@ use std::sync::Arc;
 use hyper::upgrade::Upgraded;
 use propolis::dispatch::AsyncCtx;
 use propolis::instance::Instance;
-use slog::info;
+use slog::{error, info};
 use tokio_util::codec::Framed;
 
 use crate::migrate::codec;
 use crate::migrate::preamble::Preamble;
 use crate::migrate::{MigrateContext, MigrateError, MigrationState};
-
-type Result<T> = anyhow::Result<T, MigrateError>;
 
 pub async fn migrate(
     migrate_context: Arc<MigrateContext>,
@@ -19,7 +17,7 @@ pub async fn migrate(
     async_context: AsyncCtx,
     conn: Upgraded,
     log: slog::Logger,
-) -> Result<()> {
+) -> Result<(), MigrateError> {
     {
         // TODO: Not exactly the right error
         let ctx = async_context
@@ -34,7 +32,10 @@ pub async fn migrate(
         migrate_context,
         instance,
         async_context,
-        conn: Framed::new(conn, codec::LiveMigrationFramer::new()),
+        conn: Framed::new(
+            conn,
+            codec::LiveMigrationFramer::new(log.new(slog::o!())),
+        ),
         log,
     };
     proto.start();
@@ -63,23 +64,33 @@ impl DestinationProtocol {
         info!(self.log, "Entering Destination Migration Task");
     }
 
-    async fn sync(&mut self) -> Result<()> {
+    async fn sync(&mut self) -> Result<(), MigrateError> {
         self.migrate_context.set_state(MigrationState::Sync).await;
         let preamble: Preamble = match self.read_msg().await? {
             codec::Message::Serialized(s) => {
-                ron::de::from_str(&s).map_err(|_| MigrateError::Encoding)
+                ron::de::from_str(&s).map_err(codec::ProtocolError::from)?
             }
-            _ => Err(MigrateError::Protocol),
+            msg => {
+                error!(
+                    self.log,
+                    "expected serialized preamble but received: {msg:?}"
+                );
+                Err(MigrateError::UnexpectedMessage)
+            }
         }?;
         info!(self.log, "Src read Preamble: {:?}", preamble);
         // XXX: For demonstration purposes only.
         if preamble.vm_descr.vcpus != vec![0u32, 1, 2, 3] {
-            return Err(MigrateError::Protocol);
+            error!(
+                self.log,
+                "invalid CPU count in preamble ({:?})", preamble.vm_descr.vcpus
+            );
+            return Err(MigrateError::InvalidInstanceState);
         }
         self.send_msg(codec::Message::Okay).await
     }
 
-    async fn ram_push(&mut self) -> Result<()> {
+    async fn ram_push(&mut self) -> Result<(), MigrateError> {
         self.migrate_context.set_state(MigrationState::RamPush).await;
         self.send_msg(codec::Message::MemQuery(0, !0)).await?;
         // TODO(cross): Implement the rest of the RAM transfer protocol here. :-)
@@ -88,19 +99,19 @@ impl DestinationProtocol {
         self.send_msg(codec::Message::MemDone).await
     }
 
-    async fn device_state(&mut self) -> Result<()> {
+    async fn device_state(&mut self) -> Result<(), MigrateError> {
         self.migrate_context.set_state(MigrationState::Device).await;
         self.send_msg(codec::Message::Okay).await?;
         self.read_ok().await
     }
 
-    async fn arch_state(&mut self) -> Result<()> {
+    async fn arch_state(&mut self) -> Result<(), MigrateError> {
         self.migrate_context.set_state(MigrationState::Arch).await;
         self.send_msg(codec::Message::Okay).await?;
         self.read_ok().await
     }
 
-    async fn ram_pull(&mut self) -> Result<()> {
+    async fn ram_pull(&mut self) -> Result<(), MigrateError> {
         self.migrate_context.set_state(MigrationState::RamPull).await;
         self.send_msg(codec::Message::MemQuery(0, !0)).await?;
         let m = self.read_msg().await?;
@@ -108,7 +119,7 @@ impl DestinationProtocol {
         self.send_msg(codec::Message::MemDone).await
     }
 
-    async fn finish(&mut self) -> Result<()> {
+    async fn finish(&mut self) -> Result<(), MigrateError> {
         self.migrate_context.set_state(MigrationState::Finish).await;
         self.send_msg(codec::Message::Okay).await?;
         let _ = self.read_ok().await; // A failure here is ok.
@@ -119,18 +130,24 @@ impl DestinationProtocol {
         info!(self.log, "Destination Migration Successful");
     }
 
-    async fn read_msg(&mut self) -> Result<codec::Message> {
-        self.conn.next().await.unwrap().map_err(|_| MigrateError::Protocol)
+    async fn read_msg(&mut self) -> Result<codec::Message, MigrateError> {
+        Ok(self.conn.next().await.unwrap()?)
     }
 
-    async fn read_ok(&mut self) -> Result<()> {
+    async fn read_ok(&mut self) -> Result<(), MigrateError> {
         match self.read_msg().await? {
             codec::Message::Okay => Ok(()),
-            _ => Err(MigrateError::Protocol),
+            msg => {
+                error!(self.log, "expected `Okay` but received: {msg:?}");
+                Err(MigrateError::UnexpectedMessage)
+            }
         }
     }
 
-    async fn send_msg(&mut self, m: codec::Message) -> Result<()> {
-        self.conn.send(m).await.map_err(|_| MigrateError::Protocol)
+    async fn send_msg(
+        &mut self,
+        m: codec::Message,
+    ) -> Result<(), MigrateError> {
+        Ok(self.conn.send(m).await?)
     }
 }

--- a/server/src/lib/migrate/destination.rs
+++ b/server/src/lib/migrate/destination.rs
@@ -47,7 +47,7 @@ impl DestinationProtocol {
         self.migrate_context.set_state(MigrationState::Sync).await;
         let preamble: Preamble = match self.read_msg().await? {
             codec::Message::Serialized(s) => {
-                ron::de::from_str(&s).map_err(codec::ProtocolError::from)?
+                Ok(ron::de::from_str(&s).map_err(codec::ProtocolError::from)?)
             }
             msg => {
                 error!(

--- a/server/src/lib/migrate/mod.rs
+++ b/server/src/lib/migrate/mod.rs
@@ -143,6 +143,10 @@ pub enum MigrateError {
     /// Received a message out of order
     #[error("received unexpected migration message")]
     UnexpectedMessage,
+
+    /// Failed to pause the source instance's devices or tasks
+    #[error("failed to pause source instance")]
+    SourcePause,
 }
 
 impl MigrateError {
@@ -186,9 +190,8 @@ impl Into<HttpError> for MigrateError {
             | MigrateError::InstanceNotInitialized
             | MigrateError::InvalidInstanceState
             | MigrateError::Codec(_)
-            | MigrateError::UnexpectedMessage => {
-                HttpError::for_internal_error(msg)
-            }
+            | MigrateError::UnexpectedMessage
+            | MigrateError::SourcePause => HttpError::for_internal_error(msg),
             MigrateError::MigrationAlreadyInProgress
             | MigrateError::NoMigrationInProgress
             | MigrateError::UuidMismatch

--- a/server/src/lib/migrate/mod.rs
+++ b/server/src/lib/migrate/mod.rs
@@ -102,6 +102,9 @@ pub enum MigrateError {
 
     #[error("encountered invalid instance state")]
     InvalidInstanceState,
+
+    #[error("failed to pause devices")]
+    PauseDevices,
 }
 
 impl From<hyper::Error> for MigrateError {
@@ -137,9 +140,8 @@ impl Into<HttpError> for MigrateError {
             | MigrateError::Initiate
             | MigrateError::Incompatible(_, _)
             | MigrateError::InstanceNotInitialized
-            | MigrateError::InvalidInstanceState => {
-                HttpError::for_internal_error(msg)
-            }
+            | MigrateError::InvalidInstanceState
+            | MigrateError::PauseDevices => HttpError::for_internal_error(msg),
             MigrateError::MigrationAlreadyInProgress
             | MigrateError::NoMigrationInProgress
             | MigrateError::Protocol

--- a/server/src/lib/migrate/mod.rs
+++ b/server/src/lib/migrate/mod.rs
@@ -232,15 +232,10 @@ pub async fn source_start(
 
     // The migration task needs an async descriptor context.
     let async_ctx = instance.disp.async_ctx();
-    let migrate_ctx_id = async_ctx.context_id();
 
     // We've successfully negotiated a migration protocol w/ the destination.
     // Now, we spawn a new task to handle the actual migration over the upgraded socket
     let mctx = migrate_context.clone();
-
-    // Request instance to enter 'migrating' state
-    // and allow our migrate task access to the DispCtx & Machine
-    instance.begin_migrate(MigrateRole::Source, migrate_ctx_id)?;
 
     let task = tokio::spawn(async move {
         // We have to await on the HTTP upgrade future in a new
@@ -379,11 +374,6 @@ pub async fn dest_initiate(
 
     // The migration task needs an async descriptor context.
     let async_context = instance.disp.async_ctx();
-    let migrate_ctx_id = async_context.context_id();
-
-    // Request instance to enter 'migrating' state
-    // and allow our migrate task access to the DispCtx & Machine
-    instance.begin_migrate(MigrateRole::Destination, migrate_ctx_id)?;
 
     let task = tokio::spawn(async move {
         if let Err(e) = destination::migrate(

--- a/server/src/lib/migrate/mod.rs
+++ b/server/src/lib/migrate/mod.rs
@@ -102,9 +102,6 @@ pub enum MigrateError {
 
     #[error("encountered invalid instance state")]
     InvalidInstanceState,
-
-    #[error("failed to pause devices")]
-    PauseDevices,
 }
 
 impl From<hyper::Error> for MigrateError {
@@ -140,8 +137,9 @@ impl Into<HttpError> for MigrateError {
             | MigrateError::Initiate
             | MigrateError::Incompatible(_, _)
             | MigrateError::InstanceNotInitialized
-            | MigrateError::InvalidInstanceState
-            | MigrateError::PauseDevices => HttpError::for_internal_error(msg),
+            | MigrateError::InvalidInstanceState => {
+                HttpError::for_internal_error(msg)
+            }
             MigrateError::MigrationAlreadyInProgress
             | MigrateError::NoMigrationInProgress
             | MigrateError::Protocol

--- a/server/src/lib/migrate/source.rs
+++ b/server/src/lib/migrate/source.rs
@@ -5,8 +5,7 @@ use std::time::Duration;
 use tokio::{task, time};
 
 use hyper::upgrade::Upgraded;
-use propolis::dispatch::AsyncCtx;
-use propolis::instance::{Instance, ReqState};
+use propolis::instance::ReqState;
 use slog::{error, info, warn};
 use tokio_util::codec::Framed;
 
@@ -15,21 +14,13 @@ use crate::migrate::preamble::Preamble;
 use crate::migrate::{MigrateContext, MigrateError, MigrationState};
 
 pub async fn migrate(
-    migrate_context: Arc<MigrateContext>,
-    instance: Arc<Instance>,
-    async_context: AsyncCtx,
+    mctx: Arc<MigrateContext>,
     conn: Upgraded,
-    log: slog::Logger,
 ) -> Result<(), MigrateError> {
+    let codec_log = mctx.log.new(slog::o!());
     let mut proto = SourceProtocol {
-        migrate_context,
-        instance,
-        async_context,
-        conn: Framed::new(
-            conn,
-            codec::LiveMigrationFramer::new(log.new(slog::o!())),
-        ),
-        log,
+        mctx,
+        conn: Framed::new(conn, codec::LiveMigrationFramer::new(codec_log)),
     };
     proto.start();
     proto.sync().await?;
@@ -43,22 +34,22 @@ pub async fn migrate(
 }
 
 struct SourceProtocol {
-    migrate_context: Arc<MigrateContext>,
-    instance: Arc<Instance>,
-    #[allow(dead_code)]
-    async_context: AsyncCtx,
+    mctx: Arc<MigrateContext>,
     conn: Framed<Upgraded, codec::LiveMigrationFramer>,
-    log: slog::Logger,
 }
 
 impl SourceProtocol {
+    fn log(&self) -> &slog::Logger {
+        &self.mctx.log
+    }
+
     fn start(&mut self) {
-        info!(self.log, "Entering Source Migration Task");
+        info!(self.log(), "Entering Source Migration Task");
     }
 
     async fn sync(&mut self) -> Result<(), MigrateError> {
-        self.migrate_context.set_state(MigrationState::Sync).await;
-        let preamble = Preamble::new(self.instance.as_ref());
+        self.mctx.set_state(MigrationState::Sync).await;
+        let preamble = Preamble::new(self.mctx.instance.as_ref());
         let s = ron::ser::to_string(&preamble)
             .map_err(codec::ProtocolError::from)?;
         self.send_msg(codec::Message::Serialized(s)).await?;
@@ -66,31 +57,32 @@ impl SourceProtocol {
     }
 
     async fn ram_push(&mut self) -> Result<(), MigrateError> {
-        self.migrate_context.set_state(MigrationState::RamPush).await;
+        self.mctx.set_state(MigrationState::RamPush).await;
         let m = self.read_msg().await?;
-        info!(self.log, "ram_push: got query {:?}", m);
+        info!(self.log(), "ram_push: got query {:?}", m);
         // TODO(cross): Implement the rest of the RAM transfer protocol here. :-)
         self.pause().await?;
-        self.migrate_context.set_state(MigrationState::RamPushDirty).await;
+        self.mctx.set_state(MigrationState::RamPushDirty).await;
         self.send_msg(codec::Message::MemEnd(0, !0)).await?;
         let m = self.read_msg().await?;
-        info!(self.log, "ram_push: got done {:?}", m);
+        info!(self.log(), "ram_push: got done {:?}", m);
         Ok(())
     }
 
     async fn pause(&mut self) -> Result<(), MigrateError> {
-        self.migrate_context.set_state(MigrationState::Pause).await;
+        self.mctx.set_state(MigrationState::Pause).await;
 
         // Ask the instance to begin transitioning to the paused state
         // This will inform each device to pause.
-        info!(self.log, "Pausing devices");
+        info!(self.log(), "Pausing devices");
         let (pause_tx, pause_rx) = std::sync::mpsc::channel();
-        self.instance
-            .migrate_pause(self.async_context.context_id(), pause_rx)?;
+        self.mctx
+            .instance
+            .migrate_pause(self.mctx.async_ctx.context_id(), pause_rx)?;
 
         // Grab a reference to all the devices that are a part of this Instance
         let mut devices = vec![];
-        let inv = self.instance.inv();
+        let inv = self.mctx.instance.inv();
         inv.for_each_node(Order::Pre, |_, rec| {
             devices.push((rec.name().to_owned(), Arc::clone(rec.entity())))
         });
@@ -99,7 +91,7 @@ impl SourceProtocol {
         let mut migrate_ready_futs = vec![];
         for (name, device) in &devices {
             if let Some(migrate_hdl) = device.migrate() {
-                let log = self.log.new(slog::o!("device" => name.clone()));
+                let log = self.log().new(slog::o!("device" => name.clone()));
                 let pause_fut = migrate_hdl.paused();
                 migrate_ready_futs.push(task::spawn(async move {
                     if let Err(_) =
@@ -112,7 +104,7 @@ impl SourceProtocol {
                     Ok(())
                 }));
             } else {
-                warn!(self.log, "No migrate handle for {}", name);
+                warn!(self.log(), "No migrate handle for {}", name);
                 continue;
             }
         }
@@ -138,39 +130,39 @@ impl SourceProtocol {
     }
 
     async fn device_state(&mut self) -> Result<(), MigrateError> {
-        self.migrate_context.set_state(MigrationState::Device).await;
+        self.mctx.set_state(MigrationState::Device).await;
         self.read_ok().await?;
         self.send_msg(codec::Message::Okay).await
     }
 
     async fn arch_state(&mut self) -> Result<(), MigrateError> {
-        self.migrate_context.set_state(MigrationState::Arch).await;
+        self.mctx.set_state(MigrationState::Arch).await;
         self.read_ok().await?;
         self.send_msg(codec::Message::Okay).await
     }
 
     async fn ram_pull(&mut self) -> Result<(), MigrateError> {
-        self.migrate_context.set_state(MigrationState::RamPush).await;
+        self.mctx.set_state(MigrationState::RamPush).await;
         let m = self.read_msg().await?;
-        info!(self.log, "ram_pull: got query {:?}", m);
-        self.migrate_context.set_state(MigrationState::Pause).await;
-        self.migrate_context.set_state(MigrationState::RamPushDirty).await;
+        info!(self.log(), "ram_pull: got query {:?}", m);
+        self.mctx.set_state(MigrationState::Pause).await;
+        self.mctx.set_state(MigrationState::RamPushDirty).await;
         self.send_msg(codec::Message::MemEnd(0, !0)).await?;
         let m = self.read_msg().await?;
-        info!(self.log, "ram_pull: got done {:?}", m);
+        info!(self.log(), "ram_pull: got done {:?}", m);
         Ok(())
     }
 
     async fn finish(&mut self) -> Result<(), MigrateError> {
-        self.migrate_context.set_state(MigrationState::Finish).await;
+        self.mctx.set_state(MigrationState::Finish).await;
         self.read_ok().await?;
         let _ = self.send_msg(codec::Message::Okay).await; // A failure here is ok.
         Ok(())
     }
 
     fn end(&mut self) -> Result<(), MigrateError> {
-        self.instance.set_target_state(ReqState::Halt)?;
-        info!(self.log, "Source Migration Successful");
+        self.mctx.instance.set_target_state(ReqState::Halt)?;
+        info!(self.log(), "Source Migration Successful");
         Ok(())
     }
 

--- a/server/src/lib/migrate/source.rs
+++ b/server/src/lib/migrate/source.rs
@@ -1,13 +1,10 @@
-use futures::{future, SinkExt, StreamExt};
-use propolis::inventory::Order;
+use futures::{SinkExt, StreamExt};
 use std::sync::Arc;
-use std::time::Duration;
-use tokio::{task, time};
 
 use hyper::upgrade::Upgraded;
 use propolis::dispatch::AsyncCtx;
 use propolis::instance::{Instance, ReqState};
-use slog::{error, info, warn};
+use slog::{error, info};
 use tokio_util::codec::Framed;
 
 use crate::migrate::codec;
@@ -83,55 +80,26 @@ impl SourceProtocol {
         // Ask the instance to begin transitioning to the paused state
         // This will inform each device to pause.
         info!(self.log, "Pausing devices");
-        let (pause_tx, pause_rx) = std::sync::mpsc::channel();
-        self.instance
-            .migrate_pause(self.async_context.context_id(), pause_rx)?;
 
-        // Grab a reference to all the devices that are a part of this Instance
-        let mut devices = vec![];
-        let inv = self.instance.inv();
-        inv.for_each_node(Order::Pre, |_, rec| {
-            devices.push((rec.name().to_owned(), Arc::clone(rec.entity())))
-        });
+        let instance = Arc::clone(&self.instance);
+        let ctx_id = self.async_context.context_id();
 
-        // Ask each device for a future indicating they've finishing pausing
-        let mut migrate_ready_futs = vec![];
-        for (name, device) in &devices {
-            if let Some(migrate_hdl) = device.migrate() {
-                let log = self.log.new(slog::o!("device" => name.clone()));
-                let pause_fut = migrate_hdl.paused();
-                migrate_ready_futs.push(task::spawn(async move {
-                    if let Err(_) =
-                        time::timeout(Duration::from_secs(2), pause_fut).await
-                    {
-                        error!(log, "Timed out pausing device");
-                        return Err(());
-                    }
-                    info!(log, "Paused device");
+        let paused = tokio::task::spawn_blocking(move || {
+            instance.migrate_pause(ctx_id).map(|paused| {
+                if paused {
                     Ok(())
-                }));
-            } else {
-                warn!(self.log, "No migrate handle for {}", name);
-                continue;
-            }
+                } else {
+                    Err(instance.migrate_error())
+                }
+            })
+        })
+        .await
+        .map_err(|_| MigrateError::PauseDevices)??;
+
+        if let Err(err) = paused {
+            error!(self.log, "failed to pause devices: {:?}", err);
+            return Err(MigrateError::PauseDevices);
         }
-
-        // Now we wait for all the devices to have paused
-        future::join_all(migrate_ready_futs)
-            .await
-            // Hoist out the JoinError's
-            .into_iter()
-            .collect::<std::result::Result<Vec<_>, _>>()
-            // TODO: Better error
-            .map_err(|_| MigrateError::InvalidInstanceState)?
-            // Hoist out the pause task errors if any
-            .into_iter()
-            .collect::<std::result::Result<Vec<_>, _>>()
-            // TODO: Better error
-            .map_err(|_| MigrateError::Protocol)?;
-
-        // Inform the instance state machine we're done pausing
-        pause_tx.send(()).unwrap();
 
         Ok(())
     }

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -115,6 +115,7 @@ fn api_to_propolis_state(
         ApiState::Run => PropolisState::Run,
         ApiState::Stop => PropolisState::Halt,
         ApiState::Reboot => PropolisState::Reset,
+        ApiState::MigrateStart => PropolisState::StartMigrate,
     }
 }
 
@@ -129,7 +130,7 @@ fn propolis_to_api_state(
         PropolisState::Boot => ApiState::Starting,
         PropolisState::Run => ApiState::Running,
         PropolisState::Quiesce => ApiState::Stopping,
-        PropolisState::Migrate(_) => ApiState::Migrating,
+        PropolisState::Migrate(_, _) => ApiState::Migrating,
         PropolisState::Halt => ApiState::Stopped,
         PropolisState::Reset => ApiState::Rebooting,
         PropolisState::Destroy => ApiState::Destroyed,


### PR DESCRIPTION
This presents an approach to threading one aspect of the migration process through the existing instance state machine.

We currently have the migration being driven from `propolis-server` but it needs to be able inspect and influence the `Instance` from the core propolis lib. `Instance` already had a 'migrating' state but this expands it with some phases: (just `Start` and `Pause` for now). A migration begins in the `Start` phase.

Once the migrate task is ready to pause the source instance it requests a transition to the `Pause` phase. But pausing the VM involves having every device stop servicing the guest, along with making sure any outstanding requests are completed (or canceled). To support that, the `Migrate(Source, Pause)` state triggers the normal state transition logic which notifies each device in turn (via `Entity::state_transition` along with a shortcut `Migrate::pause`). This is the point at which each device is expected to stop servicing guest requests.

Crucially though, we can't rely on every device being ready to pause at that moment due to the possibility of outstanding requests. To handle that, every device also implements `Migrate::paused` which returns a future that indicates the device is done pausing.

Right now, the state machine just waits on a passed in channel to allow `propolis-server` to actually collect and await on the device futures. Alternatively could move the awaiting logic to the core state transition loop and just have the migrate task wait (via `Instance::wait_for_state`).

~~**EDIT** The last commit presents a slightly modified approach that sees most of pause machinery stay in propolis core. The `pause` & `paused` methods on `Migrate` are collapsed back into one but this time called directly from the Instance's `drive_state` loop. That just leaves the caller in `propolis-server` to call a simple `migrate_pause` method to initiate the process.~~

After some discussion w/ pmooney this moves us back to driving the pause polling from outside the core propolis state transition loop. This gives more latitude to consumers (propolis-server) in deciding on things like timeouts and being able to track which devices aren't ready.