### PR TITLE
Disambiguate block backend instances in inventory.

### DIFF
--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1" }
 serde_arrays = "0.1"
 erased-serde = "0.3"
 serde_json = "1.0"
+uuid = "0.8"
 
 [dev-dependencies]
 crossbeam-channel = "0.5"

--- a/propolis/src/block/crucible.rs
+++ b/propolis/src/block/crucible.rs
@@ -71,6 +71,11 @@ impl CrucibleBackend {
 
         Ok(Arc::new(be))
     }
+
+    /// Retrieve the UUID identifying this Crucible backend.
+    pub fn get_uuid(&self) -> Result<uuid::Uuid> {
+        self.block_io.get_uuid().map_err(map_crucible_error_to_io)
+    }
 }
 
 impl block::Backend for CrucibleBackend {

--- a/server/src/lib/config.rs
+++ b/server/src/lib/config.rs
@@ -140,7 +140,8 @@ impl BlockDevice {
                 let be = propolis::block::FileBackend::create(
                     path, readonly, nworkers,
                 )?;
-                let child = inventory::ChildRegister::new(&be, None);
+                let child =
+                    inventory::ChildRegister::new(&be, Some(path.to_string()));
 
                 Ok((be, child))
             }

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -273,7 +273,7 @@ impl<'a> MachineInitializer<'a> {
         )?;
 
         info!(self.log, "Creating ChildRegister");
-        let creg = ChildRegister::new(&be, None);
+        let creg = ChildRegister::new(&be, Some(be.get_uuid()?.to_string()));
 
         match disk.device.as_ref() {
             "virtio" => {
@@ -300,6 +300,7 @@ impl<'a> MachineInitializer<'a> {
     pub fn initialize_in_memory_virtio_from_bytes(
         &self,
         chipset: &RegisteredChipset,
+        name: impl Into<String>,
         bytes: Vec<u8>,
         bdf: pci::Bdf,
         read_only: bool,
@@ -309,7 +310,7 @@ impl<'a> MachineInitializer<'a> {
             propolis::block::InMemoryBackend::create(bytes, read_only, 512)?;
 
         info!(self.log, "Creating ChildRegister");
-        let creg = ChildRegister::new(&be, None);
+        let creg = ChildRegister::new(&be, Some(name.into()));
 
         info!(self.log, "Calling initialize_virtio_block");
         self.initialize_virtio_block(chipset, bdf, be, creg)

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -328,7 +328,11 @@ async fn instance_ensure(
                 })?;
 
                 init.initialize_in_memory_virtio_from_bytes(
-                    &chipset, bytes, bdf, true,
+                    &chipset,
+                    "cloud-init",
+                    bytes,
+                    bdf,
+                    true,
                 )?;
 
                 info!(rqctx.log, "cloud-init disk created");

--- a/standalone/src/config.rs
+++ b/standalone/src/config.rs
@@ -99,7 +99,7 @@ impl BlockDevice {
                 )
                 .unwrap();
 
-                let creg = ChildRegister::new(&be, None);
+                let creg = ChildRegister::new(&be, Some(path.to_string()));
                 (be, creg)
             }
             _ => {


### PR DESCRIPTION
At some point I updated the device inventory to return an error if you tried to add the same instance twice. It does this by keeping track of what's been added so far based on the type name (via `Entity::type_name`) which is generic to all instances of that type and the instance name, which is an optional parameter to the inventory methods used for adding items.

There are certain kinds of devices we only ever expect a single instance of to be present and thus never give instance-specific names to. The block backends were mistakenly being treated as such and thus if you ever had more than one it would fail upon trying to instantiate the second one, e.g. you couldn't have two disks both backed by a file even if they were using separate files.

The fix is simple enough: fill in the instance-specific portions for each of the block backends we support today:
1. **File**: we simply use the file path for the instance name. (*)
2. **Crucible**: use the UUID associated with the specific crucible backend.
3. **In-Memory**: require specifying an instance name up front (just `"cloud-init"` today).

(*) Note, it is still possible to run into conflicts with the File backend if one uses the same file for 2 different backends. For the most part I don't think this is a scenario that's necessary to support.