### PR TITLE
Check bhyve-api interfaces against gate headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /*/target
+/*/*/target
 **/Cargo.lock
 debug.out
 core

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ default-members = [
   "standalone",
 ]
 
+exclude = [
+  "bhyve-api/header-check"
+]
+
 [profile.dev]
 panic = "abort"
 [profile.release]

--- a/bhyve-api/README.md
+++ b/bhyve-api/README.md
@@ -1,0 +1,7 @@
+# bhyve-api
+
+This crate exposes the interfaces from the bhyve kernel VMM.  Since those
+interfaces are Private and subject to change, it means this crate must be kept
+in sync with changes, and Propolis binaries built against a given version of
+the crate (and implied interface version) will only run on systems with that
+exact OS version.

--- a/bhyve-api/header-check/Cargo.toml
+++ b/bhyve-api/header-check/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "header-check"
+version = "0.0.1"
+authors = ["Patrick Mooney <pmooney@oxide.computer>"]
+license = "MPL-2.0"
+build = "build.rs"
+repository = "https://github.com/oxidecomputer/propolis"
+
+[dependencies]
+bhyve_api = { path = ".." }
+libc = "0.2"
+
+[build-dependencies]
+cc = "1.0.73"
+ctest2 = "0.4.3"
+
+[[test]]
+name = "main"
+path = "test/main.rs"
+harness = false

--- a/bhyve-api/header-check/README.md
+++ b/bhyve-api/header-check/README.md
@@ -1,0 +1,24 @@
+# bhyve-api Header Check
+
+In order to facilitate accurate reproduction of the bhyve kernel interfaces
+from their respective headers, this crate uses `ctest2` in the same manner as
+[rust-libc](https://github.com/rust-lang/libc/).
+
+## Usage
+
+Building and executing the test requires a set of illumos-gate sources
+corresponding to the version of interfaces authoried in bhyve-api.  Due to a
+tangle in those headers, building and executing the test must itself be done on
+a moderately recent illumos system, although that may change in the future.
+
+From the `header-check` directory, execute `cargo test` with the `GATE_SRC`
+environment variable pointing towards the afformentioned illumos-gate source
+tree:
+
+```
+$ GATE_SRC=/path/to/my/illumos-gate cargo test
+    Finished test [unoptimized + debuginfo] target(s) in 0.02s
+     Running test/main.rs (target/debug/deps/main-2be1b9ed23245f3a)
+RUNNING ALL TESTS
+PASSED 578 tests
+```

--- a/bhyve-api/header-check/build.rs
+++ b/bhyve-api/header-check/build.rs
@@ -1,0 +1,79 @@
+#![deny(warnings)]
+
+use std::convert::TryFrom;
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let mut cfg = ctest2::TestGenerator::new();
+
+    let gate_dir = match env::var("GATE_SRC").map(PathBuf::try_from) {
+        Ok(Ok(dir)) => dir,
+        _ => {
+            eprintln!("Must specify path to illumos-gate sources with GATE_SRC env var");
+            std::process::exit(1);
+        }
+    };
+
+    let include_paths = [
+        // For #include_next to work, these need to be first
+        "usr/src/compat/bhyve",
+        "usr/src/compat/bhyve/amd64",
+        "usr/src/contrib/bhyve",
+        "usr/src/contrib/bhyve/amd64",
+        "usr/src/head",
+        "usr/src/uts/intel",
+        "usr/src/uts/common",
+    ];
+    cfg.include("/usr/include");
+    for p in include_paths {
+        cfg.include(gate_dir.join(p));
+    }
+
+    cfg.header("sys/types.h");
+    cfg.header("sys/vmm.h");
+    cfg.header("sys/vmm_dev.h");
+
+    cfg.skip_const(move |name| match name {
+        _n if _n.starts_with("SEG_") => true,
+
+        // defined for crate consumer convenience
+        "VMM_PATH_PREFIX" => true,
+        "VMM_CTL_PATH" => true,
+
+        _ => false,
+    });
+
+    cfg.skip_struct(|name| match name {
+        // Skip over the vmexit/vmentry structs due to unions being a mess
+        "vm_exit" => true,
+        "vm_exit_payload" => true,
+        "vm_entry" => true,
+        "vm_entry_payload" => true,
+
+        // Skip anonymous types from vm_exit
+        "vm_rwmsr" => true,
+        "vm_exit_vmx" => true,
+        "vm_exit_svm" => true,
+        "vm_exit_msr" => true,
+        "vm_inst_emul" => true,
+        "vm_paging" => true,
+
+        _ => false,
+    });
+
+    cfg.skip_field_type(|ty, field| match (ty, field) {
+        // Defined as an `int` in the crate, instead of an enum
+        ("vm_isa_irq_trigger", "trigger") => true,
+        ("vm_capability", "captype") => true,
+
+        // Strictness between `u8` and `char` is excessive
+        ("vm_create_req", "name") => true,
+        ("vm_destroy_req", "name") => true,
+        ("vm_memseg", "name") => true,
+
+        _ => false,
+    });
+
+    cfg.generate("../src/lib.rs", "main.rs");
+}

--- a/bhyve-api/header-check/test/main.rs
+++ b/bhyve-api/header-check/test/main.rs
@@ -1,0 +1,7 @@
+extern crate bhyve_api;
+extern crate libc;
+
+use bhyve_api::*;
+use libc::*;
+
+include!(concat!(env!("OUT_DIR"), "/main.rs"));

--- a/propolis/src/vcpu.rs
+++ b/propolis/src/vcpu.rs
@@ -80,7 +80,7 @@ impl VcpuHdl {
     /// pending interrupts).
     pub fn reboot_state(&mut self) -> Result<()> {
         let mut vvr = bhyve_api::vm_vcpu_reset {
-            cpuid: self.id,
+            vcpuid: self.id,
             kind: bhyve_api::vcpu_reset_kind::VRK_RESET as u32,
         };
 
@@ -101,7 +101,7 @@ impl VcpuHdl {
     /// Set the state of a virtual CPU.
     pub fn set_run_state(&mut self, state: u32) -> Result<()> {
         let mut state = bhyve_api::vm_run_state {
-            cpuid: self.id,
+            vcpuid: self.id,
             state,
             sipi_vector: 0,
             ..Default::default()

--- a/propolis/src/vmm/mapping.rs
+++ b/propolis/src/vmm/mapping.rs
@@ -29,12 +29,12 @@ bitflags! {
     /// Bitflags representing memory protections.
     pub struct Prot: u8 {
         const NONE = 0;
-        const READ = bhyve_api::PROT_READ as u8;
-        const WRITE = bhyve_api::PROT_WRITE as u8;
-        const EXEC = bhyve_api::PROT_EXEC as u8;
-        const ALL = (bhyve_api::PROT_READ
-                    | bhyve_api::PROT_WRITE
-                    | bhyve_api::PROT_EXEC) as u8;
+        const READ = libc::PROT_READ as u8;
+        const WRITE = libc::PROT_WRITE as u8;
+        const EXEC = libc::PROT_EXEC as u8;
+        const ALL = (libc::PROT_READ
+                    | libc::PROT_WRITE
+                    | libc::PROT_EXEC) as u8;
     }
 }
 


### PR DESCRIPTION
Use `ctest` in a manner similar to rust-libc to verify interfaces transcribed from the illumos headers.