### PR TITLE
no longer can we only boot alpine

### DIFF
--- a/smf/propolis-server/config.toml
+++ b/smf/propolis-server/config.toml
@@ -5,16 +5,6 @@
 
 bootrom = "/opt/oxide/propolis-server/blob/OVMF_CODE.fd"
 
-[block_dev.alpine_iso]
-type = "file"
-path = "/opt/oxide/propolis-server/blob/alpine.iso"
-readonly = "true"
-
-[dev.block0]
-driver = "pci-virtio-block"
-block_dev = "alpine_iso"
-pci-path = "0.4.0"
-
 # NOTE: This VNIC is here for reference, but VNICs are typically managed by the
 # Sled Agent.
 


### PR DESCRIPTION
Remove alpine block dev so that after the global images PR lands, there
isn't a boot device conflict.