### PR TITLE
Using anyhow::Result in main sometimes prints superfluous 'Error' text.

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
     register_probes().unwrap();
 
     // Command line arguments.
-    let args = Args::from_args_safe()?;
+    let args = Args::from_args();
 
     match args {
         Args::OpenApi => run_openapi()


### PR DESCRIPTION
Returning `anyhow::Result` from main means the `Err` variant will be written out to stderr prefixed with 'Error: '. This doesn't play so well with `structopt`'s `from_args_safe` method which returns `Err` but also prints its own output to stdout/err (e.g. when passing -V or -h). In this case there's no reason for us to not just use the `from_args` variant which also exits the program instead of returning Err thereby sidestepping the extra output.

Fixes https://github.com/oxidecomputer/propolis/issues/91.