### PR TITLE
Create Crucible volumes from construction requests

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -16,3 +16,4 @@ slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_deb
 structopt = "0.3"
 thiserror = "1.0"
 uuid = { version = "0.8", features = [ "serde", "v4" ] }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "4090a023b77dcab7a5000057cf2c96cdbb0469b6" }

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -6,7 +6,7 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use uuid::Uuid;
 
@@ -237,7 +237,7 @@ pub struct DiskRequest {
 
     // Crucible related opts
     pub gen: u64,
-    pub volume_construction_request: BTreeMap<String, serde_json::Value>,
+    pub volume_construction_request: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -6,6 +6,7 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use uuid::Uuid;
 
@@ -230,13 +231,13 @@ type DiskFlags = u32;
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct DiskRequest {
     pub name: String,
-    pub address: Vec<SocketAddr>,
     pub slot: Slot,
     pub read_only: bool,
-    pub key: Option<String>,
-    pub gen: u64,
     pub device: String,
-    pub admin: Option<SocketAddr>,
+
+    // Crucible related opts
+    pub gen: u64,
+    pub volume_construction_request: BTreeMap<String, serde_json::Value>,
 }
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]

--- a/client/src/api.rs
+++ b/client/src/api.rs
@@ -6,7 +6,6 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::net::SocketAddr;
 use uuid::Uuid;
 
@@ -237,7 +236,7 @@ pub struct DiskRequest {
 
     // Crucible related opts
     pub gen: u64,
-    pub volume_construction_request: HashMap<String, serde_json::Value>,
+    pub volume_construction_request: crucible::VolumeConstructionRequest,
 }
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]

--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -21,7 +21,7 @@ viona_api = { path = "../viona-api" }
 usdt = { version = "0.2.1", default-features = false }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "1381ad45aaee517f9d9c34b8c8f186e614848415", optional = true }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "4090a023b77dcab7a5000057cf2c96cdbb0469b6", optional = true }
 anyhow = "1"
 slog = "2.7"
 serde = { version = "1" }

--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -21,12 +21,13 @@ viona_api = { path = "../viona-api" }
 usdt = { version = "0.2.1", default-features = false }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "ab6309ced8e06c30354d4a5c87634fb4d205db3f", optional = true }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "1381ad45aaee517f9d9c34b8c8f186e614848415", optional = true }
 anyhow = "1"
 slog = "2.7"
 serde = { version = "1" }
 serde_arrays = "0.1"
 erased-serde = "0.3"
+serde_json = "1.0"
 
 [dev-dependencies]
 crossbeam-channel = "0.5"

--- a/propolis/src/block/crucible.rs
+++ b/propolis/src/block/crucible.rs
@@ -1,6 +1,6 @@
 //! Implement a virtual block device backed by Crucible
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{HashMap, VecDeque};
 use std::io::{Error, ErrorKind, Result};
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Condvar, Mutex};
@@ -33,7 +33,7 @@ impl CrucibleBackend {
     pub fn create(
         disp: &Dispatcher,
         gen: u64,
-        request: BTreeMap<String, serde_json::Value>,
+        request: HashMap<String, serde_json::Value>,
         read_only: bool,
     ) -> Result<Arc<Self>> {
         CrucibleBackend::_create(disp, gen, request, read_only)
@@ -43,7 +43,7 @@ impl CrucibleBackend {
     fn _create(
         disp: &Dispatcher,
         gen: u64,
-        request: BTreeMap<String, serde_json::Value>,
+        request: HashMap<String, serde_json::Value>,
         read_only: bool,
     ) -> anyhow::Result<Arc<Self>, crucible::CrucibleError> {
         slog::info!(

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -265,16 +265,12 @@ impl<'a> MachineInitializer<'a> {
         disk: &propolis_client::api::DiskRequest,
         bdf: pci::Bdf,
     ) -> Result<(), Error> {
-        let addresses = disk.address.clone();
-
-        info!(self.log, "Creating Crucible disk from {:#?}", addresses);
+        info!(self.log, "Creating Crucible disk from {:#?}", disk);
         let be = propolis::block::CrucibleBackend::create(
             self.disp,
-            addresses,
+            disk.gen,
+            disk.volume_construction_request.clone(),
             disk.read_only,
-            disk.key.clone(),
-            Some(disk.gen),
-            disk.admin,
         )?;
 
         info!(self.log, "Creating ChildRegister");

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -203,15 +203,6 @@ async fn instance_ensure(
         ));
     }
 
-    for disk in &disks {
-        if disk.address.len() != 3 {
-            return Err(HttpError::for_bad_request(
-                None,
-                "Crucible requires three targets per disk".to_string(),
-            ));
-        }
-    }
-
     // Handle requsts to an instance that has already been initialized.
     let mut context = server_context.context.lock().await;
     if let Some(ctx) = &*context {

--- a/standalone/src/config.rs
+++ b/standalone/src/config.rs
@@ -1,5 +1,4 @@
 use std::collections::{btree_map, BTreeMap};
-use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -82,7 +81,7 @@ pub struct BlockDevice {
 impl BlockDevice {
     pub fn block_dev(
         &self,
-        disp: &Dispatcher,
+        _disp: &Dispatcher,
     ) -> (Arc<dyn block::Backend>, ChildRegister) {
         match &self.bdtype as &str {
             "file" => {
@@ -100,48 +99,6 @@ impl BlockDevice {
                 )
                 .unwrap();
 
-                let creg = ChildRegister::new(&be, None);
-                (be, creg)
-            }
-            "crucible" => {
-                let mut targets: Vec<SocketAddr> = Vec::new();
-
-                for target in self
-                    .options
-                    .get("targets")
-                    .unwrap()
-                    .as_array()
-                    .unwrap()
-                    .to_vec()
-                {
-                    let addr =
-                        target.as_str().unwrap().to_string().parse().unwrap();
-                    targets.push(addr);
-                }
-
-                let read_only: bool = || -> Option<bool> {
-                    self.options.get("readonly")?.as_str()?.parse().ok()
-                }()
-                .unwrap_or(false);
-
-                let key: Option<String> = self
-                    .options
-                    .get("key")
-                    .map(|x| x.as_str().unwrap().to_string());
-                let gen: Option<u64> = self
-                    .options
-                    .get("gen")
-                    .map(|x| x.as_str())
-                    .flatten()
-                    .map(|x| u64::from_str(x).ok())
-                    .flatten();
-
-                let be = propolis::block::CrucibleBackend::create(
-                    disp, targets, read_only, key, gen, None,
-                )
-                .unwrap();
-
-                // TODO: use volume ID or something for instance name
                 let creg = ChildRegister::new(&be, None);
                 (be, creg)
             }


### PR DESCRIPTION
Change DiskRequest to accept only two fields: gen and a new "volume
construction request". To avoid bringing in that type at this part of
the repo, use a generic map from String to serde_json::Value.

The new Volume::construct function accepts this volume construction
request and allows for Nexus to request arbitrarily shaped volumes. This
PR also changes from Guest to the BlockIO trait to support this.

Remove creating Crucible block backends from the stand alone or server
TOML file.