### PR TITLE
Update hardware IDs to match current assignments in OANA.

### DIFF
--- a/propolis/src/hw/chipset/i440fx.rs
+++ b/propolis/src/hw/chipset/i440fx.rs
@@ -6,6 +6,7 @@ use crate::common::*;
 use crate::dispatch::DispCtx;
 use crate::hw::bhyve::BhyvePmTimer;
 use crate::hw::ibmpc;
+use crate::hw::ids::pci::VENDOR_INTEL;
 use crate::hw::pci::{
     self, Bdf, BusNum, INTxPinID, PcieCfgDecoder, PioCfgDecoder,
 };
@@ -318,7 +319,7 @@ struct Piix4HostBridge {
 impl Piix4HostBridge {
     pub fn create() -> Arc<Self> {
         let pci_state = pci::Builder::new(pci::Ident {
-            vendor_id: 0x8086,
+            vendor_id: VENDOR_INTEL,
             device_id: 0x1237,
             class: 0x06,
             ..Default::default()
@@ -360,7 +361,7 @@ pub struct Piix3Lpc {
 impl Piix3Lpc {
     fn create(irq_config: Arc<IrqConfig>) -> Arc<Self> {
         let pci_state = pci::Builder::new(pci::Ident {
-            vendor_id: 0x8086,
+            vendor_id: VENDOR_INTEL,
             device_id: 0x7000,
             class: 0x06,
             subclass: 0x01,
@@ -658,7 +659,7 @@ pub struct Piix3PM {
 impl Piix3PM {
     pub fn create() -> Arc<Self> {
         let pci_state = pci::Builder::new(pci::Ident {
-            vendor_id: 0x8086,
+            vendor_id: VENDOR_INTEL,
             device_id: 0x7113,
             class: 0x06,
             subclass: 0x80,

--- a/propolis/src/hw/chipset/i440fx.rs
+++ b/propolis/src/hw/chipset/i440fx.rs
@@ -6,7 +6,7 @@ use crate::common::*;
 use crate::dispatch::DispCtx;
 use crate::hw::bhyve::BhyvePmTimer;
 use crate::hw::ibmpc;
-use crate::hw::ids::pci::VENDOR_INTEL;
+use crate::hw::ids::pci::{VENDOR_INTEL, PIIX4_HB_DEV_ID, PIIX3_ISA_DEV_ID, PIIX4_PM_DEV_ID};
 use crate::hw::pci::{
     self, Bdf, BusNum, INTxPinID, PcieCfgDecoder, PioCfgDecoder,
 };
@@ -320,7 +320,7 @@ impl Piix4HostBridge {
     pub fn create() -> Arc<Self> {
         let pci_state = pci::Builder::new(pci::Ident {
             vendor_id: VENDOR_INTEL,
-            device_id: 0x1237,
+            device_id: PIIX4_HB_DEV_ID,
             class: 0x06,
             ..Default::default()
         })
@@ -362,7 +362,7 @@ impl Piix3Lpc {
     fn create(irq_config: Arc<IrqConfig>) -> Arc<Self> {
         let pci_state = pci::Builder::new(pci::Ident {
             vendor_id: VENDOR_INTEL,
-            device_id: 0x7000,
+            device_id: PIIX3_ISA_DEV_ID,
             class: 0x06,
             subclass: 0x01,
             ..Default::default()
@@ -660,7 +660,7 @@ impl Piix3PM {
     pub fn create() -> Arc<Self> {
         let pci_state = pci::Builder::new(pci::Ident {
             vendor_id: VENDOR_INTEL,
-            device_id: 0x7113,
+            device_id: PIIX4_PM_DEV_ID,
             class: 0x06,
             subclass: 0x80,
             ..Default::default()

--- a/propolis/src/hw/chipset/i440fx.rs
+++ b/propolis/src/hw/chipset/i440fx.rs
@@ -6,7 +6,11 @@ use crate::common::*;
 use crate::dispatch::DispCtx;
 use crate::hw::bhyve::BhyvePmTimer;
 use crate::hw::ibmpc;
-use crate::hw::ids::pci::{VENDOR_INTEL, PIIX4_HB_DEV_ID, PIIX3_ISA_DEV_ID, PIIX4_PM_DEV_ID};
+use crate::hw::ids::pci::{
+    PIIX3_ISA_DEV_ID, PIIX3_ISA_SUB_DEV_ID, PIIX4_HB_DEV_ID,
+    PIIX4_HB_SUB_DEV_ID, PIIX4_PM_DEV_ID, PIIX4_PM_SUB_DEV_ID, VENDOR_INTEL,
+    VENDOR_OXIDE,
+};
 use crate::hw::pci::{
     self, Bdf, BusNum, INTxPinID, PcieCfgDecoder, PioCfgDecoder,
 };
@@ -321,6 +325,8 @@ impl Piix4HostBridge {
         let pci_state = pci::Builder::new(pci::Ident {
             vendor_id: VENDOR_INTEL,
             device_id: PIIX4_HB_DEV_ID,
+            sub_vendor_id: VENDOR_OXIDE,
+            sub_device_id: PIIX4_HB_SUB_DEV_ID,
             class: 0x06,
             ..Default::default()
         })
@@ -363,6 +369,8 @@ impl Piix3Lpc {
         let pci_state = pci::Builder::new(pci::Ident {
             vendor_id: VENDOR_INTEL,
             device_id: PIIX3_ISA_DEV_ID,
+            sub_vendor_id: VENDOR_OXIDE,
+            sub_device_id: PIIX3_ISA_SUB_DEV_ID,
             class: 0x06,
             subclass: 0x01,
             ..Default::default()
@@ -661,6 +669,8 @@ impl Piix3PM {
         let pci_state = pci::Builder::new(pci::Ident {
             vendor_id: VENDOR_INTEL,
             device_id: PIIX4_PM_DEV_ID,
+            sub_vendor_id: VENDOR_OXIDE,
+            sub_device_id: PIIX4_PM_SUB_DEV_ID,
             class: 0x06,
             subclass: 0x80,
             ..Default::default()

--- a/propolis/src/hw/ids.rs
+++ b/propolis/src/hw/ids.rs
@@ -1,0 +1,60 @@
+//! Definitions of various IDs assigned to the devices we expose to guest instances.
+
+/// Oxide's IEE MA-L assignment.
+pub const OXIDE_OUI: [u8; 3] = [0xa8, 0x40, 0x25];
+
+/// PCI Specific IDs
+pub mod pci {
+    // Vendor IDs
+
+    /// Oxide's PCI-SIG assigned Vendor ID.
+    ///
+    /// Devices emulating existing hardware will generally use the corresponding vendor &
+    /// device IDs but specifiy a Oxide as the Subsystem Vendor. For virtual devices defined
+    /// entirely by Propolis shall use Oxide's Vendor ID.
+    pub const VENDOR_OXIDE: u16 = 0x1de;
+
+    /// RedHat's PCI-SIG assigned Vendor ID, as used for Virtio devices.
+    ///
+    /// See Virtio 1.1 Section 4.1.2 PCI Device Discovery
+    pub const VENDOR_VIRTIO: u16 = 0x1AF4;
+
+    /// Intel's PCI-SIG assigned Vendor ID.
+    pub const VENDOR_INTEL: u16 = 0x8086;
+
+    // Emulated Device IDs
+
+    /// PCI Device ID for the PIIX4 Host Bridge.
+    pub const PIIX4_HB_DEV_ID: u16 = 0x1237;
+
+    /// PCI Device ID for the PIIX3 ISA Controller.
+    pub const PIIX3_ISA_DEV_ID: u16 = 0x7000;
+
+    /// PCI Device ID for the PIIX4 ACPI PM Controller.
+    pub const PIIX4_PM_DEV_ID: u16 = 0x7113;
+
+    // Subsystem Device IDs (for devices emulated by propolis)
+
+    /// PCI Subsystem Device ID for the PIIX4 Host Bridge as emulated by propolis.
+    pub const PIIX4_HB_SUB_DEV_ID: u16 = 0xfffe;
+
+    /// PCI Subsystem Device ID for the PIIX3 ISA Controller as emulated by propolis.
+    pub const PIIX3_ISA_SUB_DEV_ID: u16 = 0xfffd;
+
+    /// PCI Subsystem Device ID for the PIIX4 ACPI PM Controller as emulated by propolis.
+    pub const PIIX4_PM_SUB_DEV_ID: u16 = 0xfffc;
+
+    /// PCI Subsystem Device ID for the Propolis Virtio Network device.
+    pub const VIRTIO_NET_SUB_DEV_ID: u16 = 0xfffb;
+
+    /// PCI Subsystem Device ID for the Propolis Virtio Block device.
+    pub const VIRTIO_BLOCK_SUB_DEV_ID: u16 = 0xfffa;
+
+    // Propolis-specific Device IDs
+
+    /// PCI Device ID for the Propolis NVMe controller.
+    pub const PROPOLIS_NVME_DEV_ID: u16 = 0x0;
+
+    /// PCI Device ID for the Propolis xHCI controller.
+    pub const PROPOLIS_XHCI_DEV_ID: u16 = 0x1;
+}

--- a/propolis/src/hw/mod.rs
+++ b/propolis/src/hw/mod.rs
@@ -1,6 +1,7 @@
 pub mod bhyve;
 pub mod chipset;
 pub mod ibmpc;
+pub mod ids;
 pub mod nvme;
 pub mod pci;
 pub mod ps2ctrl;

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -3,6 +3,7 @@ use std::mem::size_of;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::dispatch::DispCtx;
+use crate::hw::ids::OXIDE_OUI;
 use crate::hw::pci;
 use crate::migrate::{Migrate, Migrator};
 use crate::util::regmap::RegMap;
@@ -455,7 +456,7 @@ impl PciNvme {
             vid: vendor,
             ssvid: vendor,
             sn,
-            ieee: [0xA8, 0x40, 0x25], // Oxide OUI
+            ieee: OXIDE_OUI,
             // We use standard Completion/Submission Queue Entry structures with no extra
             // data, so required (minimum) == maximum
             sqes: NvmQueueEntrySize(0).with_maximum(sqes).with_required(sqes),

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -3,6 +3,7 @@ use std::mem::size_of;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::dispatch::DispCtx;
+use crate::hw::ids::pci::{PROPOLIS_NVME_DEV_ID, VENDOR_OXIDE};
 use crate::hw::ids::OXIDE_OUI;
 use crate::hw::pci;
 use crate::migrate::{Migrate, Migrator};
@@ -423,16 +424,14 @@ pub struct PciNvme {
 impl PciNvme {
     /// Create a new pci-nvme device with the given values
     pub fn create(
-        vendor: u16,
-        device: u16,
         serial_number: String,
         binfo: block::DeviceInfo,
     ) -> Arc<Self> {
         let builder = pci::Builder::new(pci::Ident {
-            vendor_id: vendor,
-            device_id: device,
-            sub_vendor_id: vendor,
-            sub_device_id: device,
+            vendor_id: VENDOR_OXIDE,
+            device_id: PROPOLIS_NVME_DEV_ID,
+            sub_vendor_id: VENDOR_OXIDE,
+            sub_device_id: PROPOLIS_NVME_DEV_ID,
             class: pci::bits::CLASS_STORAGE,
             subclass: pci::bits::SUBCLASS_NVM,
             prog_if: pci::bits::PROGIF_ENTERPRISE_NVME,
@@ -453,8 +452,8 @@ impl PciNvme {
         // Initialize the Identify structure returned when the host issues
         // an Identify Controller command.
         let ctrl_ident = bits::IdentifyController {
-            vid: vendor,
-            ssvid: vendor,
+            vid: VENDOR_OXIDE,
+            ssvid: VENDOR_OXIDE,
             sn,
             ieee: OXIDE_OUI,
             // We use standard Completion/Submission Queue Entry structures with no extra

--- a/propolis/src/hw/virtio/bits.rs
+++ b/propolis/src/hw/virtio/bits.rs
@@ -48,3 +48,12 @@ pub const VIRTQ_DESC_F_WRITE: u16 = 2;
 pub const VIRTQ_DESC_F_INDIRECT: u16 = 4;
 pub const VRING_AVAIL_F_NO_INTERRUPT: u16 = 1;
 pub const VRING_USED_F_NO_NOTIFY: u16 = 1;
+
+/// Returns the corresponding propolis specific Subsystem Device ID for the given Virtio Device ID.
+pub(super) fn virtio_sub_dev_id(dev_id: u16) -> u16 {
+    match dev_id {
+        VIRTIO_DEV_NET => crate::hw::ids::pci::VIRTIO_NET_SUB_DEV_ID,
+        VIRTIO_DEV_BLOCK => crate::hw::ids::pci::VIRTIO_BLOCK_SUB_DEV_ID,
+        dev_id => panic!("unhandled virtio device id: {:#x}", dev_id),
+    }
+}

--- a/propolis/src/hw/virtio/pci.rs
+++ b/propolis/src/hw/virtio/pci.rs
@@ -8,7 +8,7 @@ use super::queue::VirtQueues;
 use super::{VirtioDevice, VirtioIntr, VqChange, VqIntr};
 use crate::common::*;
 use crate::dispatch::DispCtx;
-use crate::hw::ids::pci::VENDOR_VIRTIO;
+use crate::hw::ids::pci::{VENDOR_OXIDE, VENDOR_VIRTIO};
 use crate::hw::pci;
 use crate::intr_pins::IntrPin;
 use crate::util::regmap::RegMap;
@@ -187,8 +187,8 @@ impl PciVirtioState {
         let mut builder = pci::Builder::new(pci::Ident {
             vendor_id: VENDOR_VIRTIO,
             device_id: dev_id,
-            sub_vendor_id: VENDOR_VIRTIO,
-            sub_device_id: dev_id - 0xfff,
+            sub_vendor_id: VENDOR_OXIDE,
+            sub_device_id: super::bits::virtio_sub_dev_id(dev_id),
             class: dev_class,
             ..Default::default()
         })

--- a/propolis/src/hw/virtio/pci.rs
+++ b/propolis/src/hw/virtio/pci.rs
@@ -8,13 +8,12 @@ use super::queue::VirtQueues;
 use super::{VirtioDevice, VirtioIntr, VqChange, VqIntr};
 use crate::common::*;
 use crate::dispatch::DispCtx;
+use crate::hw::ids::pci::VENDOR_VIRTIO;
 use crate::hw::pci;
 use crate::intr_pins::IntrPin;
 use crate::util::regmap::RegMap;
 
 use lazy_static::lazy_static;
-
-const VIRTIO_VENDOR: u16 = 0x1af4;
 
 const VIRTIO_MSI_NO_VECTOR: u16 = 0xffff;
 
@@ -186,9 +185,9 @@ impl PciVirtioState {
         cfg_sz: usize,
     ) -> (Self, pci::DeviceState) {
         let mut builder = pci::Builder::new(pci::Ident {
-            vendor_id: VIRTIO_VENDOR,
+            vendor_id: VENDOR_VIRTIO,
             device_id: dev_id,
-            sub_vendor_id: VIRTIO_VENDOR,
+            sub_vendor_id: VENDOR_VIRTIO,
             sub_device_id: dev_id - 0xfff,
             class: dev_class,
             ..Default::default()

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -12,6 +12,7 @@ use propolis::hw::chipset::i440fx;
 use propolis::hw::chipset::i440fx::I440Fx;
 use propolis::hw::chipset::Chipset;
 use propolis::hw::ibmpc;
+use propolis::hw::ids::pci::VENDOR_OXIDE;
 use propolis::hw::pci;
 use propolis::hw::ps2ctrl::PS2Ctrl;
 use propolis::hw::qemu::{debug::QemuDebugPort, fwcfg, ramfb};
@@ -254,7 +255,7 @@ impl<'a> MachineInitializer<'a> {
         be_register: ChildRegister,
     ) -> Result<(), Error> {
         let be_info = backend.info();
-        let nvme = nvme::PciNvme::create(0x1de, 0x1000, name, be_info);
+        let nvme = nvme::PciNvme::create(VENDOR_OXIDE, 0x1000, name, be_info);
         let id = self.inv.register_instance(&nvme, bdf.to_string())?;
         let _ = self.inv.register_child(be_register, id).unwrap();
 

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -12,7 +12,6 @@ use propolis::hw::chipset::i440fx;
 use propolis::hw::chipset::i440fx::I440Fx;
 use propolis::hw::chipset::Chipset;
 use propolis::hw::ibmpc;
-use propolis::hw::ids::pci::VENDOR_OXIDE;
 use propolis::hw::pci;
 use propolis::hw::ps2ctrl::PS2Ctrl;
 use propolis::hw::qemu::{debug::QemuDebugPort, fwcfg, ramfb};
@@ -255,7 +254,7 @@ impl<'a> MachineInitializer<'a> {
         be_register: ChildRegister,
     ) -> Result<(), Error> {
         let be_info = backend.info();
-        let nvme = nvme::PciNvme::create(VENDOR_OXIDE, 0x1000, name, be_info);
+        let nvme = nvme::PciNvme::create(name, be_info);
         let id = self.inv.register_instance(&nvme, bdf.to_string())?;
         let _ = self.inv.register_child(be_register, id).unwrap();
 

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -20,7 +20,6 @@ use std::time::SystemTime;
 use propolis::chardev::{BlockingSource, Sink, Source};
 use propolis::hw::chipset::Chipset;
 use propolis::hw::ibmpc;
-use propolis::hw::ids::pci::VENDOR_OXIDE;
 use propolis::hw::ps2ctrl::PS2Ctrl;
 use propolis::hw::uart::LpcUart;
 use propolis::instance::{Instance, ReqState, State};
@@ -252,12 +251,8 @@ fn main() {
                     let bdf = bdf.unwrap();
 
                     let info = backend.info();
-                    let nvme = hw::nvme::PciNvme::create(
-                        VENDOR_OXIDE,
-                        0x1000,
-                        block_dev.to_string(),
-                        info,
-                    );
+                    let nvme =
+                        hw::nvme::PciNvme::create(block_dev.to_string(), info);
 
                     let id = inv.register_instance(&nvme, bdf.to_string())?;
                     let _be_id = inv.register_child(creg, id)?;

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -20,6 +20,7 @@ use std::time::SystemTime;
 use propolis::chardev::{BlockingSource, Sink, Source};
 use propolis::hw::chipset::Chipset;
 use propolis::hw::ibmpc;
+use propolis::hw::ids::pci::VENDOR_OXIDE;
 use propolis::hw::ps2ctrl::PS2Ctrl;
 use propolis::hw::uart::LpcUart;
 use propolis::instance::{Instance, ReqState, State};
@@ -252,7 +253,7 @@ fn main() {
 
                     let info = backend.info();
                     let nvme = hw::nvme::PciNvme::create(
-                        0x1de,
+                        VENDOR_OXIDE,
                         0x1000,
                         block_dev.to_string(),
                         info,


### PR DESCRIPTION
Update propolis to reflect the current set of IDs assigned in [OANA (Oxide Assigned Numbers Authority)](https://github.com/oxidecomputer/oana).