### PR TITLE
Pull in fix from rfb for underflow panic when pressing F1.

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -42,7 +42,7 @@ slog = "2.7"
 structopt = { version = "0.3", default-features = false }
 propolis = { path = "../propolis", features = ["crucible"], default-features = false }
 propolis-client = { path = "../client" }
-rfb = { git = "https://github.com/oxidecomputer/rfb", rev = "7c16e55" }
+rfb = { git = "https://github.com/oxidecomputer/rfb", branch = "main" }
 uuid = "0.8"
 base64 = "0.13"
 


### PR DESCRIPTION
Currently if you press `F1` while using vnc, propolis panics inside the `rfb` crate:
```
Apr 29 22:45:43.015 INFO Starting server...
thread 'tokio-runtime-worker' panicked at 'attempt to subtract with overflow', /home/jordan/.cargo/git/checkouts/rfb-288dbd459c42dc7a/7c16e55/src/keysym/mod.rs:58:25
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
./start-server.sh: line 9: 27387 Abort                   RUST_LOG=debug pfexec $SERVER run $CONF $ADDR:$PORT
```

This change changes propolis to track `main` on the `rfb` crate, which has a fix for this panic (https://github.com/oxidecomputer/rfb/commit/13c3e4570f0528e212df4300d3a47df249d6827b).

I confirmed that propolis-server no longer panics with the updated dep while pressing `F1` in a connected vnc client.