### PR TITLE
Update some deps to reduce duplicates compilation graph.

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,7 +16,7 @@ slog-async = "2.7"
 slog-term = "2.8"
 structopt = "0.3"
 tokio = { version = "1", features = ["full"] }
-tokio-tungstenite = "0.14"
+tokio-tungstenite = "0.17"
 uuid = "1.0.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "1.0"
 bhyve_api = { path = "../bhyve-api" }
 dladm = { path = "../dladm" }
 viona_api = { path = "../viona-api" }
-usdt = { version = "0.2.1", default-features = false }
+usdt = { version = "0.3.2", default-features = false }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "cd74a23ea42ce5e673923a00faf31b0a920191cc", optional = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -31,8 +31,8 @@ num_enum = "0.5"
 ron = "0.7"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
-tokio-tungstenite = "0.14"
-tokio-util = { version = "0.6", features = ["codec"] }
+tokio-tungstenite = "0.17"
+tokio-util = { version = "0.7", features = ["codec"] }
 toml = "0.5"
 semver = { version = "1", features = ["serde"] }
 serde = "1.0"


### PR DESCRIPTION
Coming off the Rust study this week, I ran the propolis build with `--timings` (or `-Z timings` depending on version) and noticed some easy wins. Updating our deps to reduce some duplicates across the compilation graph along with https://github.com/oxidecomputer/rfb/pull/4 gave me about an 11% decrease in clean debug build time.