### PR TITLE
Generalize Outstanding I/Os waiting logic for devices

### DIFF
--- a/propolis/src/block/file.rs
+++ b/propolis/src/block/file.rs
@@ -1,18 +1,15 @@
-use std::collections::VecDeque;
 use std::fs::{metadata, File, OpenOptions};
 use std::io::{Error, ErrorKind, Result};
 use std::num::NonZeroUsize;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Mutex};
 
 use super::DeviceInfo;
 use crate::block;
-use crate::dispatch::{AsyncCtx, DispCtx, Dispatcher, SyncCtx, WakeFn};
+use crate::dispatch::{DispCtx, Dispatcher};
 use crate::inventory::Entity;
 use crate::vmm::MappingExt;
-
-use tokio::sync::Semaphore;
 
 // XXX: completely arb for now
 const MAX_WORKERS: usize = 32;
@@ -21,10 +18,10 @@ const MAX_WORKERS: usize = 32;
 pub struct FileBackend {
     fp: Arc<File>,
 
-    driver: Mutex<Option<Arc<Driver>>>,
+    driver: Mutex<Option<Arc<block::Driver>>>,
     worker_count: NonZeroUsize,
 
-    is_ro: bool,
+    read_only: bool,
     block_size: usize,
     sectors: usize,
 }
