### PR TITLE
update uuid to v1.0.0

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ slog-term = "2.8"
 structopt = "0.3"
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.14"
-uuid = "0.8"
+uuid = "1.0.0"
 serde = "1.0"
 serde_json = "1.0"
 base64 = "0.13"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2018"
 [dependencies]
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 ring = "0.16"
-schemars = { version = "0.8", features = [ "uuid" ] }
+schemars = { version = "0.8.10", features = [ "uuid1" ] }
 serde = "1.0"
 serde_json = "1.0"
 slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_debug" ] }
 structopt = "0.3"
 thiserror = "1.0"
-uuid = { version = "0.8", features = [ "serde", "v4" ] }
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "8ea317a9dfee65d7c018a1fda89fdec63a560ef3" }
+uuid = { version = "1.0.0", features = [ "serde", "v4" ] }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "57f0951793a74b31afd824bc3a0e5d89a41a540b" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -16,4 +16,4 @@ slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_deb
 structopt = "0.3"
 thiserror = "1.0"
 uuid = { version = "1.0.0", features = [ "serde", "v4" ] }
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "57f0951793a74b31afd824bc3a0e5d89a41a540b" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "cd74a23ea42ce5e673923a00faf31b0a920191cc" }

--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -21,14 +21,14 @@ viona_api = { path = "../viona-api" }
 usdt = { version = "0.2.1", default-features = false }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "8ea317a9dfee65d7c018a1fda89fdec63a560ef3", optional = true }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "57f0951793a74b31afd824bc3a0e5d89a41a540b", optional = true }
 anyhow = "1"
 slog = "2.7"
 serde = { version = "1" }
 serde_arrays = "0.1"
 erased-serde = "0.3"
 serde_json = "1.0"
-uuid = "0.8"
+uuid = "1.0.0"
 
 [dev-dependencies]
 crossbeam-channel = "0.5"

--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -21,7 +21,7 @@ viona_api = { path = "../viona-api" }
 usdt = { version = "0.2.1", default-features = false }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "57f0951793a74b31afd824bc3a0e5d89a41a540b", optional = true }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "cd74a23ea42ce5e673923a00faf31b0a920191cc", optional = true }
 anyhow = "1"
 slog = "2.7"
 serde = { version = "1" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -43,7 +43,7 @@ structopt = { version = "0.3", default-features = false }
 propolis = { path = "../propolis", features = ["crucible"], default-features = false }
 propolis-client = { path = "../client" }
 rfb = { git = "https://github.com/oxidecomputer/rfb", branch = "main" }
-uuid = "0.8"
+uuid = "1.0.0"
 base64 = "0.13"
 
 [dev-dependencies]


### PR DESCRIPTION
See https://github.com/oxidecomputer/omicron/pull/1091 for the plan. This will be updated with the omicron and crucible revs after those PRs are merged.