### PR TITLE
Let propolis-server package itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/Cargo.lock
 debug.out
 core
+out/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,14 @@ members = [
   "standalone",
 ]
 
+default-members = [
+  "cli",
+  "client",
+  "propolis",
+  "server",
+  "standalone",
+]
+
 [profile.dev]
 panic = "abort"
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [workspace]
 
 members = [
-  "propolis",
   "cli",
   "client",
+  "package",
+  "propolis",
   "server",
   "standalone",
 ]

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -1,0 +1,9 @@
+[package.propolis-server]
+rust.binary_names = ["propolis-server"]
+rust.release = true
+service_name = "propolis-server"
+zone = true
+blobs = [ "alpine.iso", "OVMF_CODE.fd" ]
+[[package.propolis-server.paths]]
+from = "smf/propolis-server"
+to = "/var/svc/manifest/site/propolis-server"

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "propolis-package"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+tokio = "1.17"
+omicron-zone-package = "0.1.2"

--- a/package/README.md
+++ b/package/README.md
@@ -11,5 +11,5 @@ To create the Zone image:
 
 ```rust
 $ cargo build --release
-$ cargo run --bin propolis-package
+$ cargo run -p propolis-package
 ```

--- a/package/README.md
+++ b/package/README.md
@@ -1,0 +1,15 @@
+# Propolis Zone
+
+This binary can be used to produce an Omicron-branded Zone image,
+which consists of the Propolis Server binary (along
+with some auxiliary files) in a specially-formatted tarball.
+
+A manifest describing this Zone image exists in `package-manifest.toml`,
+and the resulting image is created as `out/propolis-server.tar.gz`.
+
+To create the Zone image:
+
+```rust
+$ cargo build --release
+$ cargo run --bin propolis-package
+```

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -1,0 +1,19 @@
+// Copyright 2022 Oxide Computer Company
+
+use anyhow::Result;
+use std::fs::create_dir_all;
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cfg = omicron_zone_package::config::parse("package-manifest.toml")?;
+
+    let output_dir = Path::new("out");
+    create_dir_all(&output_dir)?;
+
+    for package in cfg.packages.values() {
+        package.create(output_dir).await?;
+    }
+
+    Ok(())
+}

--- a/smf/propolis-server/config.toml
+++ b/smf/propolis-server/config.toml
@@ -1,0 +1,24 @@
+# Configuration for propolis server.
+#
+# Refer to https://github.com/oxidecomputer/propolis#readme
+# for more detail on the config format.
+
+bootrom = "/opt/oxide/propolis-server/blob/OVMF_CODE.fd"
+
+[block_dev.alpine_iso]
+type = "file"
+path = "/opt/oxide/propolis-server/blob/alpine.iso"
+readonly = "true"
+
+[dev.block0]
+driver = "pci-virtio-block"
+block_dev = "alpine_iso"
+pci-path = "0.4.0"
+
+# NOTE: This VNIC is here for reference, but VNICs are typically managed by the
+# Sled Agent.
+
+# [dev.net0]
+# driver = "pci-virtio-viona"
+# vnic = "vnic_prop0"
+# pci-path = "0.5.0"

--- a/smf/propolis-server/manifest.xml
+++ b/smf/propolis-server/manifest.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+
+<service_bundle type='manifest' name='propolis-server'>
+
+<service name='system/illumos/propolis-server' type='service' version='1'>
+  <dependency name='network' grouping='require_all' restart_on='none'
+    type='service'>
+  <service_fmri value='svc:/milestone/network:default' />
+  </dependency>
+
+  <method_context>
+    <method_environment>
+      <envvar name="LD_LIBRARY_PATH" value="/opt/ooce/pgsql-13/lib/amd64" />
+    </method_environment>
+  </method_context>
+  <exec_method type='method' name='start'
+    exec='ctrun -l child -o noorphan,regent /opt/oxide/propolis-server/bin/propolis-server run /var/svc/manifest/site/propolis-server/config.toml %{config/server_addr} &amp;'
+    timeout_seconds='0' />
+  <exec_method type='method' name='stop' exec=':kill' timeout_seconds='0' />
+
+  <property_group name='config' type='application'>
+    <propval name='server_addr' type='astring' value='unknown' />
+  </property_group>
+
+  <property_group name='startd' type='framework'>
+    <propval name='duration' type='astring' value='contract' />
+  </property_group>
+
+  <stability value='Unstable' />
+
+  <template>
+    <common_name>
+      <loctext xml:lang='C'>Oxide Propolis Server</loctext>
+    </common_name>
+    <description>
+      <loctext xml:lang='C'>Hypervisor</loctext>
+    </description>
+  </template>
+</service>
+
+</service_bundle>


### PR DESCRIPTION
This change enables propolis-server to publish a zone image, rather than relying on external repos (like [omicron](https://github.com/oxidecomputer/omicron)) to do that themselves.

- This change adds a new package in the Cargo workspace named `propolis-package`, which has the sole responsibility of bundling up a `propolis-server` into the [omicron-brand zone](https://github.com/oxidecomputer/helios-omicron-brand) format.
- This also moves the SMF files and "package manifest" directly from Omicron - they are now "owned" by the Propolis repo.

This change has parity with our packaging for other zone images created outside Omicron, [similar to Crucible](https://github.com/oxidecomputer/crucible/tree/main/package).