@@ -45,9 +42,9 @@ impl FileBackend {
         let p: &Path = path.as_ref();
 
         let meta = metadata(p)?;
-        let is_ro = readonly || meta.permissions().readonly();
+        let read_only = readonly || meta.permissions().readonly();
 
-        let fp = OpenOptions::new().read(true).write(!is_ro).open(p)?;
+        let fp = OpenOptions::new().read(true).write(!read_only).open(p)?;
         let len = fp.metadata().unwrap().len() as usize;
 
         let this = Self {
@@ -56,7 +53,7 @@ impl FileBackend {
             driver: Mutex::new(None),
             worker_count,
 
-            is_ro,
+            read_only,
             block_size: 512,
             sectors: len / 512,
         };
@@ -64,22 +61,37 @@ impl FileBackend {
         Ok(Arc::new(this))
     }
 }
+
 impl block::Backend for FileBackend {
     fn info(&self) -> DeviceInfo {
         DeviceInfo {
             block_size: self.block_size as u32,
             total_size: self.sectors as u64,
-            writable: !self.is_ro,
+            writable: !self.read_only,
         }
     }
 
-    fn attach(&self, dev: Arc<dyn block::Device>, disp: &Dispatcher) {
+    fn attach(
+        &self,
+        dev: Arc<dyn block::Device>,
+        disp: &Dispatcher,
+    ) -> Result<()> {
         let mut driverg = self.driver.lock().unwrap();
         assert!(driverg.is_none());
 
-        let driver = Driver::new(self.fp.clone(), dev, self.is_ro);
-        driver.spawn(self.worker_count, disp);
+        let fp = Arc::clone(&self.fp);
+        let read_only = self.read_only;
+        let req_handler =
+            Box::new(move |req: &block::Request, ctx: &DispCtx| {
+                process_request(&fp, req, ctx, read_only)
+            });
+
+        // Spawn driver to service block dev requests
+        let driver = Arc::new(block::Driver::new(dev, req_handler));
+        driver.spawn("file", self.worker_count, disp)?;
         *driverg = Some(driver);
+
+        Ok(())
     }
 }
 impl Entity for FileBackend {
@@ -88,127 +100,11 @@ impl Entity for FileBackend {
     }
 }
 
-struct Driver {
-    fp: Arc<File>,
-    is_ro: bool,
-    cv: Condvar,
-    queue: Mutex<VecDeque<block::Request>>,
-    idle_threads: Semaphore,
-    dev: Arc<dyn block::Device>,
-    waiter: block::AsyncWaiter,
-}
-
-impl Driver {
-    fn new(
-        fp: Arc<File>,
-        dev: Arc<dyn block::Device>,
-        is_ro: bool,
-    ) -> Arc<Self> {
-        let waiter = block::AsyncWaiter::new(dev.as_ref());
-        Arc::new(Self {
-            fp,
-            is_ro,
-            cv: Condvar::new(),
-            queue: Mutex::new(VecDeque::new()),
-            idle_threads: Semaphore::new(0),
-            dev,
-            waiter,
-        })
-    }
-
-    fn blocking_loop(&self, sctx: &mut SyncCtx) {
-        let mut idled = false;
-        loop {
-            if sctx.check_yield() {
-                break;
-            }
-
-            let mut guard = self.queue.lock().unwrap();
-            if let Some(req) = guard.pop_front() {
-                drop(guard);
-                idled = false;
-                let ctx = sctx.dispctx();
-                match process_request(&self.fp, &req, &ctx, self.is_ro) {
-                    Ok(_) => req.complete(block::Result::Success, &ctx),
-                    Err(_) => req.complete(block::Result::Failure, &ctx),
-                }
-            } else {
-                // wait until more requests are available
-                if !idled {
-                    self.idle_threads.add_permits(1);
-                    idled = true;
-                }
-                let _guard = self
-                    .cv
-                    .wait_while(guard, |g| {
-                        // While `sctx.check_yield()` is tempting here, it will
-                        // block if this thread goes into a quiesce state,
-                        // excluding all others from the queue lock.
-                        g.is_empty() && !sctx.pending_reqs()
-                    })
-                    .unwrap();
-            }
-        }
-    }
-
-    async fn do_scheduling(&self, actx: &AsyncCtx) {
-        loop {
-            let avail = self.idle_threads.acquire().await.unwrap();
-            avail.forget();
-
-            if let Some(req) = self.waiter.next(self.dev.as_ref(), actx).await {
-                let mut queue = self.queue.lock().unwrap();
-                queue.push_back(req);
-                drop(queue);
-                self.cv.notify_one();
-            }
-        }
-    }
-
-    fn spawn(self: &Arc<Self>, worker_count: NonZeroUsize, disp: &Dispatcher) {
-        for i in 0..worker_count.get() {
-            let tself = Arc::clone(self);
-
-            // Configure a waker to help threads to reach their yield points
-            // Doing this once (from thread 0) is adequate to wake them all.
-            let wake = if i == 0 {
-                let tnotify = Arc::downgrade(self);
-                Some(Box::new(move |_ctx: &DispCtx| {
-                    if let Some(this) = tnotify.upgrade() {
-                        let _guard = this.queue.lock().unwrap();
-                        this.cv.notify_all();
-                    }
-                }) as Box<WakeFn>)
-            } else {
-                None
-            };
-
-            let _ = disp
-                .spawn_sync(
-                    format!("file bdev {}", i),
-                    Box::new(move |mut sctx| {
-                        tself.blocking_loop(&mut sctx);
-                    }),
-                    wake,
-                )
-                .unwrap();
-        }
-
-        let sched_self = Arc::clone(self);
-        let actx = disp.async_ctx();
-        let sched_task = tokio::spawn(async move {
-            sched_self.do_scheduling(&actx).await;
-        });
-        // TODO: do we need to manipulate the task later?
-        disp.track(sched_task);
-    }
-}
-
 fn process_request(
     fp: &File,
     req: &block::Request,
     ctx: &DispCtx,
-    is_ro: bool,
+    read_only: bool,
 ) -> Result<()> {
     let mem = ctx.mctx.memctx();
     match req.oper() {
@@ -223,7 +119,7 @@ fn process_request(
             }
         }
         block::Operation::Write(off) => {
-            if is_ro {
+            if read_only {
                 return Err(Error::new(
                     ErrorKind::PermissionDenied,
                     "backend is read-only",

--- a/propolis/src/block/mod.rs
+++ b/propolis/src/block/mod.rs
@@ -1,13 +1,15 @@
 //! Implements an interface to virtualized block devices.
 
+use std::collections::VecDeque;
+use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 
 use crate::common::*;
-use crate::dispatch::{AsyncCtx, DispCtx, Dispatcher};
+use crate::dispatch::{AsyncCtx, DispCtx, Dispatcher, SyncCtx, WakeFn};
 use crate::vmm::{MemCtx, SubMapping};
 
-use tokio::sync::Notify;
+use tokio::sync::{Notify, Semaphore};
 
 mod file;
 pub use file::FileBackend;
@@ -140,7 +142,11 @@ pub trait Device: Send + Sync + 'static {
 }
 
 pub trait Backend: Send + Sync + 'static {
-    fn attach(&self, dev: Arc<dyn Device>, disp: &Dispatcher);
+    fn attach(
+        &self,
+        dev: Arc<dyn Device>,
+        disp: &Dispatcher,
+    ) -> std::io::Result<()>;
     fn info(&self) -> DeviceInfo;
 }
 
@@ -190,30 +196,171 @@ impl Notifier {
     }
 }
 
-pub struct AsyncWaiter {
+pub type BackendProcessFn =
+    dyn Fn(&Request, &DispCtx) -> std::io::Result<()> + Send + Sync + 'static;
+
+/// Driver used to service requests from a block device with a specific backend.
+pub struct Driver {
+    /// The block device generating the requests to service
+    bdev: Arc<dyn Device>,
+
+    /// Backend provided handler for requests from block device
+    req_handler: Box<BackendProcessFn>,
+
+    /// Queue of I/O requests from the device ready to be serviced by the backend
+    queue: Mutex<VecDeque<Request>>,
+
+    /// Synchronization primitive used to block backend worker threads on requests in the queue
+    cv: Condvar,
+
+    /// Semaphore to block polling block device unless we have idle backend worker threads
+    idle_threads: Semaphore,
+
+    /// Notify handle used by block device to proactively inform us of any new requests
     wake: Arc<Notify>,
 }
-impl AsyncWaiter {
-    pub fn new(attach_dev: &dyn Device) -> Self {
-        let this = Self { wake: Arc::new(Notify::new()) };
-        let wake = Arc::clone(&this.wake);
-        attach_dev
-            .set_notifier(Some(Box::new(move |_dev, _ctx| wake.notify_one())));
-        this
+
+impl Driver {
+    /// Create new `BackendDriver` to service requests for the given block device.
+    pub fn new(
+        bdev: Arc<dyn Device>,
+        req_handler: Box<BackendProcessFn>,
+    ) -> Self {
+        let wake = Arc::new(Notify::new());
+        // Wire up notifier to the block device
+        let bdev_wake = Arc::clone(&wake);
+        bdev.set_notifier(Some(Box::new(move |_dev, _ctx| {
+            bdev_wake.notify_one()
+        })));
+        Self {
+            bdev,
+            req_handler,
+            queue: Mutex::new(VecDeque::new()),
+            cv: Condvar::new(),
+            idle_threads: Semaphore::new(0),
+            wake,
+        }
     }
-    pub async fn next(
-        &self,
-        dev: &dyn Device,
-        actx: &AsyncCtx,
-    ) -> Option<Request> {
+
+    /// Start the given number of worker threads and an async task to feed the worker
+    /// with requests from the block device.
+    pub fn spawn(
+        self: &Arc<Self>,
+        name: &'static str,
+        worker_count: NonZeroUsize,
+        disp: &Dispatcher,
+    ) -> std::io::Result<()> {
+        for i in 0..worker_count.get() {
+            let worker_self = Arc::clone(self);
+
+            // Configure a waker to help threads to reach their yield points
+            // Doing this once (from thread 0) is adequate to wake them all.
+            let wake = if i == 0 {
+                let notify_self = Arc::downgrade(self);
+                Some(Box::new(move |_ctx: &DispCtx| {
+                    if let Some(this) = notify_self.upgrade() {
+                        let _guard = this.queue.lock().unwrap();
+                        this.cv.notify_all();
+                    }
+                }) as Box<WakeFn>)
+            } else {
+                None
+            };
+
+            // Spawn worker thread
+            let _ = disp.spawn_sync(
+                format!("{name} bdev {i}"),
+                Box::new(move |mut sctx| {
+                    worker_self.blocking_loop(&mut sctx);
+                }),
+                wake,
+            )?;
+        }
+
+        // Create async task to get requests from block device and feed the worker threads
+        let sched_self = Arc::clone(self);
+        let sched_actx = disp.async_ctx();
+        let sched_task = tokio::spawn(async move {
+            let _ = sched_self.do_scheduling(&sched_actx).await;
+        });
+        disp.track(sched_task);
+
+        Ok(())
+    }
+
+    /// Worker thread's main-loop: looks for requests to service in the queue.
+    fn blocking_loop(&self, sctx: &mut SyncCtx) {
+        let mut idled = false;
+        loop {
+            if sctx.check_yield() {
+                break;
+            }
+
+            // Check if we've received any requests to process
+            let mut guard = self.queue.lock().unwrap();
+            if let Some(req) = guard.pop_front() {
+                drop(guard);
+                idled = false;
+                let logger = sctx.log().clone();
+                let ctx = sctx.dispctx();
+                match (self.req_handler)(&req, &ctx) {
+                    Ok(()) => req.complete(Result::Success, &ctx),
+                    Err(e) => {
+                        slog::error!(logger, "{e:?} error on req {:?}", req.op);
+                        req.complete(Result::Failure, &ctx)
+                    }
+                }
+            } else {
+                // Wait until more requests are available
+                if !idled {
+                    self.idle_threads.add_permits(1);
+                    idled = true;
+                }
+                let _guard = self
+                    .cv
+                    .wait_while(guard, |g| {
+                        // While `sctx.check_yield()` is tempting here, it will
+                        // block if this thread goes into a quiesce state,
+                        // excluding all others from the queue lock.
+                        g.is_empty() && !sctx.pending_reqs()
+                    })
+                    .unwrap();
+            }
+        }
+    }
+
+    /// Attempt to grab a request from the block device (if one's available)
+    async fn next_req(&self, actx: &AsyncCtx) -> Option<Request> {
         loop {
             {
                 let ctx = actx.dispctx().await?;
-                if let Some(r) = dev.next(&ctx) {
-                    return Some(r);
+                if let Some(req) = self.bdev.next(&ctx) {
+                    return Some(req);
                 }
             }
+
+            // Don't busy-loop on the device but just wait for it to wake us
+            // when the next request is available
             self.wake.notified().await;
+        }
+    }
+
+    /// Scheduling task body: feed worker threads with requests from block device.
+    async fn do_scheduling(&self, actx: &AsyncCtx) {
+        loop {
+            // Are they any idle worker threads?
+            let avail = self.idle_threads.acquire().await.unwrap();
+            // We found an idle thread!
+            // It will increase the permit count once it's done with any work
+            avail.forget();
+
+            // Get the next request to process
+            if let Some(req) = self.next_req(actx).await {
+                let mut queue = self.queue.lock().unwrap();
+                queue.push_back(req);
+                drop(queue);
+                self.cv.notify_one();
+            }
         }
     }
 }

--- a/propolis/src/block/mod.rs
+++ b/propolis/src/block/mod.rs
@@ -306,7 +306,10 @@ impl Notifier {
     /// when the pause operation is complete.
     pub fn pause(&self) {
         // Stop responding to any requests
-        assert!(!self.paused.swap(true, Ordering::Release));
+        let paused = self.paused.swap(true, Ordering::Release);
+
+        // Should not be attempting to pause while already paused
+        assert!(!paused);
 
         // Create a new `Notify` object and stash it in the shared reference
         // given to outstanding I/O requests. We only create the `Notify`

--- a/propolis/src/block/mod.rs
+++ b/propolis/src/block/mod.rs
@@ -55,7 +55,7 @@ pub struct Request {
     /// A list of regions of guest memory to read/write into as part of the I/O request
     regions: Vec<GuestRegion>,
 
-    /// Block devuce specific completion function for this I/O request
+    /// Block device specific completion function for this I/O request
     donef: Option<Box<CompleteFn>>,
 
     /// A shared count of outstanding I/O requests for the block backend handling this request
@@ -308,7 +308,7 @@ impl Notifier {
         // Stop responding to any requests
         assert!(!self.paused.swap(true, Ordering::Release));
 
-        // Create a new `Notify` object and stash it in the shard reference
+        // Create a new `Notify` object and stash it in the shared reference
         // given to outstanding I/O requests. We only create the `Notify`
         // object once we've received a request to stop servicing the guest.
         // We do this so that hitting 0 outstanding requests during the normal

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -221,7 +221,7 @@ impl<'a> MachineInitializer<'a> {
         let id = self.inv.register_instance(&vioblk, bdf.to_string())?;
         let _ = self.inv.register_child(be_register, id).unwrap();
 
-        backend.attach(vioblk.clone(), self.disp);
+        backend.attach(vioblk.clone(), self.disp)?;
         chipset.device().pci_attach(bdf, vioblk);
 
         Ok(())
@@ -240,7 +240,7 @@ impl<'a> MachineInitializer<'a> {
         let id = self.inv.register_instance(&nvme, bdf.to_string())?;
         let _ = self.inv.register_child(be_register, id).unwrap();
 
-        backend.attach(nvme.clone(), self.disp);
+        backend.attach(nvme.clone(), self.disp)?;
         chipset.device().pci_attach(bdf, nvme);
 
         Ok(())

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -224,8 +224,10 @@ fn main() {
                     let id = inv.register_instance(&vioblk, bdf.to_string())?;
                     let _be_id = inv.register_child(creg, id)?;
 
-                    backend
-                        .attach(vioblk.clone() as Arc<dyn block::Device>, disp);
+                    backend.attach(
+                        vioblk.clone() as Arc<dyn block::Device>,
+                        disp,
+                    )?;
 
                     chipset.pci_attach(bdf, vioblk);
                 }
@@ -258,7 +260,7 @@ fn main() {
                     let id = inv.register_instance(&nvme, bdf.to_string())?;
                     let _be_id = inv.register_child(creg, id)?;
 
-                    backend.attach(nvme.clone(), disp);
+                    backend.attach(nvme.clone(), disp)?;
 
                     chipset.pci_attach(bdf, nvme);
                 }


### PR DESCRIPTION
As part of https://github.com/oxidecomputer/propolis/pull/92 I added some logic to wait for outstanding I/O requests to the NVMe device while pausing it during migration. This generalizes the logic to apply to any emulated block device.

Also cleaned up some duplication amongst the block backends.

Fixes #98 