### PR TITLE
Use less IDs in paths

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -317,7 +317,7 @@ async fn test_stdin_to_websockets_task() {
 }
 
 async fn serial(addr: SocketAddr) -> anyhow::Result<()> {
-    let path = format!("ws://{}/instances/serial", addr);
+    let path = format!("ws://{}/instance/serial", addr);
     let (mut ws, _) = tokio_tungstenite::connect_async(path)
         .await
         .with_context(|| anyhow!("failed to create serial websocket stream"))?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -73,32 +73,20 @@ enum Command {
     },
 
     /// Get the properties of a propolis instance
-    Get {
-        /// Instance name
-        name: String,
-    },
+    Get,
 
     /// Transition the instance to a new state
     State {
-        /// Instance name
-        name: String,
-
         /// The requested state
         #[structopt(parse(try_from_str = parse_state))]
         state: InstanceStateRequested,
     },
 
     /// Drop to a Serial console connected to the instance
-    Serial {
-        /// Instance name
-        name: String,
-    },
+    Serial,
 
     /// Migrate instance to new propolis-server
     Migrate {
-        /// Instance name
-        name: String,
-
         /// Destination propolis-server address
         #[structopt(parse(try_from_str = resolve_host))]
         dst_server: IpAddr,
@@ -193,16 +181,9 @@ async fn new_instance(
     Ok(())
 }
 
-async fn get_instance(client: &Client, name: String) -> anyhow::Result<()> {
-    // Grab the Instance UUID
-    let id = client
-        .instance_get_uuid(&name)
-        .await
-        .with_context(|| anyhow!("failed to get instance UUID"))?;
-
-    // Get the rest of the Instance properties
+async fn get_instance(client: &Client) -> anyhow::Result<()> {
     let res = client
-        .instance_get(id)
+        .instance_get()
         .await
         .with_context(|| anyhow!("failed to get instance properties"))?;
 
@@ -213,17 +194,10 @@ async fn get_instance(client: &Client, name: String) -> anyhow::Result<()> {
 
 async fn put_instance(
     client: &Client,
-    name: String,
     state: InstanceStateRequested,
 ) -> anyhow::Result<()> {
-    // Grab the Instance UUID
-    let id = client
-        .instance_get_uuid(&name)
-        .await
-        .with_context(|| anyhow!("failed to get instance UUID"))?;
-
     client
-        .instance_state_put(id, state)
+        .instance_state_put(state)
         .await
         .with_context(|| anyhow!("failed to set instance state"))?;
 
@@ -342,18 +316,8 @@ async fn test_stdin_to_websockets_task() {
     assert!(wsrx.recv().await.is_none());
 }
 
-async fn serial(
-    client: &Client,
-    addr: SocketAddr,
-    name: String,
-) -> anyhow::Result<()> {
-    // Grab the Instance UUID
-    let id = client
-        .instance_get_uuid(&name)
-        .await
-        .with_context(|| anyhow!("failed to get instance UUID"))?;
-
-    let path = format!("ws://{}/instances/{}/serial", addr, id);
+async fn serial(addr: SocketAddr) -> anyhow::Result<()> {
+    let path = format!("ws://{}/instances/serial", addr);
     let (mut ws, _) = tokio_tungstenite::connect_async(path)
         .await
         .with_context(|| anyhow!("failed to create serial websocket stream"))?;
@@ -417,21 +381,15 @@ async fn serial(
 async fn migrate_instance(
     src_client: Client,
     dst_client: Client,
-    src_name: String,
     src_addr: SocketAddr,
     dst_uuid: Uuid,
 ) -> anyhow::Result<()> {
-    // Grab the src instance UUID
-    let src_uuid = src_client
-        .instance_get_uuid(&src_name)
-        .await
-        .with_context(|| anyhow!("failed to get src instance UUID"))?;
-
     // Grab the instance details
     let src_instance = src_client
-        .instance_get(src_uuid)
+        .instance_get()
         .await
         .with_context(|| anyhow!("failed to get src instance properties"))?;
+    let src_uuid = src_instance.instance.properties.id;
 
     let request = InstanceEnsureRequest {
         properties: InstanceProperties {
@@ -452,11 +410,11 @@ async fn migrate_instance(
 
     // Get the source instance ready
     src_client
-        .instance_state_put(src_uuid, InstanceStateRequested::MigrateStart)
+        .instance_state_put(InstanceStateRequested::MigrateStart)
         .await
         .with_context(|| {
-            anyhow!("failed to place src instance in migrate start state")
-        })?;
+        anyhow!("failed to place src instance in migrate start state")
+    })?;
 
     // Initiate the migration via the destination instance
     let migration_id = dst_client
@@ -475,10 +433,8 @@ async fn migrate_instance(
     .map(|(role, client, id)| {
         tokio::spawn(async move {
             loop {
-                let state = client
-                    .instance_migrate_status(id, migration_id)
-                    .await?
-                    .state;
+                let state =
+                    client.instance_migrate_status(migration_id).await?.state;
                 println!("{}({}) migration state={:?}", role, id, state);
                 if state == MigrationState::Finish {
                     return Ok::<_, anyhow::Error>(());
@@ -542,16 +498,14 @@ async fn main() -> anyhow::Result<()> {
             )
             .await?
         }
-        Command::Get { name } => get_instance(&client, name).await?,
-        Command::State { name, state } => {
-            put_instance(&client, name, state).await?
-        }
-        Command::Serial { name } => serial(&client, addr, name).await?,
-        Command::Migrate { name, dst_server, dst_port, dst_uuid } => {
+        Command::Get => get_instance(&client).await?,
+        Command::State { state } => put_instance(&client, state).await?,
+        Command::Serial => serial(addr).await?,
+        Command::Migrate { dst_server, dst_port, dst_uuid } => {
             let dst_addr = SocketAddr::new(dst_server, dst_port);
             let dst_client = Client::new(dst_addr, log.clone());
             let dst_uuid = dst_uuid.unwrap_or_else(Uuid::new_v4);
-            migrate_instance(client, dst_client, name, addr, dst_uuid).await?
+            migrate_instance(client, dst_client, addr, dst_uuid).await?
         }
     }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -109,7 +109,7 @@ impl Client {
         &self,
         request: &api::InstanceEnsureRequest,
     ) -> Result<api::InstanceEnsureResponse, Error> {
-        let path = format!("http://{}/instances", self.address,);
+        let path = format!("http://{}/instance", self.address,);
         let body = Body::from(serde_json::to_string(&request).unwrap());
         self.put(path, Some(body)).await
     }
@@ -118,7 +118,7 @@ impl Client {
     pub async fn instance_get(
         &self,
     ) -> Result<api::InstanceGetResponse, Error> {
-        let path = format!("http://{}/instances", self.address);
+        let path = format!("http://{}/instance", self.address);
         self.get(path, None).await
     }
 
@@ -127,7 +127,7 @@ impl Client {
         &self,
         gen: u64,
     ) -> Result<api::InstanceStateMonitorResponse, Error> {
-        let path = format!("http://{}/instances/state-monitor", self.address);
+        let path = format!("http://{}/instance/state-monitor", self.address);
         let body = Body::from(
             serde_json::to_string(&api::InstanceStateMonitorRequest { gen })
                 .unwrap(),
@@ -140,7 +140,7 @@ impl Client {
         &self,
         state: api::InstanceStateRequested,
     ) -> Result<(), Error> {
-        let path = format!("http://{}/instances/state", self.address);
+        let path = format!("http://{}/instance/state", self.address);
         let body = Body::from(serde_json::to_string(&state).unwrap());
         self.put_no_response(path, Some(body)).await
     }
@@ -150,7 +150,7 @@ impl Client {
         &self,
         migration_id: Uuid,
     ) -> Result<api::InstanceMigrateStatusResponse, Error> {
-        let path = format!("http://{}/instances/migrate/status", self.address);
+        let path = format!("http://{}/instance/migrate/status", self.address);
         let body = Body::from(
             serde_json::to_string(&api::InstanceMigrateStatusRequest {
                 migration_id,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -109,10 +109,7 @@ impl Client {
         &self,
         request: &api::InstanceEnsureRequest,
     ) -> Result<api::InstanceEnsureResponse, Error> {
-        let path = format!(
-            "http://{}/instances/{}",
-            self.address, request.properties.id
-        );
+        let path = format!("http://{}/instances", self.address,);
         let body = Body::from(serde_json::to_string(&request).unwrap());
         self.put(path, Some(body)).await
     }
@@ -120,26 +117,17 @@ impl Client {
     /// Returns information about an instance, by UUID.
     pub async fn instance_get(
         &self,
-        id: Uuid,
     ) -> Result<api::InstanceGetResponse, Error> {
-        let path = format!("http://{}/instances/{}", self.address, id);
-        self.get(path, None).await
-    }
-
-    /// Gets instance UUID, by name.
-    pub async fn instance_get_uuid(&self, name: &str) -> Result<Uuid, Error> {
-        let path = format!("http://{}/instances/{}/uuid", self.address, name);
+        let path = format!("http://{}/instances", self.address);
         self.get(path, None).await
     }
 
     /// Long-poll for state changes.
     pub async fn instance_state_monitor(
         &self,
-        id: Uuid,
         gen: u64,
     ) -> Result<api::InstanceStateMonitorResponse, Error> {
-        let path =
-            format!("http://{}/instances/{}/state-monitor", self.address, id);
+        let path = format!("http://{}/instances/state-monitor", self.address);
         let body = Body::from(
             serde_json::to_string(&api::InstanceStateMonitorRequest { gen })
                 .unwrap(),
@@ -150,10 +138,9 @@ impl Client {
     /// Puts an instance into a new state.
     pub async fn instance_state_put(
         &self,
-        id: Uuid,
         state: api::InstanceStateRequested,
     ) -> Result<(), Error> {
-        let path = format!("http://{}/instances/{}/state", self.address, id);
+        let path = format!("http://{}/instances/state", self.address);
         let body = Body::from(serde_json::to_string(&state).unwrap());
         self.put_no_response(path, Some(body)).await
     }
@@ -161,11 +148,9 @@ impl Client {
     /// Get the status of an ongoing migration
     pub async fn instance_migrate_status(
         &self,
-        id: Uuid,
         migration_id: Uuid,
     ) -> Result<api::InstanceMigrateStatusResponse, Error> {
-        let path =
-            format!("http://{}/instances/{}/migrate/status", self.address, id);
+        let path = format!("http://{}/instances/migrate/status", self.address);
         let body = Body::from(
             serde_json::to_string(&api::InstanceMigrateStatusRequest {
                 migration_id,

--- a/server/src/lib/migrate/mod.rs
+++ b/server/src/lib/migrate/mod.rs
@@ -378,7 +378,7 @@ pub async fn dest_initiate(
     // TODO: https
     // TODO: We need to make sure the src_addr is a valid target
     let src_migrate_url = format!(
-        "http://{}/instances/{}/migrate/start",
+        "http://{}/instance/{}/migrate/start",
         migrate_info.src_addr, migrate_info.src_uuid
     );
     info!(log, "Begin migration"; "src_migrate_url" => &src_migrate_url);

--- a/server/src/lib/migrate/mod.rs
+++ b/server/src/lib/migrate/mod.rs
@@ -244,7 +244,6 @@ struct Device {
 /// connection and begin the migration in a separate task.
 pub async fn source_start(
     rqctx: Arc<RequestContext<Context>>,
-    instance_id: Uuid,
     migration_id: Uuid,
 ) -> Result<Response<Body>, MigrateError> {
     // Create a new log context for the migration
@@ -257,10 +256,6 @@ pub async fn source_start(
     let mut context = rqctx.context().context.lock().await;
     let context =
         context.as_mut().ok_or_else(|| MigrateError::InstanceNotInitialized)?;
-
-    if instance_id != context.properties.id {
-        return Err(MigrateError::UuidMismatch);
-    }
 
     // Bail if the instance hasn't been preset to Migrate Start state.
     if !matches!(
@@ -359,7 +354,6 @@ pub async fn source_start(
 /// process (destination-side).
 pub async fn dest_initiate(
     rqctx: Arc<RequestContext<Context>>,
-    instance_id: Uuid,
     migrate_info: api::InstanceMigrateInitiateRequest,
 ) -> Result<api::InstanceMigrateInitiateResponse, MigrateError> {
     let migration_id = migrate_info.migration_id;
@@ -375,10 +369,6 @@ pub async fn dest_initiate(
     let mut context = rqctx.context().context.lock().await;
     let context =
         context.as_mut().ok_or_else(|| MigrateError::InstanceNotInitialized)?;
-
-    if instance_id != context.properties.id {
-        return Err(MigrateError::UuidMismatch);
-    }
 
     let mut migrate_task = rqctx.context().migrate_task.lock().await;
 

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -553,7 +553,7 @@ async fn instance_ensure(
 
 #[endpoint {
     method = GET,
-    path = "/instances",
+    path = "/instance",
 }]
 async fn instance_get(
     rqctx: Arc<RequestContext<Context>>,
@@ -587,7 +587,7 @@ async fn instance_get(
 
 #[endpoint {
     method = GET,
-    path = "/instances/state-monitor",
+    path = "/instance/state-monitor",
 }]
 async fn instance_state_monitor(
     rqctx: Arc<RequestContext<Context>>,
@@ -622,7 +622,7 @@ async fn instance_state_monitor(
 
 #[endpoint {
     method = PUT,
-    path = "/instances/state",
+    path = "/instance/state",
 }]
 async fn instance_state_put(
     rqctx: Arc<RequestContext<Context>>,
@@ -737,7 +737,7 @@ async fn instance_serial_task(
 
 #[endpoint {
     method = GET,
-    path = "/instances/serial",
+    path = "/instance/serial",
 }]
 async fn instance_serial(
     rqctx: Arc<RequestContext<Context>>,
@@ -863,7 +863,7 @@ async fn instance_serial(
 
 #[endpoint {
     method = PUT,
-    path = "/instances/serial/detach",
+    path = "/instance/serial/detach",
 }]
 async fn instance_serial_detach(
     rqctx: Arc<RequestContext<Context>>,
@@ -906,7 +906,7 @@ async fn instance_serial_detach(
 // clients.
 #[endpoint {
     method = PUT,
-    path = "/instances/migrate/start",
+    path = "/instance/migrate/start",
     unpublished = true,
 }]
 async fn instance_migrate_start(
@@ -919,7 +919,7 @@ async fn instance_migrate_start(
 
 #[endpoint {
     method = GET,
-    path = "/instances/migrate/status"
+    path = "/instance/migrate/status"
 }]
 async fn instance_migrate_status(
     rqctx: Arc<RequestContext<Context>>,

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -188,7 +188,7 @@ fn slot_to_bdf(slot: api::Slot, ty: SlotType) -> Result<pci::Bdf> {
 
 #[endpoint {
     method = PUT,
-    path = "/instances",
+    path = "/instance",
 }]
 async fn instance_ensure(
     rqctx: Arc<RequestContext<Context>>,


### PR DESCRIPTION
## Old Behavior

For most endpoints, we'd use the format: 

```
http://<IP ADDRESS>/instances/<INSTANCE UUID>/<rest of the path, maybe>
```

For many endpoints, this UUID would be redundant with values stored in `properties` struct, and a somewhat silly check would validate this. This path format added little value, other than requiring clients to supply a redundant value.

Why is the UUID redundant? Propolis' server only supports a *single* instance anyway, so the server address should be a sufficient factor for distinguishing instances.

## New Behavior

Don't bother supplying the instance UUID. Simplify a lot of "name -> UUID" pathways where this is no longer necessary.