### PR TITLE
Provide the WebSocket URI for an instance's serial console stream in PropolisClient

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -159,4 +159,9 @@ impl Client {
         );
         self.get(path, Some(body)).await
     }
+
+    /// Returns the WebSocket URI to an instance's serial console stream.
+    pub fn instance_serial_console_ws_uri(&self) -> String {
+        format!("ws://{}/instance/serial", self.address)
+    }
 }


### PR DESCRIPTION
Since technically PropolisClient is where the layout of endpoint URIs as used by clients lives, this makes more sense to put here than in, say, sled-agent. Simply returns the string rather than making a request of any kind so as not to impose any implementation details on consumers. (needed by https://github.com/oxidecomputer/omicron/pull/1108 )