### PR TITLE
buildomat: zone image publish job

### DIFF
--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -27,7 +27,7 @@ cargo --version
 rustc --version
 
 banner build
-ptime -m cargo build --release --verbose
+ptime -m cargo build --release --verbose -p propolis-server
 
 banner image
 ptime -m cargo run -p propolis-package

--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#:
+#: name = "image"
+#: variety = "basic"
+#: target = "helios"
+#: rust_toolchain = "nightly"
+#: output_rules = [
+#:   "/out/*",
+#: ]
+#:
+#: [[publish]]
+#: series = "image"
+#: name = "propolis-server.tar.gz"
+#: from_output = "/out/propolis-server.tar.gz"
+#:
+#: [[publish]]
+#: series = "image"
+#: name = "propolis-server.sha256.txt"
+#: from_output = "/out/propolis-server.sha256.txt"
+#:
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+cargo --version
+rustc --version
+
+banner build
+ptime -m cargo build --release --verbose
+
+banner image
+ptime -m cargo run -p propolis-package
+
+banner contents
+tar tvfz out/propolis-server.tar.gz
+
+banner copy
+pfexec mkdir -p /out
+pfexec chown "$UID" /out
+mv out/propolis-server.tar.gz /out/propolis-server.tar.gz
+cd /out
+digest -a sha256 propolis-server.tar.gz > propolis-server.sha256.txt


### PR DESCRIPTION
This is basically https://github.com/oxidecomputer/crucible/pull/246 , but for Propolis.

This PR should publish the `propolis-server` zone image at:

https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/e131374d400a14674dab5eccbafcf994657c55fe/propolis-server.tar.gz