### PR TITLE
 nvme: Increase the NVMe controller register size to 0x4000 to match spec requirements for MLBAR.

### DIFF
--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -537,9 +537,8 @@ impl PciNvme {
         };
 
         let pci_state = builder
-            // XXX: add room for doorbells
-            .add_bar_mmio64(pci::BarN::BAR0, CONTROLLER_REG_SZ as u64)
             // BAR0/1 are used for the main config and doorbell registers
+            .add_bar_mmio64(pci::BarN::BAR0, CONTROLLER_REG_SZ as u64)
             // BAR2 is for the optional index/data registers
             // Place MSIX in BAR4 for now
             .add_cap_msix(pci::BarN::BAR4, NVME_MSIX_COUNT)

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -1008,9 +1008,9 @@ lazy_static! {
             (CtrlrReg::Reserved, 0),
         ];
 
-        // Pad out to the next power of two
+        // Update the last `Reserved` slot to pad out the rest of the controller register space
         let regs_sz = layout.iter().map(|(_, sz)| sz).sum::<usize>();
-        assert!(regs_sz.next_power_of_two() <= CONTROLLER_REG_SZ);
+        assert!(regs_sz <= CONTROLLER_REG_SZ);
         layout.last_mut().unwrap().1 = CONTROLLER_REG_SZ - regs_sz;
 
         // Find the offset of IOQueueDoorBells


### PR DESCRIPTION
The NVMe spec implies [1] a minimum size of 0x4000 for the controller register space. Windows thus expects `BAR0 & !(0x4000 - 1) == BAR0 & !0xF` to hold true. Which is all fine and well except Propolis sets the size to 0x2000 meaning we end up in this failing scenario where `BAR0 = 0xFEDFE004` and so the above relation no longer holds true.

TL;DR: propolis set the NVMe controller register space to half the size it should at least be.

[1] Bits 13:04 should be set to 0.

See NVMe 1.0e Section 2.1.10 Offset 10h: MLBAR (BAR0) - Memory Register Base Address, lower 32 bits:

| **Bits** | **Type** | **Reset** |                                                                                                                              **Description**                                                                                                                             |
|:--------:|:--------:|:---------:|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
|   31:14  |    RW    |     0h    | **Base Address (BA)**: Base address of register memory space. For controllers that support a larger number of doorbell registers or have vendor specific space following the doorbell registers, more bits are allowed to be RO such that more memory space is consumed. |
|   13:04  |    RO    |     0h    |                                                                                                                                 Reserved                                                                                                                                 |