### PR TITLE
Batch serial console input bytes in CLI

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -249,29 +249,82 @@ async fn serial(
     let _raw_guard = RawTermiosGuard::stdio_guard()
         .with_context(|| anyhow!("failed to set raw mode"))?;
 
-    let mut stdin = tokio::io::stdin();
     let mut stdout = tokio::io::stdout();
-    let mut next_raw = false;
+
+    // https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read_exact
+    // is not cancel safe! Meaning reads from tokio::io::stdin are not cancel
+    // safe. Spawn a separate task to read and put bytes onto this channel.
+    let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+
+    tokio::spawn(async move {
+        let mut stdin = tokio::io::stdin();
+
+        // next_raw must live outside loop, because Ctrl-A should work across
+        // multiple inbuf reads.
+        let mut next_raw = false;
+
+        loop {
+            let mut inbuf = vec![0u8; 1024];
+            let n = match stdin.read(&mut inbuf).await {
+                Err(_) | Ok(0) => break,
+                Ok(n) => n,
+            };
+            inbuf.truncate(n);
+
+            // Put bytes from inbuf to outbuf, but don't send Ctrl-A unless
+            // next_raw is true.
+            let mut outbuf = vec![];
+
+            let mut exit = false;
+            for c in inbuf {
+                match c {
+                    // Ctrl-A means send next one raw
+                    b'\x01' => {
+                        if next_raw {
+                            // Ctrl-A Ctrl-A should be sent as Ctrl-A
+                            outbuf.push(c);
+                            next_raw = false;
+                        } else {
+                            next_raw = true;
+                        }
+                    }
+                    b'\x03' => {
+                        if !next_raw {
+                            // Exit on non-raw Ctrl-C
+                            exit = true;
+                            break;
+                        } else {
+                            // Otherwise send Ctrl-C
+                            outbuf.push(c);
+                            next_raw = false;
+                        }
+                    }
+                    _ => {
+                        outbuf.push(c);
+                        next_raw = false;
+                    }
+                }
+            }
+
+            // Send what we have, even if there's a Ctrl-C at the end.
+            tx.send(outbuf).await.unwrap();
+
+            if exit {
+                break;
+            }
+        }
+    });
 
     loop {
         tokio::select! {
-            c = stdin.read_u8() => {
-                match c? {
-                    // Ctrl-A means send next one raw
-                    b'\x01' if !next_raw => {
-                        next_raw = true;
+            c = rx.recv() => {
+                match c {
+                    None => {
+                        // channel is closed
+                        break;
                     }
-                    c => {
-                        // Exit on non-raw Ctrl-C
-                        if c == b'\x03' && !next_raw {
-                            break;
-                        }
-
-                        ws.send(Message::binary(vec![c])).await?;
-
-                        if next_raw {
-                            next_raw = false;
-                        }
+                    Some(c) => {
+                        ws.send(Message::Binary(c)).await?;
                     },
                 }
             }

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -5,14 +5,12 @@ use dropshot::{
     endpoint, ApiDescription, HttpError, HttpResponseCreated, HttpResponseOk,
     HttpResponseUpdatedNoContent, Path, RequestContext, TypedBody,
 };
-use futures::future::Fuse;
-use futures::{FutureExt, SinkExt, StreamExt};
+use futures::{SinkExt, StreamExt};
 use hyper::upgrade::{self, Upgraded};
 use hyper::{header, Body, Response, StatusCode};
 use slog::{error, info, o, Logger};
 use std::borrow::Cow;
 use std::io::{Error, ErrorKind};
-use std::ops::Range;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::{oneshot, watch, Mutex};
@@ -669,29 +667,9 @@ async fn instance_serial_task(
     actx: &AsyncCtx,
 ) -> Result<(), SerialTaskError> {
     let mut output = [0u8; 1024];
-    let mut cur_output: Option<Range<usize>> = None;
-    let mut cur_input: Option<(Vec<u8>, usize)> = None;
 
     let (mut ws_sink, mut ws_stream) = ws_stream.split();
     loop {
-        let (uart_read, ws_send) = match &cur_output {
-            None => (
-                serial.read_source(&mut output, actx).fuse(),
-                Fuse::terminated(),
-            ),
-            Some(r) => (
-                Fuse::terminated(),
-                ws_sink.send(Message::binary(&output[r.clone()])).fuse(),
-            ),
-        };
-        let (ws_recv, uart_write) = match &cur_input {
-            None => (ws_stream.next().fuse(), Fuse::terminated()),
-            Some((data, consumed)) => (
-                Fuse::terminated(),
-                serial.write_sink(&data[*consumed..], actx).fuse(),
-            ),
-        };
-
         tokio::select! {
             // Poll in the order written
             biased;
@@ -709,39 +687,39 @@ async fn instance_serial_task(
                 break;
             }
 
-            // Write bytes into the UART from the WS
-            written = uart_write => {
-                match written {
+            // Read bytes from the UART to be transmitted out the WS
+            nread = serial.read_source(&mut output, actx) => {
+                match nread {
                     Some(0) | None => break,
                     Some(n) => {
-                        let (data, consumed) = cur_input.as_mut().unwrap();
-                        *consumed += n;
-                        if *consumed == data.len() {
-                            cur_input = None;
-                        }
+                        let data = &output[0..n];
+                        ws_sink.send(Message::binary(data)).await?;
                     }
                 }
             }
 
-            // Transmit bytes from the UART through the WS
-            write_success = ws_send => {
-                write_success?;
-                cur_output = None;
-            }
-
-            // Read bytes from the UART to be transmitted out the WS
-            nread = uart_read => {
-                match nread {
-                    Some(0) | None => break,
-                    Some(n) => { cur_output = Some(0..n) }
-                }
-            }
-
             // Receive bytes from the WS to be injected into the UART
-            msg = ws_recv => {
+            msg = ws_stream.next() => {
                 match msg {
                     Some(Ok(Message::Binary(input))) => {
-                        cur_input = Some((input, 0));
+                        let total = input.len();
+                        let mut i = 0;
+
+                        while i < total {
+                            let nwritten: Option<usize> =
+                                serial.write_sink(&input[i..total], actx).await;
+
+                            match nwritten {
+                                None => {
+                                    // XXX write_sink should always return Some,
+                                    // according to the code.
+                                    panic!("write_sink should always return Some!");
+                                }
+                                Some(n) => {
+                                    i += n;
+                                }
+                            }
+                        }
                     }
                     Some(Ok(Message::Close(..))) | None => break,
                     _ => continue,


### PR DESCRIPTION
In serial task, batch reads from tokio::io::stdin, and send that as one
Binary Websockets message instead of one u8 at a time. This fixes the
dreaded "[6;14R" junk that was seen in serial sessions when the propolis
server was zoned.

I suspect this is due to some timeout logic somewhere in the giant stack
of software that only considers ESC [ a [Control Sequence Introducer][1]
if it's followed by the other bytes "quickly" enough.

There were *many* red herrings during this dive, including the rewriting
of the serial task to use a channel instead of for stdin.read as a
tokio::select branch - reading from tokio::io::stdin isn't cancel safe
so it shouldn't be on one of those branches.

Multiple people have looked at this, and so did I, and going into it
with the assumption that a byte was being lost somewhere caused me to
read a lot of the plumbing code surrounding the UART logic. This commit
also adds some tests for copy_and_consume because I noticed there
weren't any.

This commit also simplifies server's instance_serial_task to only use
two tokio::select branches for UART -> WS, and WS -> UART.

[1]: https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences