### PR TITLE
Add skeleton support for VNC server.

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,11 +18,11 @@ doc = false
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1.53"
 bit_field = "0.10.1"
 bitvec = "1.0"
 bytes = "1.1"
 const_format = "0.2"
-# dropshot = "0.6"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
 erased-serde = "0.3"
 futures = "0.3"
@@ -42,6 +42,7 @@ slog = "2.7"
 structopt = { version = "0.3", default-features = false }
 propolis = { path = "../propolis", features = ["crucible"], default-features = false }
 propolis-client = { path = "../client" }
+rfb = { git = "https://github.com/oxidecomputer/rfb", rev = "7c16e55" }
 uuid = "0.8"
 base64 = "0.13"
 

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -316,7 +316,7 @@ impl<'a> MachineInitializer<'a> {
         self.initialize_virtio_block(chipset, bdf, be, creg)
     }
 
-    pub fn initialize_fwcfg(&self, cpus: u8) -> Result<(), Error> {
+    pub fn initialize_fwcfg(&self, cpus: u8) -> Result<EntityID, Error> {
         let mut fwcfg = fwcfg::FwCfgBuilder::new();
         fwcfg
             .add_legacy(
@@ -333,8 +333,8 @@ impl<'a> MachineInitializer<'a> {
         fwcfg_dev.attach(pio);
 
         self.inv.register(&fwcfg_dev)?;
-        self.inv.register(&ramfb)?;
-        Ok(())
+        let ramfb_id = self.inv.register(&ramfb)?;
+        Ok(ramfb_id)
     }
 
     pub fn initialize_cpus(&self) -> Result<(), Error> {

--- a/server/src/lib/lib.rs
+++ b/server/src/lib/lib.rs
@@ -6,3 +6,4 @@ mod initializer;
 mod migrate;
 mod serial;
 pub mod server;
+pub mod vnc;

--- a/server/src/lib/vnc.rs
+++ b/server/src/lib/vnc.rs
@@ -1,0 +1,125 @@
+use async_trait::async_trait;
+use propolis::common::GuestAddr;
+use propolis::dispatch::AsyncCtx;
+use propolis::hw::qemu::ramfb::Config;
+use rfb::encodings::RawEncoding;
+use rfb::rfb::{FramebufferUpdate, Rectangle};
+use rfb::server::Server;
+use slog::{debug, error, Logger};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[derive(Debug)]
+pub struct RamFb {
+    addr: u64,
+    width: u32,
+    height: u32,
+}
+
+impl RamFb {
+    pub fn new(addr: u64, width: u32, height: u32) -> Self {
+        Self { addr, width, height }
+    }
+}
+
+struct DefaultFb {
+    width: u16,
+    height: u16,
+}
+
+enum Framebuffer {
+    Uninitialized(DefaultFb),
+    Initialized(RamFb),
+}
+
+#[derive(Clone)]
+pub struct PropolisVncServer {
+    framebuffer: Arc<Mutex<Framebuffer>>,
+    actx: Arc<Mutex<Option<AsyncCtx>>>,
+    log: Logger,
+}
+
+impl PropolisVncServer {
+    pub fn new(initial_width: u16, initial_height: u16, log: Logger) -> Self {
+        PropolisVncServer {
+            framebuffer: Arc::new(Mutex::new(Framebuffer::Uninitialized(
+                DefaultFb { width: initial_width, height: initial_height },
+            ))),
+            actx: Arc::new(Mutex::new(None)),
+            log,
+        }
+    }
+
+    pub async fn set_async_ctx(&self, actx: AsyncCtx) {
+        let mut locked = self.actx.lock().await;
+        *locked = Some(actx);
+    }
+
+    pub async fn initialize_framebuffer(&self, fb: RamFb) {
+        if fb.addr != 0 {
+            let mut locked = self.framebuffer.lock().await;
+            *locked = Framebuffer::Initialized(fb);
+        }
+    }
+
+    pub async fn update(&self, config: &Config, is_valid: bool) {
+        if is_valid {
+            debug!(self.log, "updating framebuffer");
+            let (addr, w, h) = config.get_framebuffer_info();
+            let fb = RamFb::new(addr, w, h);
+            self.initialize_framebuffer(fb).await;
+        } else {
+            error!(self.log, "invalid config update");
+        }
+    }
+}
+
+#[async_trait]
+impl Server for PropolisVncServer {
+    async fn get_framebuffer_update(&self) -> FramebufferUpdate {
+        let locked = self.framebuffer.lock().await;
+        let fb = match &*locked {
+            Framebuffer::Uninitialized(fb) => {
+                debug!(self.log, "framebuffer: uninitialized");
+
+                // Display a white screen if the guest isn't ready yet.
+                let len: usize = fb.width as usize * fb.height as usize * 4;
+                let pixels = vec![0xffu8; len];
+                let r = Rectangle::new(
+                    0,
+                    0,
+                    fb.width,
+                    fb.height,
+                    Box::new(RawEncoding::new(pixels)),
+                );
+                FramebufferUpdate::new(vec![r])
+            }
+            Framebuffer::Initialized(fb) => {
+                debug!(self.log, "framebuffer initialized={:?}", fb);
+
+                let len = fb.height as usize * fb.width as usize * 4;
+                let mut buf = vec![0u8; len];
+
+                let locked = self.actx.lock().await;
+                let actx = locked.as_ref().unwrap();
+                let memctx = actx.dispctx().await.unwrap().mctx.memctx();
+                let read = memctx.read_into(GuestAddr(fb.addr), &mut buf, len);
+                drop(memctx);
+
+                assert!(read.is_some());
+                debug!(self.log, "read {} bytes from guest", read.unwrap());
+
+                let r = Rectangle::new(
+                    0,
+                    0,
+                    fb.width as u16,
+                    fb.height as u16,
+                    Box::new(RawEncoding::new(buf)),
+                );
+                FramebufferUpdate::new(vec![r])
+            }
+        };
+
+        fb
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -9,12 +9,17 @@ use anyhow::anyhow;
 use dropshot::{
     ConfigDropshot, ConfigLogging, ConfigLoggingLevel, HttpServerStarter,
 };
+use futures::join;
 use propolis::usdt::register_probes;
-use slog::info;
-use std::net::SocketAddr;
+use rfb::rfb::{ProtoVersion, SecurityType, SecurityTypes};
+use rfb::server::VncServer;
+use rfb::server::{VncServerConfig, VncServerData};
+use slog::{info, o, Logger};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use structopt::StructOpt;
 
+use propolis_server::vnc::PropolisVncServer;
 use propolis_server::{config, server};
 
 #[derive(Debug, StructOpt)]
@@ -45,6 +50,32 @@ pub fn run_openapi() -> Result<(), String> {
         .map_err(|e| e.to_string())
 }
 
+fn setup_vnc(log: &Logger) -> VncServer<PropolisVncServer> {
+    // XXX: Do we want to specify this information in the config file?
+    let initial_width = 1024;
+    let initial_height = 768;
+
+    let config = VncServerConfig {
+        addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 5900),
+        version: ProtoVersion::Rfb38,
+        // vncviewer won't work without offering VncAuth, even though it doesn't ask to use
+        // it.
+        sec_types: SecurityTypes(vec![
+            SecurityType::None,
+            SecurityType::VncAuthentication,
+        ]),
+        name: "propolis-vnc".to_string(),
+    };
+    let data = VncServerData { width: initial_width, height: initial_height };
+    let pvnc = PropolisVncServer::new(
+        initial_width,
+        initial_height,
+        log.new(o!("component" => "vnc-server")),
+    );
+
+    VncServer::new(pvnc, config, data)
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Ensure proper setup of USDT probes
@@ -72,7 +103,12 @@ async fn main() -> anyhow::Result<()> {
                 |error| anyhow!("failed to create logger: {}", error),
             )?;
 
-            let context = server::Context::new(config, log.new(slog::o!()));
+            let vnc_server = setup_vnc(&log);
+            let vnc_server_hdl = vnc_server.clone();
+
+            let context =
+                server::Context::new(config, vnc_server, log.new(slog::o!()));
+
             info!(log, "Starting server...");
             let server = HttpServerStarter::new(
                 &config_dropshot,
@@ -82,8 +118,9 @@ async fn main() -> anyhow::Result<()> {
             )
             .map_err(|error| anyhow!("Failed to start server: {}", error))?
             .start();
-            server
-                .await
+
+            let (server_res, _) = join!(server, vnc_server_hdl.start());
+            server_res
                 .map_err(|e| anyhow!("Server exited with an error: {}", e))
         }
     }


### PR DESCRIPTION
  # Summary

This PR implements prototype-level support in `propolis-server` for connecting to a propolis VM over VNC. Specifically:
- propolis-server now has a vnc server listening on port 5900 (the bulk of the work for the server implemented in the [rfb](https://github.com/oxidecomputer/rfb) crate)
- one can connect to the port with a VNC client prior to starting the guest and see a blank white screen
- after the guest is started, the contents of the VM framebuffer should be visible in a VNC client ([noVNC](https://github.com/novnc/noVNC) and tigervnc both seem to work on linux)

See the "Examples" section below for what this looks like in noVNC.

There's a lot left to implement. Broadly, this includes:
- support for input devices (the keyboard and mouse events are sent to the vnc server, but propolis does not yet have device support here)
- more encoding support. Currently the only encoding supported is Raw.
- a fair amount of additional protocol support in the rfb crate (such as using the encodings, color format, and pixel format requested by the client)
- addition of vnc support in `propolis-standalone`

Still, I am making this PR now in the interest of merging often and making review easier as this project is ongoing and has a lot of moving parts.

## Overview of Changes
* Addition of the [rfb](https://github.com/oxidecomputer/rfb) crate: This crate implements a server-side implementation of RFB, the protocol that VNC uses. Consumers use the crate by implementing the `rfb::server::Server` trait, which for now only requires a method to provide framebuffer data.
* The new `PropolisVncServer` struct implements `rfb::server::Server`, which calls into the guest memory if the guest has been initialized (otherwise, it provides a white screen). A handle to this server is hung off the server Context that each dropshot endpoint gets. The propolis `RamFb` device notifies `PropolisVncServer` of updates when it's updated via `fwcfg_rw`.
* I plumbed the `RamFb` entity ID through the intializer code so that its notifier function could be updated when an instance is created (`instance_ensure`).
* The vnc server is created, kicked off, and awaited in `server/src/main.rs`.

## Examples

### Example Uninitialized Framebuffer (guest not started)
Here's an example of connecting without a guest running. I chose to make the screen white instead of black to differentiate between the framebuffer not being sent at all (which renders as black on some clients).
![example-uninitialized](https://user-images.githubusercontent.com/6669371/162861668-4e331945-506c-45b9-bed5-a688437ef8ae.png)

### Example Initialized Framebuffer (guest started)
Here's a low-ish quality gif demonstrating what it looks like to connect to propolis-server over VNC, then create a VM and run it. (It looks better on a real client, I promise).

A couple of things to note here:
- the client here (noVNC) leaves the old white background when the screen resolution changes. If I refresh the client this goes away. I'm not sure if this a bug on my end or the client; in any event I should probably figure out how to fix it.
- The serial console prompt at the end only happens if I run the `serial` command on the CLI. I'm not sure why this is, or if we should expect to see the serial console here by default (I would think so).

![example-initialized](https://user-images.githubusercontent.com/6669371/162865336-e5890f3b-2d20-4f34-93cb-c31bb9327b57.gif)

