### PR TITLE
Update for latest crucible changes.

### DIFF
--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -21,7 +21,7 @@ viona_api = { path = "../viona-api" }
 usdt = { version = "0.2.1", default-features = false }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-crucible = { git = "https://github.com/oxidecomputer/crucible", branch = "main", optional = true }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "ab6309ced8e06c30354d4a5c87634fb4d205db3f", optional = true }
 anyhow = "1"
 slog = "2.7"
 serde = { version = "1" }

--- a/propolis/src/block/crucible.rs
+++ b/propolis/src/block/crucible.rs
@@ -333,7 +333,7 @@ fn process_write_request(
 fn process_flush_request(
     guest: Arc<crucible::Guest>,
 ) -> std::result::Result<(), CrucibleError> {
-    let mut waiter = guest.flush()?;
+    let mut waiter = guest.flush(None)?;
     waiter.block_wait()?;
 
     Ok(())


### PR DESCRIPTION
Minimal propolis side changes to get it compiling again with https://github.com/oxidecomputer/crucible/pull/207. Also update the crucible dep to point to a specific revision (*) instead of just main so that CI doesn't break between once upstream changes and when we pick up the changes.

(*) I just picked the current `main`, feel free to suggest something else if that works better.