### PR TITLE
Fix failing integration test due to changed server::Context constructor.

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -11,15 +11,12 @@ use dropshot::{
 };
 use futures::join;
 use propolis::usdt::register_probes;
-use rfb::rfb::{ProtoVersion, SecurityType, SecurityTypes};
-use rfb::server::VncServer;
-use rfb::server::{VncServerConfig, VncServerData};
-use slog::{info, o, Logger};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use slog::info;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
-use propolis_server::vnc::PropolisVncServer;
+use propolis_server::vnc::setup_vnc;
 use propolis_server::{config, server};
 
 #[derive(Debug, StructOpt)]
@@ -48,32 +45,6 @@ pub fn run_openapi() -> Result<(), String> {
         .contact_email("api@oxide.computer")
         .write(&mut std::io::stdout())
         .map_err(|e| e.to_string())
-}
-
-fn setup_vnc(log: &Logger) -> VncServer<PropolisVncServer> {
-    // XXX: Do we want to specify this information in the config file?
-    let initial_width = 1024;
-    let initial_height = 768;
-
-    let config = VncServerConfig {
-        addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 5900),
-        version: ProtoVersion::Rfb38,
-        // vncviewer won't work without offering VncAuth, even though it doesn't ask to use
-        // it.
-        sec_types: SecurityTypes(vec![
-            SecurityType::None,
-            SecurityType::VncAuthentication,
-        ]),
-        name: "propolis-vnc".to_string(),
-    };
-    let data = VncServerData { width: initial_width, height: initial_height };
-    let pvnc = PropolisVncServer::new(
-        initial_width,
-        initial_height,
-        log.new(o!("component" => "vnc-server")),
-    );
-
-    VncServer::new(pvnc, config, data)
 }
 
 #[tokio::main]

--- a/server/tests/integration_tests.rs
+++ b/server/tests/integration_tests.rs
@@ -6,6 +6,7 @@ use propolis_client::{Client, Error as ClientError};
 use propolis_server::{
     config::{BlockDevice, Config, Device},
     server,
+    vnc::setup_vnc,
 };
 use slog::{o, Logger};
 use std::collections::BTreeMap;
@@ -59,8 +60,9 @@ async fn initialize_server(log: &Logger) -> HttpServer<server::Context> {
     let mut devices = BTreeMap::new();
     devices.insert("block0".to_string(), dev);
 
+    let vnc_server = setup_vnc(&log);
     let config = Config::new(artifacts.bootrom.path(), devices, block_devices);
-    let context = server::Context::new(config, log.new(slog::o!()));
+    let context = server::Context::new(config, vnc_server, log.new(slog::o!()));
 
     let config_dropshot = ConfigDropshot {
         bind_address: "127.0.0.1:0".parse().unwrap(),


### PR DESCRIPTION
I changed the `server::Context` constructor in #113, which made an integration test no longer compile. This fixes that test.