### PR TITLE
Plumb through the Crucible admin SocketAddr

### DIFF
--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -233,6 +233,7 @@ pub struct DiskRequest {
     pub key: Option<String>,
     pub gen: u64,
     pub device: String,
+    pub admin: Option<SocketAddr>,
 }
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]

--- a/propolis/src/block/crucible.rs
+++ b/propolis/src/block/crucible.rs
@@ -37,8 +37,9 @@ impl CrucibleBackend {
         read_only: bool,
         key: Option<String>,
         gen: Option<u64>,
+        admin: Option<SocketAddr>,
     ) -> Result<Arc<Self>> {
-        CrucibleBackend::_create(disp, targets, read_only, key, gen)
+        CrucibleBackend::_create(disp, targets, read_only, key, gen, admin)
             .map_err(map_crucible_error_to_io)
     }
 
@@ -48,12 +49,14 @@ impl CrucibleBackend {
         read_only: bool,
         key: Option<String>,
         gen: Option<u64>,
+        admin: Option<SocketAddr>,
     ) -> anyhow::Result<Arc<Self>, crucible::CrucibleError> {
         // spawn Crucible tasks
         let opts = crucible::CrucibleOpts {
             target: targets,
             lossy: false,
             key,
+            admin,
             ..Default::default()
         };
         let guest = Arc::new(crucible::Guest::new());

--- a/server/src/lib/config.rs
+++ b/server/src/lib/config.rs
@@ -210,7 +210,7 @@ impl BlockDevice {
                     .flatten();
 
                 let be = propolis::block::CrucibleBackend::create(
-                    disp, targets, read_only, key, gen,
+                    disp, targets, read_only, key, gen, None,
                 )?;
 
                 // TODO: use volume ID or something for instance name

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -274,6 +274,7 @@ impl<'a> MachineInitializer<'a> {
             disk.read_only,
             disk.key.clone(),
             Some(disk.gen),
+            disk.admin,
         )?;
 
         info!(self.log, "Creating ChildRegister");

--- a/standalone/src/config.rs
+++ b/standalone/src/config.rs
@@ -137,7 +137,7 @@ impl BlockDevice {
                     .flatten();
 
                 let be = propolis::block::CrucibleBackend::create(
-                    disp, targets, read_only, key, gen,
+                    disp, targets, read_only, key, gen, None,
                 )
                 .unwrap();
 


### PR DESCRIPTION
Plumb through the admin SocketAddr from DiskRequest to Crucible. This
allows Nexus to allocate an address for this particular disk and issue
Snapshot requests to the Upstairs.