### PR TITLE
Expose sub-device-IDs required by legacy VirtIO

### DIFF
--- a/propolis/src/hw/virtio/bits.rs
+++ b/propolis/src/hw/virtio/bits.rs
@@ -1,6 +1,10 @@
 pub const VIRTIO_DEV_NET: u16 = 0x1000;
 pub const VIRTIO_DEV_BLOCK: u16 = 0x1001;
 
+// Legacy virtio-pci devices must present these sub-device-IDs
+pub const VIRTIO_SUB_DEV_NET: u16 = 0x1;
+pub const VIRTIO_SUB_DEV_BLOCK: u16 = 0x2;
+
 // Legacy interface feature bits
 pub const VIRTIO_F_NOTIFY_ON_EMPTY: usize = 1 << 24;
 pub const VIRTIO_F_ANY_LAYOUT: usize = 1 << 27;
@@ -48,12 +52,3 @@ pub const VIRTQ_DESC_F_WRITE: u16 = 2;
 pub const VIRTQ_DESC_F_INDIRECT: u16 = 4;
 pub const VRING_AVAIL_F_NO_INTERRUPT: u16 = 1;
 pub const VRING_USED_F_NO_NOTIFY: u16 = 1;
-
-/// Returns the corresponding propolis specific Subsystem Device ID for the given Virtio Device ID.
-pub(super) fn virtio_sub_dev_id(dev_id: u16) -> u16 {
-    match dev_id {
-        VIRTIO_DEV_NET => crate::hw::ids::pci::VIRTIO_NET_SUB_DEV_ID,
-        VIRTIO_DEV_BLOCK => crate::hw::ids::pci::VIRTIO_BLOCK_SUB_DEV_ID,
-        dev_id => panic!("unhandled virtio device id: {:#x}", dev_id),
-    }
-}

--- a/propolis/src/hw/virtio/block.rs
+++ b/propolis/src/hw/virtio/block.rs
@@ -41,6 +41,7 @@ impl PciVirtioBlock {
             queues,
             msix_count,
             VIRTIO_DEV_BLOCK,
+            VIRTIO_SUB_DEV_BLOCK,
             pci::bits::CLASS_STORAGE,
             VIRTIO_BLK_CFG_SIZE,
         );

--- a/propolis/src/hw/virtio/pci.rs
+++ b/propolis/src/hw/virtio/pci.rs
@@ -8,7 +8,7 @@ use super::queue::VirtQueues;
 use super::{VirtioDevice, VirtioIntr, VqChange, VqIntr};
 use crate::common::*;
 use crate::dispatch::DispCtx;
-use crate::hw::ids::pci::{VENDOR_OXIDE, VENDOR_VIRTIO};
+use crate::hw::ids::pci::VENDOR_VIRTIO;
 use crate::hw::pci;
 use crate::intr_pins::IntrPin;
 use crate::util::regmap::RegMap;
@@ -181,14 +181,15 @@ impl PciVirtioState {
         queues: VirtQueues,
         msix_count: Option<u16>,
         dev_id: u16,
+        sub_dev_id: u16,
         dev_class: u8,
         cfg_sz: usize,
     ) -> (Self, pci::DeviceState) {
         let mut builder = pci::Builder::new(pci::Ident {
             vendor_id: VENDOR_VIRTIO,
             device_id: dev_id,
-            sub_vendor_id: VENDOR_OXIDE,
-            sub_device_id: super::bits::virtio_sub_dev_id(dev_id),
+            sub_vendor_id: VENDOR_VIRTIO,
+            sub_device_id: sub_dev_id,
             class: dev_class,
             ..Default::default()
         })

--- a/propolis/src/hw/virtio/viona.rs
+++ b/propolis/src/hw/virtio/viona.rs
@@ -73,6 +73,7 @@ impl PciVirtioViona {
             queues,
             msix_count,
             VIRTIO_DEV_NET,
+            VIRTIO_SUB_DEV_NET,
             pci::bits::CLASS_NETWORK,
             VIRTIO_NET_CFG_SIZE,
         );


### PR DESCRIPTION
OVMF was unable to attach drivers for virtio-block or virtio-net devices without this.