### PR TITLE
Live Migration: Transfer Device State

### DIFF
--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -89,6 +89,7 @@ pub enum MigrationState {
     Resume,
     RamPull,
     Finish,
+    Error,
 }
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]

--- a/propolis/src/block/file.rs
+++ b/propolis/src/block/file.rs
@@ -10,8 +10,10 @@ use super::DeviceInfo;
 use crate::block;
 use crate::dispatch::{AsyncCtx, DispCtx, Dispatcher, SyncCtx, WakeFn};
 use crate::inventory::Entity;
+use crate::migrate::Migrate;
 use crate::vmm::MappingExt;
 
+use erased_serde::Serialize;
 use tokio::sync::Semaphore;
 
 // XXX: completely arb for now
@@ -86,6 +88,23 @@ impl Entity for FileBackend {
     fn type_name(&self) -> &'static str {
         "block-file"
     }
+
+    fn migrate(&self) -> Option<&dyn Migrate> {
+        Some(self)
+    }
+}
+
+impl Migrate for FileBackend {
+    fn export(&self, _ctx: &DispCtx) -> Box<dyn Serialize> {
+        Box::new(migrate::FileBackendV1 {})
+    }
+}
+
+pub mod migrate {
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    pub struct FileBackendV1 {}
 }
 
 struct Driver {

--- a/propolis/src/block/file.rs
+++ b/propolis/src/block/file.rs
@@ -10,10 +10,8 @@ use super::DeviceInfo;
 use crate::block;
 use crate::dispatch::{AsyncCtx, DispCtx, Dispatcher, SyncCtx, WakeFn};
 use crate::inventory::Entity;
-use crate::migrate::Migrate;
 use crate::vmm::MappingExt;
 
-use erased_serde::Serialize;
 use tokio::sync::Semaphore;
 
 // XXX: completely arb for now
@@ -88,23 +86,6 @@ impl Entity for FileBackend {
     fn type_name(&self) -> &'static str {
         "block-file"
     }
-
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
-    }
-}
-
-impl Migrate for FileBackend {
-    fn export(&self, _ctx: &DispCtx) -> Box<dyn Serialize> {
-        Box::new(migrate::FileBackendV1 {})
-    }
-}
-
-pub mod migrate {
-    use serde::Serialize;
-
-    #[derive(Serialize)]
-    pub struct FileBackendV1 {}
 }
 
 struct Driver {

--- a/propolis/src/hw/bhyve/atpic.rs
+++ b/propolis/src/hw/bhyve/atpic.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::dispatch::DispCtx;
 use crate::inventory::Entity;
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 
 use erased_serde::Serialize;
 
@@ -17,8 +17,8 @@ impl Entity for BhyveAtPic {
     fn type_name(&self) -> &'static str {
         "lpc-bhyve-atpic"
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for BhyveAtPic {

--- a/propolis/src/hw/bhyve/atpit.rs
+++ b/propolis/src/hw/bhyve/atpit.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::dispatch::DispCtx;
 use crate::inventory::Entity;
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 
 use erased_serde::Serialize;
 
@@ -17,8 +17,8 @@ impl Entity for BhyveAtPit {
     fn type_name(&self) -> &'static str {
         "lpc-bhyve-atpit"
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for BhyveAtPit {

--- a/propolis/src/hw/bhyve/hpet.rs
+++ b/propolis/src/hw/bhyve/hpet.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::dispatch::DispCtx;
 use crate::inventory::Entity;
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 
 use erased_serde::Serialize;
 
@@ -17,8 +17,8 @@ impl Entity for BhyveHpet {
     fn type_name(&self) -> &'static str {
         "lpc-bhyve-hpet"
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for BhyveHpet {

--- a/propolis/src/hw/bhyve/ioapic.rs
+++ b/propolis/src/hw/bhyve/ioapic.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::dispatch::DispCtx;
 use crate::inventory::Entity;
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 
 use erased_serde::Serialize;
 
@@ -17,8 +17,8 @@ impl Entity for BhyveIoApic {
     fn type_name(&self) -> &'static str {
         "lpc-bhyve-ioapic"
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for BhyveIoApic {

--- a/propolis/src/hw/bhyve/pmtimer.rs
+++ b/propolis/src/hw/bhyve/pmtimer.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::dispatch::DispCtx;
 use crate::inventory::Entity;
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 
 use erased_serde::Serialize;
 
@@ -17,8 +17,8 @@ impl Entity for BhyvePmTimer {
     fn type_name(&self) -> &'static str {
         "lpc-bhyve-pmtimer"
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for BhyvePmTimer {

--- a/propolis/src/hw/bhyve/rtc.rs
+++ b/propolis/src/hw/bhyve/rtc.rs
@@ -4,7 +4,7 @@ use std::time::SystemTime;
 
 use crate::dispatch::DispCtx;
 use crate::inventory::Entity;
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 use crate::vmm::VmmHdl;
 
 use erased_serde::Serialize;
@@ -74,8 +74,8 @@ impl Entity for BhyveRtc {
     fn type_name(&self) -> &'static str {
         "lpc-bhyve-rtc"
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for BhyveRtc {

--- a/propolis/src/hw/chipset/i440fx.rs
+++ b/propolis/src/hw/chipset/i440fx.rs
@@ -10,7 +10,7 @@ use crate::hw::pci::{self, Bdf, BusNum, INTxPinID, PioCfgDecoder};
 use crate::instance::{State, SuspendKind, SuspendSource, TransitionPhase};
 use crate::intr_pins::{IntrPin, LegacyPIC, LegacyPin};
 use crate::inventory;
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 use crate::pio::{PioBus, PioFn};
 use crate::util::regmap::RegMap;
 use crate::vmm::{Machine, VmmHdl};
@@ -168,8 +168,8 @@ impl Entity for I440Fx {
             inventory::ChildRegister::new(&self.pm_timer, None),
         ])
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 
@@ -303,8 +303,8 @@ impl Entity for Piix4HostBridge {
     fn reset(&self, _ctx: &DispCtx) {
         self.pci_state.reset(self);
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for Piix4HostBridge {
@@ -431,8 +431,8 @@ impl Entity for Piix3Lpc {
     fn reset(&self, _ctx: &DispCtx) {
         self.pci_state.reset(self);
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for Piix3Lpc {
@@ -786,8 +786,8 @@ impl Entity for Piix3PM {
     fn reset(&self, _ctx: &DispCtx) {
         self.pci_state.reset(self);
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
     fn state_transition(
         &self,

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::dispatch::DispCtx;
 use crate::hw::pci;
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 use crate::util::regmap::RegMap;
 use crate::{block, common::*};
 
@@ -926,8 +926,8 @@ impl Entity for PciNvme {
         Box::pin(async move { notify.notified().await })
     }
 
-    fn migrate(&self) -> Option<&dyn crate::migrate::Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for PciNvme {

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -879,18 +879,11 @@ impl Entity for PciNvme {
     fn type_name(&self) -> &'static str {
         "pci-nvme"
     }
+
     fn reset(&self, _ctx: &DispCtx) {
         let mut ctrl = self.state.lock().unwrap();
         ctrl.reset();
         self.pci_state.reset(self);
-    }
-    fn migrate(&self) -> Option<&dyn crate::migrate::Migrate> {
-        Some(self)
-    }
-}
-impl Migrate for PciNvme {
-    fn export(&self, _ctx: &DispCtx) -> Box<dyn Serialize> {
-        Box::new(migrate::PciNvmeStateV1 { pci: self.pci_state.export() })
     }
 
     fn pause(&self, _ctx: &DispCtx) {
@@ -931,6 +924,15 @@ impl Migrate for PciNvme {
         let notify = Arc::clone(reqs_notifier.as_ref().unwrap());
 
         Box::pin(async move { notify.notified().await })
+    }
+
+    fn migrate(&self) -> Option<&dyn crate::migrate::Migrate> {
+        Some(self)
+    }
+}
+impl Migrate for PciNvme {
+    fn export(&self, _ctx: &DispCtx) -> Box<dyn Serialize> {
+        Box::new(migrate::PciNvmeStateV1 { pci: self.pci_state.export() })
     }
 }
 

--- a/propolis/src/hw/ps2ctrl.rs
+++ b/propolis/src/hw/ps2ctrl.rs
@@ -8,7 +8,7 @@ use crate::hw::chipset::Chipset;
 use crate::hw::ibmpc;
 use crate::instance;
 use crate::intr_pins::LegacyPin;
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 use crate::pio::{PioBus, PioFn};
 
 use erased_serde::Serialize;
@@ -305,8 +305,8 @@ impl Entity for PS2Ctrl {
     fn reset(&self, _ctx: &DispCtx) {
         PS2Ctrl::reset(self);
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for PS2Ctrl {

--- a/propolis/src/hw/qemu/debug.rs
+++ b/propolis/src/hw/qemu/debug.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::chardev::{BlockingSource, BlockingSourceConsumer, ConsumerCell};
 use crate::common::*;
 use crate::dispatch::DispCtx;
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 use crate::pio::{PioBus, PioFn};
 
 use erased_serde::Serialize;
@@ -50,8 +50,8 @@ impl Entity for QemuDebugPort {
         "qemu-lpc-debug"
     }
 
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 

--- a/propolis/src/hw/qemu/debug.rs
+++ b/propolis/src/hw/qemu/debug.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use crate::chardev::{BlockingSource, BlockingSourceConsumer, ConsumerCell};
 use crate::common::*;
 use crate::dispatch::DispCtx;
+use crate::migrate::Migrate;
 use crate::pio::{PioBus, PioFn};
+
+use erased_serde::Serialize;
 
 const QEMU_DEBUG_IOPORT: u16 = 0x0402;
 const QEMU_DEBUG_IDENT: u8 = 0xe9;
@@ -46,4 +49,21 @@ impl Entity for QemuDebugPort {
     fn type_name(&self) -> &'static str {
         "qemu-lpc-debug"
     }
+
+    fn migrate(&self) -> Option<&dyn Migrate> {
+        Some(self)
+    }
+}
+
+impl Migrate for QemuDebugPort {
+    fn export(&self, _ctx: &DispCtx) -> Box<dyn Serialize> {
+        Box::new(migrate::QemuDebugPortV1 {})
+    }
+}
+
+pub mod migrate {
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    pub struct QemuDebugPortV1 {}
 }

--- a/propolis/src/hw/qemu/debug.rs
+++ b/propolis/src/hw/qemu/debug.rs
@@ -3,10 +3,7 @@ use std::sync::Arc;
 use crate::chardev::{BlockingSource, BlockingSourceConsumer, ConsumerCell};
 use crate::common::*;
 use crate::dispatch::DispCtx;
-use crate::migrate::{Migrate, Migrator};
 use crate::pio::{PioBus, PioFn};
-
-use erased_serde::Serialize;
 
 const QEMU_DEBUG_IOPORT: u16 = 0x0402;
 const QEMU_DEBUG_IDENT: u8 = 0xe9;
@@ -49,21 +46,4 @@ impl Entity for QemuDebugPort {
     fn type_name(&self) -> &'static str {
         "qemu-lpc-debug"
     }
-
-    fn migrate(&self) -> Migrator {
-        Migrator::Custom(self)
-    }
-}
-
-impl Migrate for QemuDebugPort {
-    fn export(&self, _ctx: &DispCtx) -> Box<dyn Serialize> {
-        Box::new(migrate::QemuDebugPortV1 {})
-    }
-}
-
-pub mod migrate {
-    use serde::Serialize;
-
-    #[derive(Serialize)]
-    pub struct QemuDebugPortV1 {}
 }

--- a/propolis/src/hw/qemu/fwcfg.rs
+++ b/propolis/src/hw/qemu/fwcfg.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::common::*;
 use crate::dispatch::DispCtx;
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 use crate::pio::{PioBus, PioFn};
 use bits::*;
 
@@ -655,8 +655,8 @@ impl Entity for FwCfg {
     fn type_name(&self) -> &'static str {
         "qemu-fwcfg"
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for FwCfg {

--- a/propolis/src/hw/qemu/ramfb.rs
+++ b/propolis/src/hw/qemu/ramfb.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use crate::common::*;
 use crate::dispatch::DispCtx;
 use crate::hw::qemu::fwcfg::{self, FwCfgBuilder, Item};
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 use crate::util::regmap::RegMap;
 
 use erased_serde::Serialize;
@@ -135,8 +135,8 @@ impl Entity for RamFb {
     fn type_name(&self) -> &'static str {
         "qemu-ramfb"
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for RamFb {

--- a/propolis/src/hw/qemu/ramfb.rs
+++ b/propolis/src/hw/qemu/ramfb.rs
@@ -151,12 +151,32 @@ impl Migrate for RamFb {
             stride: state.stride,
         })
     }
+
+    fn import(
+        &self,
+        _dev: &str,
+        deserializer: &mut dyn erased_serde::Deserializer,
+        _ctx: &DispCtx,
+    ) -> Result<(), crate::migrate::MigrateStateError> {
+        let deserialized: migrate::RamFbV1 =
+            erased_serde::deserialize(deserializer)?;
+
+        let mut state = self.config.lock().unwrap();
+        state.addr = deserialized.addr;
+        state.fourcc = deserialized.fourcc;
+        state.flags = deserialized.flags;
+        state.width = deserialized.width;
+        state.height = deserialized.height;
+        state.stride = deserialized.stride;
+
+        Ok(())
+    }
 }
 
 pub mod migrate {
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize)]
+    #[derive(Deserialize, Serialize)]
     pub struct RamFbV1 {
         pub addr: u64,
         pub fourcc: u32,

--- a/propolis/src/hw/uart/lpc.rs
+++ b/propolis/src/hw/uart/lpc.rs
@@ -5,7 +5,7 @@ use crate::chardev::*;
 use crate::common::*;
 use crate::dispatch::DispCtx;
 use crate::intr_pins::{IntrPin, LegacyPin};
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 use crate::pio::{PioBus, PioFn};
 
 use erased_serde::Serialize;
@@ -141,8 +141,8 @@ impl Entity for LpcUart {
     fn reset(&self, _ctx: &DispCtx) {
         LpcUart::reset(self);
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for LpcUart {

--- a/propolis/src/hw/virtio/block.rs
+++ b/propolis/src/hw/virtio/block.rs
@@ -5,7 +5,7 @@ use crate::block;
 use crate::common::*;
 use crate::dispatch::DispCtx;
 use crate::hw::pci;
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 use crate::util::regmap::RegMap;
 
 use super::bits::*;
@@ -185,8 +185,8 @@ impl Entity for PciVirtioBlock {
     fn reset(&self, ctx: &DispCtx) {
         self.virtio_state.reset(self, ctx);
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for PciVirtioBlock {

--- a/propolis/src/hw/virtio/viona.rs
+++ b/propolis/src/hw/virtio/viona.rs
@@ -10,7 +10,7 @@ use crate::common::*;
 use crate::dispatch::{AsyncCtx, DispCtx};
 use crate::hw::pci;
 use crate::instance;
-use crate::migrate::Migrate;
+use crate::migrate::{Migrate, Migrator};
 use crate::util::regmap::RegMap;
 use crate::util::self_arc::*;
 use crate::util::sys;
@@ -252,8 +252,8 @@ impl Entity for PciVirtioViona {
     fn reset(&self, ctx: &DispCtx) {
         self.virtio_state.reset(self, ctx);
     }
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        Some(self)
+    fn migrate(&self) -> Migrator {
+        Migrator::Custom(self)
     }
 }
 impl Migrate for PciVirtioViona {

--- a/propolis/src/instance.rs
+++ b/propolis/src/instance.rs
@@ -11,15 +11,25 @@ use crate::inventory::{self, Inventory};
 use crate::vcpu::VcpuRunFunc;
 use crate::vmm::*;
 
+use serde::{Deserialize, Serialize};
 use slog::{self, Drain};
 use thiserror::Error;
 use tokio::runtime::Handle;
 
 /// The role of an instance during a migration.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum MigrateRole {
     Source,
     Destination,
+}
+
+impl std::fmt::Display for MigrateRole {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MigrateRole::Source => write!(fmt, "source"),
+            MigrateRole::Destination => write!(fmt, "destination"),
+        }
+    }
 }
 
 /// Phases an Instance may transition through during a migration.

--- a/propolis/src/instance.rs
+++ b/propolis/src/instance.rs
@@ -496,6 +496,8 @@ impl Instance {
                 }
 
                 ent.state_transition(state, target, phase, ctx);
+
+                Ok::<_, ()>(())
             });
 
             // Transition-func consumers only expect post-state-change

--- a/propolis/src/instance.rs
+++ b/propolis/src/instance.rs
@@ -500,9 +500,7 @@ impl Instance {
                     == State::Migrate(MigrateRole::Source, MigratePhase::Pause)
                     && phase == TransitionPhase::Pre
                 {
-                    if let Some(migrate) = ent.migrate() {
-                        migrate.pause(ctx);
-                    }
+                    ent.pause(ctx);
                 }
 
                 ent.state_transition(state, target, phase, ctx);

--- a/propolis/src/inventory.rs
+++ b/propolis/src/inventory.rs
@@ -1,3 +1,4 @@
+use futures::future::{self, BoxFuture};
 use std::any::Any;
 use std::collections::{btree_set, hash_map, BTreeMap, BTreeSet, HashMap};
 use std::io::{Error as IoError, ErrorKind};
@@ -509,6 +510,19 @@ pub trait Entity: Send + Sync + 'static {
     #[allow(unused_variables)]
     fn child_register(&self) -> Option<Vec<ChildRegister>> {
         None
+    }
+
+    /// Called to indicate the device should stop servicing the guest
+    /// and attempt to cancel or complete any pending operations.
+    ///
+    /// The device isn't necessarily expected to complete the pause
+    /// operation within the scope of this call but should return a
+    /// future indicating such via the [`Entity::paused`] method.
+    fn pause(&self, _ctx: &DispCtx) {}
+
+    /// Return a future indicating when the device has finished pausing.
+    fn paused(&self) -> BoxFuture<'static, ()> {
+        Box::pin(future::ready(()))
     }
 
     fn migrate(&self) -> Option<&dyn Migrate> {

--- a/propolis/src/inventory.rs
+++ b/propolis/src/inventory.rs
@@ -147,14 +147,19 @@ impl Inventory {
     /// Executes `func` for every record within the inventory.
     ///
     /// NOTE: `func` must not invoke any other methods on `&self`.
-    pub fn for_each_node<F>(&self, order: Order, mut func: F)
+    pub fn for_each_node<E, F>(
+        &self,
+        order: Order,
+        mut func: F,
+    ) -> Result<(), E>
     where
-        F: FnMut(EntityID, &Record),
+        F: FnMut(EntityID, &Record) -> Result<(), E>,
     {
         let inv = self.inner.lock().unwrap();
         for (eid, record) in inv.iter(order) {
-            func(eid, record);
+            func(eid, record)?;
         }
+        Ok(())
     }
 
     pub fn print(&self) {

--- a/propolis/src/inventory.rs
+++ b/propolis/src/inventory.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 
 use crate::dispatch::DispCtx;
 use crate::instance::{State, TransitionPhase};
-use crate::migrate::Migrate;
+use crate::migrate::Migrator;
 
 /// Errors returned while registering or deregistering from [`Inventory`].
 #[derive(Error, Debug, PartialEq)]
@@ -525,8 +525,17 @@ pub trait Entity: Send + Sync + 'static {
         Box::pin(future::ready(()))
     }
 
-    fn migrate(&self) -> Option<&dyn Migrate> {
-        None
+    /// Return the Migrator object that will be used to export/import
+    /// this device's state.
+    ///
+    /// By default, we return a simple impl that assumes the device
+    /// has no state that needs to be exported/imported but still wants
+    /// to opt into being migratable. For more complex cases, a device
+    /// may implement the `Migrate` trait along with its export/import
+    /// methods. A device which shouldn't be migrated should instead
+    /// override this method and explicity return `Migrator::NonMigratable`.
+    fn migrate<'a>(&'a self) -> Migrator<'a> {
+        Migrator::Simple
     }
 }
 

--- a/propolis/src/migrate.rs
+++ b/propolis/src/migrate.rs
@@ -33,7 +33,7 @@ pub trait Migrate: Send + Sync + 'static {
     /// Update the current device state by using the given deserializer.
     fn import(
         &self,
-        _deserializer: Box<dyn Deserializer>,
+        _deserializer: &dyn Deserializer,
         _ctx: &DispCtx,
     ) -> Result<(), MigrateStateError> {
         Err(MigrateStateError::ImportUnimplmented)

--- a/propolis/src/migrate.rs
+++ b/propolis/src/migrate.rs
@@ -7,6 +7,10 @@ use thiserror::Error;
 /// Errors encountered while trying to export/import device state.
 #[derive(Error, Debug, serde::Deserialize, PartialEq, serde::Serialize)]
 pub enum MigrateStateError {
+    /// The device doesn't support live migration.
+    #[error("device not migratable")]
+    NonMigratable,
+
     /// Encountered an error trying to deserialize the device state during import.
     #[error("couldn't deserialize device state: {0}")]
     ImportDeserialization(String),

--- a/propolis/src/migrate.rs
+++ b/propolis/src/migrate.rs
@@ -4,6 +4,7 @@ use erased_serde::Serialize;
 use futures::future::{self, BoxFuture};
 
 pub trait Migrate: Send + Sync + 'static {
+    /// Return a serialization of the current device state.
     fn export(&self, ctx: &DispCtx) -> Box<dyn Serialize>;
 
     /// Called to indicate the device should stop servicing the

--- a/propolis/src/migrate.rs
+++ b/propolis/src/migrate.rs
@@ -5,7 +5,9 @@ use futures::future::{self, BoxFuture};
 use thiserror::Error;
 
 /// Errors encountered while trying to export/import device state.
-#[derive(Error, Debug, serde::Deserialize, PartialEq, serde::Serialize)]
+#[derive(
+    Clone, Debug, Error, serde::Deserialize, PartialEq, serde::Serialize,
+)]
 pub enum MigrateStateError {
     /// The device doesn't support live migration.
     #[error("device not migratable")]
@@ -16,8 +18,8 @@ pub enum MigrateStateError {
     ImportDeserialization(String),
 
     /// The device doesn't implement [`Migrate::import`].
-    #[error("device state importation unimplemented")]
-    ImportUnimplmented,
+    #[error("device state importation unimplemented for `{0}`")]
+    ImportUnimplmented(String),
 }
 
 impl From<erased_serde::Error> for MigrateStateError {
@@ -33,10 +35,11 @@ pub trait Migrate: Send + Sync + 'static {
     /// Update the current device state by using the given deserializer.
     fn import(
         &self,
+        dev: &str,
         _deserializer: &dyn Deserializer,
         _ctx: &DispCtx,
     ) -> Result<(), MigrateStateError> {
-        Err(MigrateStateError::ImportUnimplmented)
+        Err(MigrateStateError::ImportUnimplmented(dev.to_string()))
     }
 
     /// Called to indicate the device should stop servicing the

--- a/propolis/src/migrate.rs
+++ b/propolis/src/migrate.rs
@@ -36,7 +36,7 @@ pub trait Migrate: Send + Sync + 'static {
     fn import(
         &self,
         dev: &str,
-        _deserializer: &dyn Deserializer,
+        _deserializer: &mut dyn Deserializer,
         _ctx: &DispCtx,
     ) -> Result<(), MigrateStateError> {
         Err(MigrateStateError::ImportUnimplmented(dev.to_string()))

--- a/propolis/src/migrate.rs
+++ b/propolis/src/migrate.rs
@@ -1,7 +1,6 @@
 use crate::dispatch::DispCtx;
 
 use erased_serde::{Deserializer, Serialize};
-use futures::future::{self, BoxFuture};
 use thiserror::Error;
 
 /// Errors encountered while trying to export/import device state.
@@ -40,18 +39,5 @@ pub trait Migrate: Send + Sync + 'static {
         _ctx: &DispCtx,
     ) -> Result<(), MigrateStateError> {
         Err(MigrateStateError::ImportUnimplmented(dev.to_string()))
-    }
-
-    /// Called to indicate the device should stop servicing the
-    /// guest and attempt to cancel or complete any pending operations.
-    ///
-    /// The device isn't necessarily expected to complete the pause
-    /// operation within this call but should instead return a future
-    /// indicating such via the `paused` method.
-    fn pause(&self, _ctx: &DispCtx) {}
-
-    /// Return a future indicating when the device has finished pausing.
-    fn paused(&self) -> BoxFuture<'static, ()> {
-        Box::pin(future::ready(()))
     }
 }

--- a/propolis/src/migrate.rs
+++ b/propolis/src/migrate.rs
@@ -1,11 +1,39 @@
 use crate::dispatch::DispCtx;
 
-use erased_serde::Serialize;
+use erased_serde::{Deserializer, Serialize};
 use futures::future::{self, BoxFuture};
+use thiserror::Error;
+
+/// Errors encountered while trying to export/import device state.
+#[derive(Error, Debug, serde::Deserialize, PartialEq, serde::Serialize)]
+pub enum MigrateStateError {
+    /// Encountered an error trying to deserialize the device state during import.
+    #[error("couldn't deserialize device state: {0}")]
+    ImportDeserialization(String),
+
+    /// The device doesn't implement [`Migrate::import`].
+    #[error("device state importation unimplemented")]
+    ImportUnimplmented,
+}
+
+impl From<erased_serde::Error> for MigrateStateError {
+    fn from(err: erased_serde::Error) -> Self {
+        MigrateStateError::ImportDeserialization(err.to_string())
+    }
+}
 
 pub trait Migrate: Send + Sync + 'static {
     /// Return a serialization of the current device state.
     fn export(&self, ctx: &DispCtx) -> Box<dyn Serialize>;
+
+    /// Update the current device state by using the given deserializer.
+    fn import(
+        &self,
+        _deserializer: Box<dyn Deserializer>,
+        _ctx: &DispCtx,
+    ) -> Result<(), MigrateStateError> {
+        Err(MigrateStateError::ImportUnimplmented)
+    }
 
     /// Called to indicate the device should stop servicing the
     /// guest and attempt to cancel or complete any pending operations.

--- a/propolis/src/migrate.rs
+++ b/propolis/src/migrate.rs
@@ -27,6 +27,18 @@ impl From<erased_serde::Error> for MigrateStateError {
     }
 }
 
+/// Type representing the migration support (if any) for a given device.
+pub enum Migrator<'a> {
+    /// The device is not migratable
+    NonMigratable,
+
+    /// No device specific logic is needed
+    Simple,
+
+    /// Device specific logic used to export/import device state
+    Custom(&'a dyn Migrate),
+}
+
 pub trait Migrate: Send + Sync + 'static {
     /// Return a serialization of the current device state.
     fn export(&self, ctx: &DispCtx) -> Box<dyn Serialize>;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,6 +24,7 @@ bytes = "1.1"
 const_format = "0.2"
 # dropshot = "0.6"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
+erased-serde = "0.3"
 futures = "0.3"
 hyper =  "0.14"
 num_enum = "0.5"

--- a/server/src/lib/migrate/destination.rs
+++ b/server/src/lib/migrate/destination.rs
@@ -2,6 +2,7 @@ use bitvec::prelude as bv;
 use futures::{SinkExt, StreamExt};
 use hyper::upgrade::Upgraded;
 use propolis::common::GuestAddr;
+use propolis::instance::MigrateRole;
 use propolis::migrate::MigrateStateError;
 use slog::{error, info, warn};
 use std::io;
@@ -20,14 +21,17 @@ pub async fn migrate(
     conn: Upgraded,
 ) -> Result<(), MigrateError> {
     let mut proto = DestinationProtocol::new(mctx, conn);
-    proto.start();
-    proto.sync().await?;
-    proto.ram_push().await?;
-    proto.device_state().await?;
-    proto.arch_state().await?;
-    proto.ram_pull().await?;
-    proto.finish().await?;
-    proto.end();
+
+    if let Err(err) = proto.run().await {
+        proto.mctx.set_state(MigrationState::Error).await;
+        // We encountered an error, try to inform the remote before bailing
+        // Note, we don't use `?` here as this is a best effort and we don't
+        // want an error encountered during this send to shadow the run error
+        // from the caller.
+        let _ = proto.conn.send(codec::Message::Error(err.clone())).await;
+        return Err(err);
+    }
+
     Ok(())
 }
 
@@ -50,6 +54,18 @@ impl DestinationProtocol {
 
     fn log(&self) -> &slog::Logger {
         &self.mctx.log
+    }
+
+    async fn run(&mut self) -> Result<(), MigrateError> {
+        self.start();
+        self.sync().await?;
+        self.ram_push().await?;
+        self.device_state().await?;
+        self.arch_state().await?;
+        self.ram_pull().await?;
+        self.finish().await?;
+        self.end();
+        Ok(())
     }
 
     fn start(&mut self) {
@@ -211,7 +227,7 @@ impl DestinationProtocol {
                         .map_err(codec::ProtocolError::from)?;
                 let deserializer =
                     &<dyn erased_serde::Deserializer>::erase(&mut deserializer);
-                migrate.import(deserializer, &dispctx)?;
+                migrate.import(dev_ent.type_name(), deserializer, &dispctx)?;
             } else {
                 warn!(
                     self.log(),
@@ -253,9 +269,25 @@ impl DestinationProtocol {
     }
 
     async fn read_msg(&mut self) -> Result<codec::Message, MigrateError> {
-        Ok(self.conn.next().await.ok_or_else(|| {
-            codec::ProtocolError::Io(io::Error::from(io::ErrorKind::BrokenPipe))
-        })??)
+        self.conn
+            .next()
+            .await
+            .ok_or_else(|| {
+                codec::ProtocolError::Io(io::Error::from(
+                    io::ErrorKind::BrokenPipe,
+                ))
+            })?
+            // If this is an error message, lift that out
+            .map(|msg| match msg {
+                codec::Message::Error(err) => {
+                    error!(self.log(), "remote error: {err}");
+                    Err(MigrateError::RemoteError(
+                        MigrateRole::Source,
+                        err.to_string(),
+                    ))
+                }
+                msg => Ok(msg),
+            })?
     }
 
     async fn read_ok(&mut self) -> Result<(), MigrateError> {

--- a/server/src/lib/migrate/destination.rs
+++ b/server/src/lib/migrate/destination.rs
@@ -225,8 +225,9 @@ impl DestinationProtocol {
                 let mut deserializer =
                     ron::Deserializer::from_str(&device.payload)
                         .map_err(codec::ProtocolError::from)?;
-                let deserializer =
-                    &<dyn erased_serde::Deserializer>::erase(&mut deserializer);
+                let deserializer = &mut <dyn erased_serde::Deserializer>::erase(
+                    &mut deserializer,
+                );
                 migrate.import(dev_ent.type_name(), deserializer, &dispctx)?;
             } else {
                 warn!(

--- a/server/src/lib/migrate/destination.rs
+++ b/server/src/lib/migrate/destination.rs
@@ -118,7 +118,7 @@ impl DestinationProtocol {
                             self.log(),
                             "ram_push: MemXfer received bad bitmap"
                         );
-                        return Err(MigrateError::Protocol);
+                        return Err(MigrateError::Phase);
                     }
                     // XXX: We should do stricter validation on the fetch
                     // request here.  For instance, we shouldn't "push" MMIO
@@ -127,7 +127,7 @@ impl DestinationProtocol {
                     // should probably disallow it at the protocol level.
                     self.xfer_ram(start, end, &bits).await?;
                 }
-                _ => return Err(MigrateError::Protocol),
+                _ => return Err(MigrateError::UnexpectedMessage),
             };
         }
         self.send_msg(codec::Message::MemDone).await?;
@@ -149,7 +149,7 @@ impl DestinationProtocol {
                 codec::Message::MemEnd(start, end) => {
                     if start != 0 || end != !0 {
                         error!(self.log(), "ram_push: received bad MemEnd");
-                        return Err(MigrateError::Protocol);
+                        return Err(MigrateError::Phase);
                     }
                     break;
                 }
@@ -159,7 +159,7 @@ impl DestinationProtocol {
                             self.log(),
                             "ram_push: MemOffer received bad bitmap"
                         );
-                        return Err(MigrateError::Protocol);
+                        return Err(MigrateError::Phase);
                     }
                     if end > highest {
                         highest = end;
@@ -170,7 +170,7 @@ impl DestinationProtocol {
                     }
                     dirty.extend_from_raw_slice(&bits);
                 }
-                _ => return Err(MigrateError::Protocol),
+                _ => return Err(MigrateError::UnexpectedMessage),
             }
         }
         Ok((dirty, highest))

--- a/server/src/lib/migrate/mod.rs
+++ b/server/src/lib/migrate/mod.rs
@@ -158,6 +158,10 @@ pub enum MigrateError {
     /// Failed to export/import device state for migration
     #[error("failed to migrate device state: {0}")]
     DeviceState(#[from] MigrateStateError),
+
+    /// The destination instance doesn't recognize the received device
+    #[error("received device state for unknown device ({0})")]
+    UnknownDevice(String),
 }
 
 impl MigrateError {
@@ -210,7 +214,8 @@ impl Into<HttpError> for MigrateError {
             MigrateError::MigrationAlreadyInProgress
             | MigrateError::NoMigrationInProgress
             | MigrateError::UuidMismatch
-            | MigrateError::UpgradeExpected => {
+            | MigrateError::UpgradeExpected
+            | MigrateError::UnknownDevice(_) => {
                 HttpError::for_bad_request(None, msg)
             }
         }

--- a/server/src/lib/migrate/mod.rs
+++ b/server/src/lib/migrate/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use bit_field::BitField;
 use dropshot::{HttpError, RequestContext};
@@ -207,6 +207,23 @@ impl Into<HttpError> for MigrateError {
             }
         }
     }
+}
+
+/// Serialized device state sent during migration.
+#[derive(Debug, Deserialize, Serialize)]
+struct Device {
+    /// The literal identifying what kind of `Entity` this device is.
+    type_name: Cow<'static, str>,
+
+    /// The index at which to find this device's parent (if one exists).
+    /// This only makes sense in the context of a complete list of
+    /// devices as sent over the wire during migration. See
+    /// `SourceProtocol::device_state` for how this gets constructed.
+    parent: Option<usize>,
+
+    /// The (Ron) serialized device state.
+    /// See `Migrate::export`.
+    payload: String,
 }
 
 /// Begin the migration process (source-side).

--- a/server/src/lib/migrate/mod.rs
+++ b/server/src/lib/migrate/mod.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc};
+use std::sync::Arc;
 
 use bit_field::BitField;
 use dropshot::{HttpError, RequestContext};
@@ -212,14 +212,8 @@ impl Into<HttpError> for MigrateError {
 /// Serialized device state sent during migration.
 #[derive(Debug, Deserialize, Serialize)]
 struct Device {
-    /// The literal identifying what kind of `Entity` this device is.
-    type_name: Cow<'static, str>,
-
-    /// The index at which to find this device's parent (if one exists).
-    /// This only makes sense in the context of a complete list of
-    /// devices as sent over the wire during migration. See
-    /// `SourceProtocol::device_state` for how this gets constructed.
-    parent: Option<usize>,
+    /// The unique name identifying the device in the instance inventory.
+    instance_name: String,
 
     /// The (Ron) serialized device state.
     /// See `Migrate::export`.

--- a/server/src/lib/migrate/mod.rs
+++ b/server/src/lib/migrate/mod.rs
@@ -151,9 +151,9 @@ pub enum MigrateError {
     #[error("failed to pause source instance")]
     SourcePause,
 
-    /// Phase error, improper or corrupted message in protocol.
-    #[error("phase, improper or corrupted message in protocol")]
-    Protocol,
+    /// Phase error
+    #[error("received out-of-phase message")]
+    Phase,
 
     /// Failed to export/import device state for migration
     #[error("failed to migrate device state: {0}")]
@@ -211,7 +211,7 @@ impl Into<HttpError> for MigrateError {
             | MigrateError::Codec(_)
             | MigrateError::UnexpectedMessage
             | MigrateError::SourcePause
-            | MigrateError::Protocol
+            | MigrateError::Phase
             | MigrateError::DeviceState(_)
             | MigrateError::RemoteError(_, _) => {
                 HttpError::for_internal_error(msg)

--- a/server/src/lib/migrate/source.rs
+++ b/server/src/lib/migrate/source.rs
@@ -105,7 +105,7 @@ impl SourceProtocol {
                 codec::Message::MemFetch(start, end, bits) => {
                     if !memx::validate_bitmap(start, end, &bits) {
                         error!(self.log(), "invalid bitmap");
-                        return Err(MigrateError::Protocol);
+                        return Err(MigrateError::Phase);
                     }
                     // XXX: We should do stricter validation on the fetch
                     // request here.  For instance, we shouldn't "push" MMIO
@@ -114,7 +114,7 @@ impl SourceProtocol {
                     // should probably disallow it at the protocol level.
                     self.xfer_ram(start, end, &bits).await?;
                 }
-                _ => return Err(MigrateError::Protocol),
+                _ => return Err(MigrateError::UnexpectedMessage),
             };
         }
         info!(self.log(), "ram_push: done sending ram");
@@ -352,7 +352,7 @@ impl SourceProtocol {
         match self.read_msg().await? {
             codec::Message::MemQuery(start, end) => {
                 if start % 4096 != 0 || (end % 4096 != 0 && end != !0) {
-                    return Err(MigrateError::Protocol);
+                    return Err(MigrateError::Phase);
                 }
                 Ok(start..end)
             }

--- a/server/src/lib/migrate/source.rs
+++ b/server/src/lib/migrate/source.rs
@@ -3,6 +3,7 @@ use hyper::upgrade::Upgraded;
 use propolis::common::GuestAddr;
 use propolis::instance::ReqState;
 use propolis::inventory::Order;
+use propolis::migrate::MigrateStateError;
 use slog::{error, info, warn};
 use std::io;
 use std::ops::Range;
@@ -244,14 +245,16 @@ impl SourceProtocol {
                 migrate.export(&dispctx)
             } else {
                 warn!(self.log(), "No migrate handle for {}", rec.name());
-                Box::new(())
+                return Err(MigrateError::DeviceState(
+                    MigrateStateError::NonMigratable,
+                ));
             };
             device_states.push(Device {
                 instance_name: rec.name().to_owned(),
                 payload: ron::ser::to_string(&payload)
                     .map_err(codec::ProtocolError::from)?,
             });
-            Ok::<_, MigrateError>(())
+            Ok(())
         })?;
         drop(dispctx);
 

--- a/server/src/lib/migrate/source.rs
+++ b/server/src/lib/migrate/source.rs
@@ -48,8 +48,9 @@ impl SourceProtocol {
     fn new(mctx: Arc<MigrateContext>, conn: Upgraded) -> Self {
         // Grab a reference to all the devices that are a part of this Instance
         let mut devices = vec![];
-        mctx.instance.inv().for_each_node(Order::Pre, |_, rec| {
-            devices.push((rec.name().to_owned(), Arc::clone(rec.entity())))
+        let _ = mctx.instance.inv().for_each_node(Order::Pre, |_, rec| {
+            devices.push((rec.name().to_owned(), Arc::clone(rec.entity())));
+            Ok::<_, ()>(())
         });
 
         let codec_log = mctx.log.new(slog::o!());

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -323,7 +323,7 @@ fn main() {
             }
             State::Quiesce => {
                 println!("Device state at quiesce:");
-                inv.for_each_node(
+                inv.for_each_node::<(), _>(
                     propolis::inventory::Order::Post,
                     |_id, record| {
                         let ent = record.entity();
@@ -334,10 +334,12 @@ fn main() {
                                 data,
                             };
                             serde_json::to_writer(std::io::stdout(), &output)
-                                .unwrap();
+                                .map_err(|_| ())?;
                         }
+                        Ok(())
                     },
-                );
+                )
+                .unwrap();
             }
             _ => {}
         }

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -23,6 +23,7 @@ use propolis::hw::ibmpc;
 use propolis::hw::ps2ctrl::PS2Ctrl;
 use propolis::hw::uart::LpcUart;
 use propolis::instance::{Instance, ReqState, State};
+use propolis::migrate::Migrator;
 use propolis::vmm::{Builder, Prot};
 use propolis::*;
 
@@ -327,7 +328,7 @@ fn main() {
                     propolis::inventory::Order::Post,
                     |_id, record| {
                         let ent = record.entity();
-                        if let Some(mig_ent) = ent.migrate() {
+                        if let Migrator::Custom(mig_ent) = ent.migrate() {
                             let data = mig_ent.export(ctx);
                             let output = DevExport {
                                 id: record.name().to_string(),


### PR DESCRIPTION
Cleaned up demo from last week for pausing the devices on the source VM, serializing their state, sending them over the transport and finally importing the device state on the destination side.