### PR TITLE
Facilitate direct access to VM memory objects

### DIFF
--- a/propolis/src/vmm/hdl.rs
+++ b/propolis/src/vmm/hdl.rs
@@ -236,7 +236,7 @@ impl VmmHdl {
     pub fn mmap_seg(&self, segid: i32, size: usize) -> Result<Mapping> {
         let devoff = self.devmem_offset(segid)?;
 
-        Mapping::new(size, Prot::WRITE, &self.inner, devoff as i64)
+        Mapping::new(size, Prot::READ | Prot::WRITE, &self.inner, devoff as i64)
     }
 
     /// Maps a portion of the guest's virtual address space into propolis'


### PR DESCRIPTION
Rather than going through the nested page tables for the guest-physical address space, use mappings which directly access the underlying memory objects.  This has a workaround for the lack of [illumos #14511](https://www.illumos.org/issues/14511), until that fix is merged.