### PR TITLE
Add missing BlockIO import.

### DIFF
--- a/propolis/src/block/crucible.rs
+++ b/propolis/src/block/crucible.rs
@@ -12,7 +12,7 @@ use crate::dispatch::{AsyncCtx, DispCtx, Dispatcher, SyncCtx, WakeFn};
 use crate::inventory::Entity;
 use crate::vmm::SubMapping;
 
-use crucible::CrucibleError;
+use crucible::{BlockIO, CrucibleError};
 
 use tokio::sync::Semaphore;
 


### PR DESCRIPTION
Looks like we need to pick up another import to work with the latest crucible changes. I imagine there's more work to support volumes fully but this unblocks the build.

Relatedly, maybe it's time to consider a `Cargo.lock` for propolis.