### PR TITLE
Snapshot and restore VMs with propolis-standalone.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ At a minimum, the build must include the fix for
 [14024](https://www.illumos.org/issues/14024). (Present since commit
 [52fac30](https://github.com/illumos/illumos-gate/commit/52fac30e3e977464254b44b1dfb4717fb8d2fbde))
 
+To exercise the snapshot/restore or live migration functionality a build
+including [14635](https://www.illumos.org/issues/14635)
+([54cf5b6](https://github.com/illumos/illumos-gate/commit/54cf5b63effe805271443d5dd7afd37ec184fbab))
+is required.
+
 To build, run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Given the current tight coupling of the `bhyve-api` component to the ioctl
 interface presented by the bhyve kernel component, running on recent illumos
 bits is required.
 
-At a minimum, the build must include the fix for
-[14024](https://www.illumos.org/issues/14024). (Present since commit
-[52fac30](https://github.com/illumos/illumos-gate/commit/52fac30e3e977464254b44b1dfb4717fb8d2fbde))
-
 To exercise the snapshot/restore or live migration functionality a build
 including [14635](https://www.illumos.org/issues/14635)
 ([54cf5b6](https://github.com/illumos/illumos-gate/commit/54cf5b63effe805271443d5dd7afd37ec184fbab))

--- a/bhyve-api/src/enums.rs
+++ b/bhyve-api/src/enums.rs
@@ -49,6 +49,7 @@ pub enum vm_reg_name {
     VM_REG_GUEST_DR3,
     VM_REG_GUEST_DR6,
     VM_REG_GUEST_ENTRY_INST_LENGTH,
+    VM_REG_GUEST_XCR0,
     VM_REG_LAST,
 }
 

--- a/propolis/src/chardev/file_out.rs
+++ b/propolis/src/chardev/file_out.rs
@@ -1,5 +1,4 @@
 use std::fs::File as FsFile;
-use std::io::Result;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -23,7 +22,7 @@ pub struct BlockingFileOutput {
 const BUF_SIZE: usize = 256;
 
 impl BlockingFileOutput {
-    pub fn new(fp: FsFile) -> Result<Arc<Self>> {
+    pub fn new(fp: FsFile) -> Arc<Self> {
         let params = pollers::BlockingParams {
             poll_interval: Duration::from_millis(10),
             poll_miss_thresh: 5,
@@ -31,7 +30,7 @@ impl BlockingFileOutput {
         };
         let poller = pollers::BlockingSourceBuffer::new(params);
 
-        Ok(Arc::new(Self { poller, inner: Mutex::new(Inner { fp: Some(fp) }) }))
+        Arc::new(Self { poller, inner: Mutex::new(Inner { fp: Some(fp) }) })
     }
 
     pub fn attach(&self, source: Arc<dyn BlockingSource>, disp: &Dispatcher) {

--- a/propolis/src/hw/bhyve/atpic.rs
+++ b/propolis/src/hw/bhyve/atpic.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::dispatch::DispCtx;
 use crate::inventory::Entity;
-use crate::migrate::{Migrate, Migrator};
+use crate::migrate::{Migrate, MigrateStateError, Migrator};
 
 use erased_serde::Serialize;
 
@@ -26,14 +26,26 @@ impl Migrate for BhyveAtPic {
         let hdl = ctx.mctx.hdl();
         Box::new(migrate::BhyveAtPicV1::read(hdl))
     }
+
+    fn import(
+        &self,
+        _dev: &str,
+        deserializer: &mut dyn erased_serde::Deserializer,
+        _ctx: &DispCtx,
+    ) -> Result<(), MigrateStateError> {
+        // TODO: import deserialized state
+        let _deserialized: migrate::BhyveAtPicV1 =
+            erased_serde::deserialize(deserializer)?;
+        Ok(())
+    }
 }
 
 pub mod migrate {
     use crate::vmm;
 
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Copy, Clone, Default, Serialize)]
+    #[derive(Copy, Clone, Default, Deserialize, Serialize)]
     pub struct BhyveAtPicV1 {
         /// XXX: do not expose vdi struct
         pub data: bhyve_api::vdi_atpic_v1,

--- a/propolis/src/hw/bhyve/atpic.rs
+++ b/propolis/src/hw/bhyve/atpic.rs
@@ -31,11 +31,11 @@ impl Migrate for BhyveAtPic {
         &self,
         _dev: &str,
         deserializer: &mut dyn erased_serde::Deserializer,
-        _ctx: &DispCtx,
+        ctx: &DispCtx,
     ) -> Result<(), MigrateStateError> {
-        // TODO: import deserialized state
-        let _deserialized: migrate::BhyveAtPicV1 =
+        let deserialized: migrate::BhyveAtPicV1 =
             erased_serde::deserialize(deserializer)?;
+        deserialized.write(ctx.mctx.hdl())?;
         Ok(())
     }
 }
@@ -57,6 +57,11 @@ pub mod migrate {
                 data: vmm::data::read(hdl, -1, bhyve_api::VDC_ATPIC, 1)
                     .unwrap(),
             }
+        }
+
+        pub(super) fn write(self, hdl: &vmm::VmmHdl) -> std::io::Result<()> {
+            vmm::data::write(hdl, -1, bhyve_api::VDC_ATPIC, 1, self.data)?;
+            Ok(())
         }
     }
 }

--- a/propolis/src/hw/bhyve/atpit.rs
+++ b/propolis/src/hw/bhyve/atpit.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::dispatch::DispCtx;
 use crate::inventory::Entity;
-use crate::migrate::{Migrate, Migrator};
+use crate::migrate::{Migrate, MigrateStateError, Migrator};
 
 use erased_serde::Serialize;
 
@@ -26,14 +26,26 @@ impl Migrate for BhyveAtPit {
         let hdl = ctx.mctx.hdl();
         Box::new(migrate::BhyveAtPitV1::read(hdl))
     }
+
+    fn import(
+        &self,
+        _dev: &str,
+        deserializer: &mut dyn erased_serde::Deserializer,
+        _ctx: &DispCtx,
+    ) -> Result<(), MigrateStateError> {
+        // TODO: import deserialized state
+        let _deserialized: migrate::BhyveAtPitV1 =
+            erased_serde::deserialize(deserializer)?;
+        Ok(())
+    }
 }
 
 pub mod migrate {
     use crate::vmm;
 
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Copy, Clone, Default, Serialize)]
+    #[derive(Copy, Clone, Default, Deserialize, Serialize)]
     pub struct BhyveAtPitV1 {
         /// XXX: do not expose vdi struct
         pub data: bhyve_api::vdi_atpit_v1,

--- a/propolis/src/hw/bhyve/atpit.rs
+++ b/propolis/src/hw/bhyve/atpit.rs
@@ -31,11 +31,11 @@ impl Migrate for BhyveAtPit {
         &self,
         _dev: &str,
         deserializer: &mut dyn erased_serde::Deserializer,
-        _ctx: &DispCtx,
+        ctx: &DispCtx,
     ) -> Result<(), MigrateStateError> {
-        // TODO: import deserialized state
-        let _deserialized: migrate::BhyveAtPitV1 =
+        let deserialized: migrate::BhyveAtPitV1 =
             erased_serde::deserialize(deserializer)?;
+        deserialized.write(ctx.mctx.hdl())?;
         Ok(())
     }
 }
@@ -57,6 +57,11 @@ pub mod migrate {
                 data: vmm::data::read(hdl, -1, bhyve_api::VDC_ATPIT, 1)
                     .unwrap(),
             }
+        }
+
+        pub(super) fn write(self, hdl: &vmm::VmmHdl) -> std::io::Result<()> {
+            vmm::data::write(hdl, -1, bhyve_api::VDC_ATPIT, 1, self.data)?;
+            Ok(())
         }
     }
 }

--- a/propolis/src/hw/bhyve/hpet.rs
+++ b/propolis/src/hw/bhyve/hpet.rs
@@ -31,11 +31,11 @@ impl Migrate for BhyveHpet {
         &self,
         _dev: &str,
         deserializer: &mut dyn erased_serde::Deserializer,
-        _ctx: &DispCtx,
+        ctx: &DispCtx,
     ) -> Result<(), MigrateStateError> {
-        // TODO: import deserialized state
-        let _deserialized: migrate::BhyveHpetV1 =
+        let deserialized: migrate::BhyveHpetV1 =
             erased_serde::deserialize(deserializer)?;
+        deserialized.write(ctx.mctx.hdl())?;
         Ok(())
     }
 }
@@ -56,6 +56,13 @@ pub mod migrate {
             Self {
                 data: vmm::data::read(hdl, -1, bhyve_api::VDC_HPET, 1).unwrap(),
             }
+        }
+
+        pub(super) fn write(self, hdl: &vmm::VmmHdl) -> std::io::Result<()> {
+            // TODO: known failure writing hpet due to the way IRQ validation is currently written
+            let _ =
+                vmm::data::write(hdl, -1, bhyve_api::VDC_HPET, 1, self.data);
+            Ok(())
         }
     }
 }

--- a/propolis/src/hw/bhyve/hpet.rs
+++ b/propolis/src/hw/bhyve/hpet.rs
@@ -59,9 +59,7 @@ pub mod migrate {
         }
 
         pub(super) fn write(self, hdl: &vmm::VmmHdl) -> std::io::Result<()> {
-            // TODO: known failure writing hpet due to the way IRQ validation is currently written
-            let _ =
-                vmm::data::write(hdl, -1, bhyve_api::VDC_HPET, 1, self.data);
+            vmm::data::write(hdl, -1, bhyve_api::VDC_HPET, 1, self.data)?;
             Ok(())
         }
     }

--- a/propolis/src/hw/bhyve/hpet.rs
+++ b/propolis/src/hw/bhyve/hpet.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::dispatch::DispCtx;
 use crate::inventory::Entity;
-use crate::migrate::{Migrate, Migrator};
+use crate::migrate::{Migrate, MigrateStateError, Migrator};
 
 use erased_serde::Serialize;
 
@@ -26,14 +26,26 @@ impl Migrate for BhyveHpet {
         let hdl = ctx.mctx.hdl();
         Box::new(migrate::BhyveHpetV1::read(hdl))
     }
+
+    fn import(
+        &self,
+        _dev: &str,
+        deserializer: &mut dyn erased_serde::Deserializer,
+        _ctx: &DispCtx,
+    ) -> Result<(), MigrateStateError> {
+        // TODO: import deserialized state
+        let _deserialized: migrate::BhyveHpetV1 =
+            erased_serde::deserialize(deserializer)?;
+        Ok(())
+    }
 }
 
 pub mod migrate {
     use crate::vmm;
 
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Copy, Clone, Serialize)]
+    #[derive(Copy, Clone, Deserialize, Serialize)]
     pub struct BhyveHpetV1 {
         /// XXX: do not expose vdi struct
         pub data: bhyve_api::vdi_hpet_v1,

--- a/propolis/src/hw/bhyve/ioapic.rs
+++ b/propolis/src/hw/bhyve/ioapic.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::dispatch::DispCtx;
 use crate::inventory::Entity;
-use crate::migrate::{Migrate, Migrator};
+use crate::migrate::{Migrate, MigrateStateError, Migrator};
 
 use erased_serde::Serialize;
 
@@ -26,14 +26,26 @@ impl Migrate for BhyveIoApic {
         let hdl = ctx.mctx.hdl();
         Box::new(migrate::BhyveIoApicV1::read(hdl))
     }
+
+    fn import(
+        &self,
+        _dev: &str,
+        deserializer: &mut dyn erased_serde::Deserializer,
+        _ctx: &DispCtx,
+    ) -> Result<(), MigrateStateError> {
+        // TODO: import deserialized state
+        let _deserialized: migrate::BhyveIoApicV1 =
+            erased_serde::deserialize(deserializer)?;
+        Ok(())
+    }
 }
 
 pub mod migrate {
     use crate::vmm;
 
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Copy, Clone, Default, Serialize)]
+    #[derive(Copy, Clone, Default, Deserialize, Serialize)]
     pub struct BhyveIoApicV1 {
         pub id: u32,
         pub reg_sel: u32,

--- a/propolis/src/hw/bhyve/pmtimer.rs
+++ b/propolis/src/hw/bhyve/pmtimer.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::dispatch::DispCtx;
 use crate::inventory::Entity;
-use crate::migrate::{Migrate, Migrator};
+use crate::migrate::{Migrate, MigrateStateError, Migrator};
 
 use erased_serde::Serialize;
 
@@ -26,14 +26,26 @@ impl Migrate for BhyvePmTimer {
         let hdl = ctx.mctx.hdl();
         Box::new(migrate::BhyvePmTimerV1::read(hdl))
     }
+
+    fn import(
+        &self,
+        _dev: &str,
+        deserializer: &mut dyn erased_serde::Deserializer,
+        _ctx: &DispCtx,
+    ) -> Result<(), MigrateStateError> {
+        // TODO: import deserialized state
+        let _deserialized: migrate::BhyvePmTimerV1 =
+            erased_serde::deserialize(deserializer)?;
+        Ok(())
+    }
 }
 
 pub mod migrate {
     use crate::vmm;
 
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize, Default)]
+    #[derive(Default, Deserialize, Serialize)]
     pub struct BhyvePmTimerV1 {
         pub start_time: u64,
     }

--- a/propolis/src/hw/bhyve/rtc.rs
+++ b/propolis/src/hw/bhyve/rtc.rs
@@ -1,10 +1,10 @@
-use std::io::Result;
+use std::io;
 use std::sync::Arc;
 use std::time::SystemTime;
 
 use crate::dispatch::DispCtx;
 use crate::inventory::Entity;
-use crate::migrate::{Migrate, Migrator};
+use crate::migrate::{Migrate, MigrateStateError, Migrator};
 use crate::vmm::VmmHdl;
 
 use erased_serde::Serialize;
@@ -24,7 +24,7 @@ impl BhyveRtc {
     /// Synchronizes the time within the virtual machine
     /// represented by `hdl` with the current system clock,
     /// accurate to the second.
-    pub fn set_time(&self, time: SystemTime, hdl: &VmmHdl) -> Result<()> {
+    pub fn set_time(&self, time: SystemTime, hdl: &VmmHdl) -> io::Result<()> {
         hdl.rtc_settime(
             time.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs(),
         )
@@ -39,7 +39,7 @@ impl BhyveRtc {
         lowmem: usize,
         highmem: usize,
         hdl: &VmmHdl,
-    ) -> Result<()> {
+    ) -> io::Result<()> {
         assert!(lowmem >= MEM_BASE);
 
         // physical memory below 4GB (less 16MB base) in 64k chunks
@@ -77,14 +77,26 @@ impl Migrate for BhyveRtc {
         let hdl = ctx.mctx.hdl();
         Box::new(migrate::BhyveRtcV1::read(hdl))
     }
+
+    fn import(
+        &self,
+        _dev: &str,
+        deserializer: &mut dyn erased_serde::Deserializer,
+        _ctx: &DispCtx,
+    ) -> Result<(), MigrateStateError> {
+        // TODO: import deserialized state
+        let _deserialized: migrate::BhyveRtcV1 =
+            erased_serde::deserialize(deserializer)?;
+        Ok(())
+    }
 }
 
 pub mod migrate {
     use crate::vmm;
 
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize)]
+    #[derive(Deserialize, Serialize)]
     pub struct BhyveRtcV1 {
         #[serde(with = "serde_arrays")]
         pub cmos: [u8; 128],

--- a/propolis/src/hw/nvme/mod.rs
+++ b/propolis/src/hw/nvme/mod.rs
@@ -6,7 +6,7 @@ use crate::dispatch::DispCtx;
 use crate::hw::ids::pci::{PROPOLIS_NVME_DEV_ID, VENDOR_OXIDE};
 use crate::hw::ids::OXIDE_OUI;
 use crate::hw::pci;
-use crate::migrate::{Migrate, Migrator};
+use crate::migrate::{Migrate, MigrateStateError, Migrator};
 use crate::util::regmap::RegMap;
 use crate::{block, common::*};
 
@@ -901,13 +901,25 @@ impl Migrate for PciNvme {
     fn export(&self, _ctx: &DispCtx) -> Box<dyn Serialize> {
         Box::new(migrate::PciNvmeStateV1 { pci: self.pci_state.export() })
     }
+
+    fn import(
+        &self,
+        _dev: &str,
+        deserializer: &mut dyn erased_serde::Deserializer,
+        _ctx: &DispCtx,
+    ) -> Result<(), MigrateStateError> {
+        // TODO: import deserialized state
+        let _deserialized: migrate::PciNvmeStateV1 =
+            erased_serde::deserialize(deserializer)?;
+        Ok(())
+    }
 }
 
 pub mod migrate {
     use crate::hw::pci::migrate::PciStateV1;
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize)]
+    #[derive(Deserialize, Serialize)]
     pub struct PciNvmeStateV1 {
         pub pci: PciStateV1,
         // TODO: Add the rest of the controller state

--- a/propolis/src/hw/pci/bar.rs
+++ b/propolis/src/hw/pci/bar.rs
@@ -217,22 +217,24 @@ impl Bars {
 }
 
 pub mod migrate {
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize)]
+    #[derive(Deserialize, Serialize)]
     pub enum BarKindV1 {
         Pio,
         Mmio,
         Mmio64,
     }
-    #[derive(Serialize)]
+
+    #[derive(Deserialize, Serialize)]
     pub struct BarEntryV1 {
         pub n: u8,
         pub kind: BarKindV1,
         pub size: u64,
         pub value: u64,
     }
-    #[derive(Serialize)]
+
+    #[derive(Deserialize, Serialize)]
     pub struct BarStateV1 {
         pub entries: Vec<BarEntryV1>,
     }

--- a/propolis/src/hw/pci/device.rs
+++ b/propolis/src/hw/pci/device.rs
@@ -988,8 +988,6 @@ impl MsixCfg {
                 addr: lentry.addr,
                 data: lentry.data,
                 is_vec_masked: lentry.mask_vec,
-                is_func_masked: lentry.mask_func,
-                is_enabled: lentry.enabled,
                 is_pending: lentry.pending,
             });
         }
@@ -1027,8 +1025,8 @@ impl MsixCfg {
             entry.addr = saved.addr;
             entry.data = saved.data;
             entry.mask_vec = saved.is_vec_masked;
-            entry.mask_func = saved.is_func_masked;
-            entry.enabled = saved.is_enabled;
+            entry.mask_func = state.is_func_masked;
+            entry.enabled = state.is_enabled;
             entry.pending = saved.is_pending;
         }
 
@@ -1207,8 +1205,6 @@ pub mod migrate {
         pub addr: u64,
         pub data: u32,
         pub is_vec_masked: bool,
-        pub is_func_masked: bool,
-        pub is_enabled: bool,
         pub is_pending: bool,
     }
 

--- a/propolis/src/hw/pci/device.rs
+++ b/propolis/src/hw/pci/device.rs
@@ -602,6 +602,14 @@ impl DeviceState {
         inner.reg_intr_line = state.reg_intr_line;
         inner.bars.import(state.bars)?;
 
+        // Reattach any imported Bars to their respective handlers (pio, mmio)
+        let attach = inner.attached();
+        for n in BarN::iter() {
+            if let Some((def, addr)) = inner.bars.get(n) {
+                attach.bar_register(n, def, addr);
+            }
+        }
+
         match (self.msix_cfg.as_ref(), state.msix) {
             (Some(msix_cfg), Some(saved_cfg)) => msix_cfg.import(saved_cfg)?,
             (None, None) => {}

--- a/propolis/src/hw/pci/device.rs
+++ b/propolis/src/hw/pci/device.rs
@@ -1116,9 +1116,9 @@ impl Builder {
 pub mod migrate {
     use crate::hw::pci::bar;
 
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize)]
+    #[derive(Deserialize, Serialize)]
     pub struct MsixEntryV1 {
         pub addr: u64,
         pub data: u32,
@@ -1126,7 +1126,7 @@ pub mod migrate {
         pub is_vec_masked: bool,
     }
 
-    #[derive(Serialize)]
+    #[derive(Deserialize, Serialize)]
     pub struct MsixStateV1 {
         pub count: u16,
         pub is_enabled: bool,
@@ -1134,7 +1134,7 @@ pub mod migrate {
         pub entries: Vec<MsixEntryV1>,
     }
 
-    #[derive(Serialize)]
+    #[derive(Deserialize, Serialize)]
     pub struct PciStateV1 {
         pub reg_command: u16,
         pub reg_intr_line: u8,

--- a/propolis/src/hw/pci/device.rs
+++ b/propolis/src/hw/pci/device.rs
@@ -974,8 +974,10 @@ impl MsixCfg {
             entries.push(migrate::MsixEntryV1 {
                 addr: lentry.addr,
                 data: lentry.data,
-                is_pending: lentry.pending,
                 is_vec_masked: lentry.mask_vec,
+                is_func_masked: lentry.mask_func,
+                is_enabled: lentry.enabled,
+                is_pending: lentry.pending,
             });
         }
         migrate::MsixStateV1 {
@@ -1011,9 +1013,10 @@ impl MsixCfg {
             let mut entry = entry.lock().unwrap();
             entry.addr = saved.addr;
             entry.data = saved.data;
-            entry.pending = saved.is_pending;
             entry.mask_vec = saved.is_vec_masked;
-            // TODO: what about mask_func and enabled?
+            entry.mask_func = saved.is_func_masked;
+            entry.enabled = saved.is_enabled;
+            entry.pending = saved.is_pending;
         }
 
         Ok(())
@@ -1190,8 +1193,10 @@ pub mod migrate {
     pub struct MsixEntryV1 {
         pub addr: u64,
         pub data: u32,
-        pub is_pending: bool,
         pub is_vec_masked: bool,
+        pub is_func_masked: bool,
+        pub is_enabled: bool,
+        pub is_pending: bool,
     }
 
     #[derive(Deserialize, Serialize)]

--- a/propolis/src/hw/pci/device.rs
+++ b/propolis/src/hw/pci/device.rs
@@ -606,7 +606,12 @@ impl DeviceState {
         let attach = inner.attached();
         for n in BarN::iter() {
             if let Some((def, addr)) = inner.bars.get(n) {
-                attach.bar_register(n, def, addr);
+                let pio_en = inner.reg_command.contains(RegCmd::IO_EN);
+                let mmio_en = inner.reg_command.contains(RegCmd::MMIO_EN);
+
+                if (pio_en && def.is_pio()) || (mmio_en && def.is_mmio()) {
+                    attach.bar_register(n, def, addr);
+                }
             }
         }
 

--- a/propolis/src/hw/pci/mod.rs
+++ b/propolis/src/hw/pci/mod.rs
@@ -258,6 +258,11 @@ impl PioCfgDecoder {
         let addr = self.addr.lock().unwrap();
         *addr
     }
+
+    pub(super) fn set_addr(&self, addr: u32) {
+        let mut inner = self.addr.lock().unwrap();
+        *inner = addr;
+    }
 }
 
 pub struct PcieCfgDecoder {

--- a/propolis/src/hw/qemu/fwcfg.rs
+++ b/propolis/src/hw/qemu/fwcfg.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::common::*;
 use crate::dispatch::DispCtx;
-use crate::migrate::{Migrate, Migrator};
+use crate::migrate::{Migrate, MigrateStateError, Migrator};
 use crate::pio::{PioBus, PioFn};
 use bits::*;
 
@@ -668,12 +668,24 @@ impl Migrate for FwCfg {
             offset: state.offset,
         })
     }
+
+    fn import(
+        &self,
+        _dev: &str,
+        deserializer: &mut dyn erased_serde::Deserializer,
+        _ctx: &DispCtx,
+    ) -> std::result::Result<(), MigrateStateError> {
+        // TODO: import deserialized state
+        let _deserialized: migrate::FwCfgV1 =
+            erased_serde::deserialize(deserializer)?;
+        Ok(())
+    }
 }
 
 pub mod migrate {
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize)]
+    #[derive(Deserialize, Serialize)]
     pub struct FwCfgV1 {
         pub dma_addr: u64,
         pub selector: u16,

--- a/propolis/src/hw/qemu/fwcfg.rs
+++ b/propolis/src/hw/qemu/fwcfg.rs
@@ -675,9 +675,15 @@ impl Migrate for FwCfg {
         deserializer: &mut dyn erased_serde::Deserializer,
         _ctx: &DispCtx,
     ) -> std::result::Result<(), MigrateStateError> {
-        // TODO: import deserialized state
-        let _deserialized: migrate::FwCfgV1 =
+        let deserialized: migrate::FwCfgV1 =
             erased_serde::deserialize(deserializer)?;
+
+        let mut inner = self.state.lock().unwrap();
+        inner.addr_low = deserialized.dma_addr as u32;
+        inner.addr_high = (deserialized.dma_addr >> 32) as u32;
+        inner.selector = deserialized.selector;
+        inner.offset = deserialized.offset;
+
         Ok(())
     }
 }

--- a/propolis/src/hw/uart/base.rs
+++ b/propolis/src/hw/uart/base.rs
@@ -301,9 +301,9 @@ impl Fifo {
 }
 
 pub mod migrate {
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize)]
+    #[derive(Deserialize, Serialize)]
     pub struct UartV1 {
         pub intr_enable: u8,
         pub intr_status: u8,

--- a/propolis/src/hw/uart/base.rs
+++ b/propolis/src/hw/uart/base.rs
@@ -267,6 +267,19 @@ impl Uart {
             thre_state: self.thre_intr,
         }
     }
+
+    pub(super) fn import(&mut self, state: &migrate::UartV1) {
+        self.reg_intr_enable = state.intr_enable;
+        self.reg_intr_status = state.intr_status;
+        self.reg_line_ctrl = state.line_ctrl;
+        self.reg_line_status = state.line_status;
+        self.reg_modem_ctrl = state.modem_ctrl;
+        self.reg_modem_status = state.modem_status;
+        self.reg_scratch = state.scratch;
+        self.reg_div_low = state.div_low;
+        self.reg_div_high = state.div_high;
+        self.thre_intr = state.thre_state;
+    }
 }
 
 struct Fifo {

--- a/propolis/src/hw/uart/lpc.rs
+++ b/propolis/src/hw/uart/lpc.rs
@@ -5,7 +5,7 @@ use crate::chardev::*;
 use crate::common::*;
 use crate::dispatch::DispCtx;
 use crate::intr_pins::{IntrPin, LegacyPin};
-use crate::migrate::{Migrate, Migrator};
+use crate::migrate::{Migrate, MigrateStateError, Migrator};
 use crate::pio::{PioBus, PioFn};
 
 use erased_serde::Serialize;
@@ -150,13 +150,25 @@ impl Migrate for LpcUart {
         let state = self.state.lock().unwrap();
         Box::new(migrate::LpcUartV1 { uart_state: state.uart.export() })
     }
+
+    fn import(
+        &self,
+        _dev: &str,
+        deserializer: &mut dyn erased_serde::Deserializer,
+        _ctx: &DispCtx,
+    ) -> Result<(), MigrateStateError> {
+        // TODO: import deserialized state
+        let _deserialized: migrate::LpcUartV1 =
+            erased_serde::deserialize(deserializer)?;
+        Ok(())
+    }
 }
 
 pub mod migrate {
     use crate::hw::uart::base::migrate::UartV1;
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize)]
+    #[derive(Deserialize, Serialize)]
     pub struct LpcUartV1 {
         pub uart_state: UartV1,
     }

--- a/propolis/src/hw/uart/lpc.rs
+++ b/propolis/src/hw/uart/lpc.rs
@@ -157,9 +157,10 @@ impl Migrate for LpcUart {
         deserializer: &mut dyn erased_serde::Deserializer,
         _ctx: &DispCtx,
     ) -> Result<(), MigrateStateError> {
-        // TODO: import deserialized state
-        let _deserialized: migrate::LpcUartV1 =
+        let deserialized: migrate::LpcUartV1 =
             erased_serde::deserialize(deserializer)?;
+        let mut state = self.state.lock().unwrap();
+        state.uart.import(&deserialized.uart_state);
         Ok(())
     }
 }

--- a/propolis/src/hw/virtio/block.rs
+++ b/propolis/src/hw/virtio/block.rs
@@ -5,7 +5,7 @@ use crate::block;
 use crate::common::*;
 use crate::dispatch::DispCtx;
 use crate::hw::pci;
-use crate::migrate::{Migrate, Migrator};
+use crate::migrate::{Migrate, MigrateStateError, Migrator};
 use crate::util::regmap::RegMap;
 
 use super::bits::*;
@@ -204,6 +204,18 @@ impl Migrate for PciVirtioBlock {
             pci_virtio_state: self.virtio_state.export(&self.pci_state),
         })
     }
+
+    fn import(
+        &self,
+        _dev: &str,
+        deserializer: &mut dyn erased_serde::Deserializer,
+        _ctx: &DispCtx,
+    ) -> Result<(), MigrateStateError> {
+        // TODO: import deserialized state
+        let _deserialized: migrate::PciVirtioBlockV1 =
+            erased_serde::deserialize(deserializer)?;
+        Ok(())
+    }
 }
 
 fn complete_blockreq(
@@ -285,9 +297,9 @@ lazy_static! {
 
 pub mod migrate {
     use crate::hw::virtio::pci::migrate::PciVirtioStateV1;
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize)]
+    #[derive(Deserialize, Serialize)]
     pub struct PciVirtioBlockV1 {
         pub pci_virtio_state: PciVirtioStateV1,
     }

--- a/propolis/src/hw/virtio/block.rs
+++ b/propolis/src/hw/virtio/block.rs
@@ -211,9 +211,15 @@ impl Migrate for PciVirtioBlock {
         deserializer: &mut dyn erased_serde::Deserializer,
         _ctx: &DispCtx,
     ) -> Result<(), MigrateStateError> {
-        // TODO: import deserialized state
-        let _deserialized: migrate::PciVirtioBlockV1 =
+        let deserialized: migrate::PciVirtioBlockV1 =
             erased_serde::deserialize(deserializer)?;
+
+        // TODO: separate pci and virtio state into separate fields?
+        // Kinda cludgy to give the whole thing to virtio_state and have it return
+        // just the pci bits.
+        let pci_state =
+            self.virtio_state.import(deserialized.pci_virtio_state)?;
+        self.pci_state.import(pci_state)?;
         Ok(())
     }
 }

--- a/propolis/src/hw/virtio/block.rs
+++ b/propolis/src/hw/virtio/block.rs
@@ -217,8 +217,9 @@ impl Migrate for PciVirtioBlock {
         // TODO: separate pci and virtio state into separate fields?
         // Kinda cludgy to give the whole thing to virtio_state and have it return
         // just the pci bits.
+        let hdl = self.pci_state.msix_hdl().unwrap();
         let pci_state =
-            self.virtio_state.import(deserialized.pci_virtio_state)?;
+            self.virtio_state.import(deserialized.pci_virtio_state, hdl)?;
         self.pci_state.import(pci_state)?;
         Ok(())
     }

--- a/propolis/src/hw/virtio/pci.rs
+++ b/propolis/src/hw/virtio/pci.rs
@@ -11,6 +11,7 @@ use crate::dispatch::DispCtx;
 use crate::hw::ids::pci::VENDOR_VIRTIO;
 use crate::hw::pci;
 use crate::intr_pins::IntrPin;
+use crate::migrate::MigrateStateError;
 use crate::util::regmap::RegMap;
 
 use lazy_static::lazy_static;
@@ -75,6 +76,23 @@ impl VirtioState {
             msix_cfg_vec: self.msix_cfg_vec,
             msix_queue_vec: self.msix_queue_vec.clone(),
         }
+    }
+    pub fn import(
+        &mut self,
+        state: migrate::VirtioStateV1,
+    ) -> Result<(), MigrateStateError> {
+        self.status = Status::from_bits(state.status).ok_or_else(|| {
+            MigrateStateError::ImportFailed(format!(
+                "virtio status: failed to import saved value {:#x}",
+                state.status
+            ))
+        })?;
+        self.queue_sel = state.queue_sel;
+        self.nego_feat = state.nego_feat;
+        self.msix_cfg_vec = state.msix_cfg_vec;
+        self.msix_queue_vec = state.msix_queue_vec;
+        // TODO: intr_mode*
+        Ok(())
     }
 }
 
@@ -497,6 +515,22 @@ impl PciVirtioState {
             queues,
             isr: isr_inner.value != 0,
         }
+    }
+    pub fn import(
+        &self,
+        state: migrate::PciVirtioStateV1,
+    ) -> Result<pci::migrate::PciStateV1, MigrateStateError> {
+        let mut inner = self.state.lock().unwrap();
+        inner.import(state.state)?;
+
+        let mut isr_inner = self.isr_state.inner.lock().unwrap();
+        isr_inner.value = state.isr as u8;
+
+        for (q, state) in self.queues[..].iter().zip(state.queues.into_iter()) {
+            q.import(state)?;
+        }
+
+        Ok(state.pci)
     }
 }
 

--- a/propolis/src/hw/virtio/pci.rs
+++ b/propolis/src/hw/virtio/pci.rs
@@ -648,9 +648,9 @@ lazy_static! {
 pub mod migrate {
     use crate::hw::pci::migrate::PciStateV1;
     use crate::hw::virtio::queue;
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize)]
+    #[derive(Deserialize, Serialize)]
     pub struct VirtioStateV1 {
         pub status: u8,
         pub queue_sel: u16,
@@ -659,7 +659,7 @@ pub mod migrate {
         pub msix_queue_vec: Vec<u16>,
     }
 
-    #[derive(Serialize)]
+    #[derive(Deserialize, Serialize)]
     pub struct PciVirtioStateV1 {
         pub pci: PciStateV1,
         pub state: VirtioStateV1,

--- a/propolis/src/hw/virtio/queue.rs
+++ b/propolis/src/hw/virtio/queue.rs
@@ -309,11 +309,11 @@ impl VirtQueue {
             size: self.size,
             descr_gpa: ctrl.gpa_desc.0,
 
-            avail_gpa: avail.gpa_idx.0,
+            avail_gpa: avail.gpa_flags.0,
             avail_valid: avail.valid,
             avail_cur_idx: avail.cur_avail_idx.0,
 
-            used_gpa: used.gpa_idx.0,
+            used_gpa: used.gpa_flags.0,
             used_valid: used.valid,
             used_idx: used.used_idx.0,
         }
@@ -340,14 +340,19 @@ impl VirtQueue {
             )));
         }
 
-        ctrl.gpa_desc.0 = state.descr_gpa;
+        ctrl.gpa_desc = GuestAddr(state.descr_gpa);
 
-        avail.gpa_idx.0 = state.avail_gpa;
         avail.valid = state.avail_valid;
+        avail.gpa_flags = GuestAddr(state.avail_gpa);
+        avail.gpa_idx = GuestAddr(state.avail_gpa + 2);
+        avail.gpa_ring = GuestAddr(state.avail_gpa + 4);
+        avail.gpa_desc = GuestAddr(state.descr_gpa);
         avail.cur_avail_idx.0 = state.avail_cur_idx;
 
-        used.gpa_idx.0 = state.used_gpa;
         used.valid = state.used_valid;
+        used.gpa_flags = GuestAddr(state.used_gpa);
+        used.gpa_idx = GuestAddr(state.used_gpa + 2);
+        used.gpa_ring = GuestAddr(state.used_gpa + 4);
         used.used_idx.0 = state.used_idx;
 
         Ok(())

--- a/propolis/src/hw/virtio/queue.rs
+++ b/propolis/src/hw/virtio/queue.rs
@@ -616,9 +616,9 @@ impl<S: SliceIndex<[Arc<VirtQueue>]>> Index<S> for VirtQueues {
 }
 
 pub mod migrate {
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize)]
+    #[derive(Deserialize, Serialize)]
     pub struct VirtQueueV1 {
         pub id: u16,
         pub size: u16,

--- a/propolis/src/instance.rs
+++ b/propolis/src/instance.rs
@@ -182,7 +182,7 @@ pub enum TransitionError {
 }
 
 type TransitionFunc =
-    dyn Fn(State, &Inventory, &DispCtx) + Send + Sync + 'static;
+    dyn Fn(State, Option<State>, &Inventory, &DispCtx) + Send + Sync + 'static;
 
 struct Inner {
     state_current: State,
@@ -539,7 +539,7 @@ impl Instance {
             // notifications for now.
             if phase == TransitionPhase::Post {
                 for f in inner.transition_funcs.iter() {
-                    f(state, &inner.inv, ctx)
+                    f(state, target, &inner.inv, ctx)
                 }
             }
         });

--- a/propolis/src/instance.rs
+++ b/propolis/src/instance.rs
@@ -617,7 +617,11 @@ impl Instance {
 
             // Implicit actions for a state change
             match state {
-                State::Boot => {
+                // Gated on Illumos here because the non-Illumos test runners
+                // still create a fake Instance which transitions through to
+                // the "Run" state and would otherwise fail on the ioctl calls
+                // invoked here.
+                State::Boot if cfg!(target_os = "illumos") => {
                     // Set vCPUs to their proper boot (INIT) state
                     for vcpu in &inner.machine.as_ref().unwrap().vcpus {
                         vcpu.reboot_state().unwrap();

--- a/propolis/src/instance.rs
+++ b/propolis/src/instance.rs
@@ -734,7 +734,12 @@ impl Drop for Instance {
                 })
                 .unwrap();
         }
-        let _joined = state.drive_thread.take().unwrap().join();
+        let join_handle = state.drive_thread.take().unwrap();
+        // The last Instance handle may be held by the drive_thread itself
+        // which would mean a deadlock or error if we tried to join
+        if std::thread::current().id() != join_handle.thread().id() {
+            let _joined = join_handle.join();
+        }
     }
 }
 

--- a/propolis/src/instance.rs
+++ b/propolis/src/instance.rs
@@ -488,9 +488,9 @@ impl Instance {
     pub fn wait_for_state(&self, target: State) {
         let mut state = self.inner.lock().unwrap();
         self.cv.wait_while(state, |state| {
-            // bail if we reach the target state _or Destroy
+            // bail if we reach the target state or Destroy
             state.state_current != target
-                || state.state_current != State::Destroy
+                && state.state_current != State::Destroy
         });
     }
 

--- a/propolis/src/migrate.rs
+++ b/propolis/src/migrate.rs
@@ -19,11 +19,21 @@ pub enum MigrateStateError {
     /// The device doesn't implement [`Migrate::import`].
     #[error("device state importation unimplemented for `{0}`")]
     ImportUnimplmented(String),
+
+    /// The device failed to import the deserialized device state.
+    #[error("failed to apply deserialized device state: {0}")]
+    ImportFailed(String),
 }
 
 impl From<erased_serde::Error> for MigrateStateError {
     fn from(err: erased_serde::Error) -> Self {
         MigrateStateError::ImportDeserialization(err.to_string())
+    }
+}
+
+impl From<std::io::Error> for MigrateStateError {
+    fn from(err: std::io::Error) -> Self {
+        MigrateStateError::ImportFailed(err.to_string())
     }
 }
 

--- a/propolis/src/vcpu.rs
+++ b/propolis/src/vcpu.rs
@@ -270,6 +270,7 @@ pub mod migrate {
         pub dr3: u64,
         pub dr6: u64,
         pub dr7: u64,
+        pub xcr0: u64,
     }
 
     #[derive(Copy, Clone, Default, Deserialize, Serialize)]
@@ -381,6 +382,7 @@ pub mod migrate {
                 dr3: vcpu.get_reg(vm_reg_name::VM_REG_GUEST_DR3)?,
                 dr6: vcpu.get_reg(vm_reg_name::VM_REG_GUEST_DR6)?,
                 dr7: vcpu.get_reg(vm_reg_name::VM_REG_GUEST_DR7)?,
+                xcr0: vcpu.get_reg(vm_reg_name::VM_REG_GUEST_XCR0)?,
             })
         }
 
@@ -395,6 +397,7 @@ pub mod migrate {
             vcpu.set_reg(vm_reg_name::VM_REG_GUEST_DR3, self.dr3)?;
             vcpu.set_reg(vm_reg_name::VM_REG_GUEST_DR6, self.dr6)?;
             vcpu.set_reg(vm_reg_name::VM_REG_GUEST_DR7, self.dr7)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_XCR0, self.xcr0)?;
             Ok(())
         }
     }

--- a/propolis/src/vcpu.rs
+++ b/propolis/src/vcpu.rs
@@ -189,20 +189,20 @@ impl Migrate for Vcpu {
         deserializer: &mut dyn erased_serde::Deserializer,
         _ctx: &DispCtx,
     ) -> std::result::Result<(), MigrateStateError> {
-        // TODO: import deserialized state
-        let _deserialized: migrate::BhyveVcpuV1 =
+        let deserialized: migrate::BhyveVcpuV1 =
             erased_serde::deserialize(deserializer)?;
+        deserialized.write(self)?;
         Ok(())
     }
 }
 
 pub mod migrate {
-    use std::io;
+    use std::{convert::TryInto, io};
 
     use super::Vcpu;
     use crate::vmm;
 
-    use bhyve_api::vm_reg_name;
+    use bhyve_api::{vdi_field_entry_v1, vm_reg_name};
     use serde::{Deserialize, Serialize};
 
     #[derive(Clone, Default, Deserialize, Serialize)]
@@ -313,7 +313,30 @@ pub mod migrate {
                 rflags: vcpu.get_reg(vm_reg_name::VM_REG_GUEST_RFLAGS)?,
             })
         }
+
+        fn write(self, vcpu: &Vcpu) -> io::Result<()> {
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_RAX, self.rax)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_RCX, self.rcx)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_RDX, self.rdx)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_RBX, self.rbx)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_RSP, self.rsp)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_RBP, self.rbp)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_RSI, self.rsi)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_RDI, self.rdi)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_R8, self.r8)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_R9, self.r9)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_R10, self.r10)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_R11, self.r11)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_R12, self.r12)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_R13, self.r13)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_R14, self.r14)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_R15, self.r15)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_RIP, self.rip)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_RFLAGS, self.rflags)?;
+            Ok(())
+        }
     }
+
     impl CtrlRegsV1 {
         pub(super) fn read(vcpu: &Vcpu) -> io::Result<Self> {
             Ok(Self {
@@ -329,7 +352,22 @@ pub mod migrate {
                 dr7: vcpu.get_reg(vm_reg_name::VM_REG_GUEST_DR7)?,
             })
         }
+
+        fn write(self, vcpu: &Vcpu) -> io::Result<()> {
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_CR0, self.cr0)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_CR2, self.cr2)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_CR3, self.cr3)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_CR4, self.cr4)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_DR0, self.dr0)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_DR1, self.dr1)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_DR2, self.dr2)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_DR3, self.dr3)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_DR6, self.dr6)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_DR7, self.dr7)?;
+            Ok(())
+        }
     }
+
     impl SegRegsV1 {
         pub(super) fn read(vcpu: &Vcpu) -> io::Result<Self> {
             let cs = SegDescV1::from_raw(
@@ -374,7 +412,47 @@ pub mod migrate {
             );
             Ok(Self { cs, ds, es, fs, gs, ss, gdtr, idtr, ldtr, tr })
         }
+
+        fn write(self, vcpu: &Vcpu) -> io::Result<()> {
+            let (cs, css) = self.cs.into_raw();
+            vcpu.set_segreg(vm_reg_name::VM_REG_GUEST_CS, &cs)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_CS, css.into())?;
+
+            let (ds, dss) = self.ds.into_raw();
+            vcpu.set_segreg(vm_reg_name::VM_REG_GUEST_DS, &ds)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_DS, dss.into())?;
+
+            let (es, ess) = self.es.into_raw();
+            vcpu.set_segreg(vm_reg_name::VM_REG_GUEST_ES, &es)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_ES, ess.into())?;
+
+            let (fs, fss) = self.fs.into_raw();
+            vcpu.set_segreg(vm_reg_name::VM_REG_GUEST_FS, &fs)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_FS, fss.into())?;
+
+            let (gs, gss) = self.gs.into_raw();
+            vcpu.set_segreg(vm_reg_name::VM_REG_GUEST_GS, &gs)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_GS, gss.into())?;
+
+            let (ss, sss) = self.ss.into_raw();
+            vcpu.set_segreg(vm_reg_name::VM_REG_GUEST_SS, &ss)?;
+            vcpu.set_reg(vm_reg_name::VM_REG_GUEST_SS, sss.into())?;
+
+            let (gdtr, _) = self.gdtr.into_raw();
+            vcpu.set_segreg(vm_reg_name::VM_REG_GUEST_GDTR, &gdtr)?;
+
+            let (idtr, _) = self.idtr.into_raw();
+            vcpu.set_segreg(vm_reg_name::VM_REG_GUEST_IDTR, &idtr)?;
+
+            let (ldtr, _) = self.ldtr.into_raw();
+            vcpu.set_segreg(vm_reg_name::VM_REG_GUEST_LDTR, &ldtr)?;
+
+            let (tr, _) = self.tr.into_raw();
+            vcpu.set_segreg(vm_reg_name::VM_REG_GUEST_TR, &tr)?;
+            Ok(())
+        }
     }
+
     impl SegDescV1 {
         fn from_raw(inp: bhyve_api::seg_desc, selector: u16) -> Self {
             Self {
@@ -384,12 +462,33 @@ pub mod migrate {
                 selector,
             }
         }
+        fn into_raw(self) -> (bhyve_api::seg_desc, u16) {
+            (
+                bhyve_api::seg_desc {
+                    base: self.base,
+                    limit: self.limit,
+                    access: self.access,
+                },
+                self.selector,
+            )
+        }
     }
-    impl From<bhyve_api::vdi_field_entry_v1> for MsrEntryV1 {
-        fn from(raw: bhyve_api::vdi_field_entry_v1) -> Self {
+
+    impl From<vdi_field_entry_v1> for MsrEntryV1 {
+        fn from(raw: vdi_field_entry_v1) -> Self {
             Self { ident: raw.vfe_ident, value: raw.vfe_value }
         }
     }
+    impl From<MsrEntryV1> for vdi_field_entry_v1 {
+        fn from(entry: MsrEntryV1) -> Self {
+            vdi_field_entry_v1 {
+                vfe_ident: entry.ident,
+                vfe_value: entry.value,
+                ..Default::default()
+            }
+        }
+    }
+
     impl FpuStateV1 {
         pub(super) fn read(vcpu: &Vcpu) -> io::Result<Self> {
             let mut fpu_area_desc = bhyve_api::vm_fpu_desc::default();
@@ -407,6 +506,21 @@ pub mod migrate {
             vcpu.hdl.ioctl(bhyve_api::VM_GET_FPU, &mut fpu_req)?;
 
             Ok(Self { blob: fpu })
+        }
+
+        fn write(mut self, vcpu: &Vcpu) -> io::Result<()> {
+            let mut fpu_req = bhyve_api::vm_fpu_state {
+                vcpuid: vcpu.cpuid(),
+                buf: self.blob.as_mut_ptr() as *mut _,
+                len: self.blob.len().try_into().map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        "fpu blob size too large",
+                    )
+                })?,
+            };
+            vcpu.hdl.ioctl(bhyve_api::VM_SET_FPU, &mut fpu_req)?;
+            Ok(())
         }
     }
 
@@ -428,6 +542,35 @@ pub mod migrate {
                 ms_regs: msrs.into_iter().map(MsrEntryV1::from).collect(),
             };
             res
+        }
+
+        pub(super) fn write(self, vcpu: &Vcpu) -> io::Result<()> {
+            let hdl = &vcpu.hdl;
+            let mut msrs: Vec<vdi_field_entry_v1> = self
+                .ms_regs
+                .into_iter()
+                .filter(|entry| entry.ident != 0xFE) // TODO: writes to mtrrcap not allowed
+                .map(From::from)
+                .collect();
+            vmm::data::write_many(
+                hdl,
+                vcpu.cpuid(),
+                bhyve_api::VDC_MSR,
+                1,
+                &mut msrs,
+            )?;
+            vmm::data::write(
+                hdl,
+                vcpu.cpuid(),
+                bhyve_api::VDC_LAPIC,
+                1,
+                self.lapic,
+            )?;
+            self.gp_regs.write(vcpu)?;
+            self.ctrl_regs.write(vcpu)?;
+            self.seg_regs.write(vcpu)?;
+            self.fpu_state.write(vcpu)?;
+            Ok(())
         }
     }
 }

--- a/propolis/src/vmm/data.rs
+++ b/propolis/src/vmm/data.rs
@@ -142,8 +142,7 @@ pub fn write_many<T: Sized>(
         vdx_result_len: 0,
         vdx_data: data.as_mut_ptr() as *mut c_void,
     };
-    let _bytes_written = ioctl_xlate(hdl, bhyve_api::VM_DATA_WRITE, &mut xfer)?;
-    // TODO: uncomment. writing the MSRs trips this
-    // assert_eq!(bytes_written, write_len);
+    let bytes_written = ioctl_xlate(hdl, bhyve_api::VM_DATA_WRITE, &mut xfer)?;
+    assert_eq!(bytes_written, write_len);
     Ok(())
 }

--- a/propolis/src/vmm/data.rs
+++ b/propolis/src/vmm/data.rs
@@ -142,7 +142,8 @@ pub fn write_many<T: Sized>(
         vdx_result_len: 0,
         vdx_data: data.as_mut_ptr() as *mut c_void,
     };
-    let bytes_written = ioctl_xlate(hdl, bhyve_api::VM_DATA_WRITE, &mut xfer)?;
-    assert_eq!(bytes_written, write_len);
+    let _bytes_written = ioctl_xlate(hdl, bhyve_api::VM_DATA_WRITE, &mut xfer)?;
+    // TODO: restore once `vmm_data_write_vmm_arch` updates the count on return
+    // assert_eq!(bytes_written, write_len);
     Ok(())
 }

--- a/propolis/src/vmm/data.rs
+++ b/propolis/src/vmm/data.rs
@@ -14,6 +14,23 @@ pub enum VmmDataError {
     SpaceNeeded(u32),
 }
 
+impl From<VmmDataError> for std::io::Error {
+    fn from(err: VmmDataError) -> Self {
+        use std::io::{Error, ErrorKind};
+        match err {
+            VmmDataError::IoError(e) => e,
+            VmmDataError::SpaceNeeded(c) => {
+                // ErrorKind::StorageFull would more accurately match the underlying ENOSPC
+                // but that variant is unstable still
+                Error::new(
+                    ErrorKind::Other,
+                    format!("operation requires {} bytes", c),
+                )
+            }
+        }
+    }
+}
+
 fn ioctl_xlate(
     hdl: &VmmHdl,
     op: i32,
@@ -125,7 +142,8 @@ pub fn write_many<T: Sized>(
         vdx_result_len: 0,
         vdx_data: data.as_mut_ptr() as *mut c_void,
     };
-    let bytes_written = ioctl_xlate(hdl, bhyve_api::VM_DATA_WRITE, &mut xfer)?;
-    assert_eq!(bytes_written, write_len);
+    let _bytes_written = ioctl_xlate(hdl, bhyve_api::VM_DATA_WRITE, &mut xfer)?;
+    // TODO: uncomment. writing the MSRs trips this
+    // assert_eq!(bytes_written, write_len);
     Ok(())
 }

--- a/propolis/src/vmm/hdl.rs
+++ b/propolis/src/vmm/hdl.rs
@@ -7,6 +7,8 @@
 //! for encapsulating commands to the underlying kernel
 //! object which represents a single VM.
 
+use erased_serde::{Deserializer, Serialize};
+
 use super::mapping::*;
 use std::fs::{File, OpenOptions};
 use std::io::{Error, ErrorKind, Result, Write};
@@ -17,6 +19,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::common::PAGE_SIZE;
+use crate::migrate::MigrateStateError;
 use crate::util::sys::ioctl;
 
 #[derive(Default, Copy, Clone)]
@@ -418,6 +421,24 @@ impl VmmHdl {
             destroy_vm(&self.name)
         }
     }
+
+    /// Export the global VMM state.
+    pub fn export(
+        &self,
+    ) -> std::result::Result<Box<dyn Serialize>, MigrateStateError> {
+        Ok(Box::new(migrate::BhyveVmV1::read(self)?))
+    }
+
+    /// Restore previously exported global VMM state.
+    pub fn import(
+        &self,
+        deserializer: &mut dyn Deserializer,
+    ) -> std::result::Result<(), MigrateStateError> {
+        let deserialized: migrate::BhyveVmV1 =
+            erased_serde::deserialize(deserializer)?;
+        deserialized.write(self)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -457,4 +478,72 @@ pub fn query_reservoir() -> Result<bhyve_api::vmm_resv_query> {
 #[cfg(not(target_os = "illumos"))]
 pub fn query_reservoir() -> Result<bhyve_api::vmm_resv_query> {
     Err(Error::new(ErrorKind::Other, "illumos required"))
+}
+
+pub mod migrate {
+    use std::io;
+
+    use bhyve_api::vdi_field_entry_v1;
+    use serde::{Deserialize, Serialize};
+
+    use crate::vmm;
+
+    use super::VmmHdl;
+
+    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    pub struct BhyveVmV1 {
+        arch_entries: Vec<ArchEntryV1>,
+    }
+
+    #[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
+    pub struct ArchEntryV1 {
+        pub ident: u32,
+        pub value: u64,
+    }
+
+    impl From<vdi_field_entry_v1> for ArchEntryV1 {
+        fn from(raw: vdi_field_entry_v1) -> Self {
+            Self { ident: raw.vfe_ident, value: raw.vfe_value }
+        }
+    }
+    impl From<ArchEntryV1> for vdi_field_entry_v1 {
+        fn from(entry: ArchEntryV1) -> Self {
+            vdi_field_entry_v1 {
+                vfe_ident: entry.ident,
+                vfe_value: entry.value,
+                ..Default::default()
+            }
+        }
+    }
+
+    impl BhyveVmV1 {
+        pub(super) fn read(hdl: &VmmHdl) -> io::Result<Self> {
+            let arch_entries: Vec<bhyve_api::vdi_field_entry_v1> =
+                vmm::data::read_many(hdl, -1, bhyve_api::VDC_VMM_ARCH, 1)?;
+            Ok(Self {
+                arch_entries: arch_entries
+                    .into_iter()
+                    .map(From::from)
+                    .collect(),
+            })
+        }
+
+        pub(super) fn write(self, hdl: &VmmHdl) -> io::Result<()> {
+            let mut arch_entries: Vec<bhyve_api::vdi_field_entry_v1> = self
+                .arch_entries
+                .into_iter()
+                // TODO: Guest TSC frequency is not currently adjustable
+                .filter(|e| e.ident != bhyve_api::VAI_TSC_FREQ)
+                .map(From::from)
+                .collect();
+            vmm::data::write_many(
+                hdl,
+                -1,
+                bhyve_api::VDC_VMM_ARCH,
+                1,
+                &mut arch_entries,
+            )?;
+            Ok(())
+        }
+    }
 }

--- a/propolis/src/vmm/mapping.rs
+++ b/propolis/src/vmm/mapping.rs
@@ -6,7 +6,6 @@ use crate::common::PAGE_SIZE;
 use crate::util::aspace::ASpace;
 use crate::vmm::VmmFile;
 
-use std::fs::File;
 use std::io::{Error, ErrorKind, Result};
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
@@ -371,7 +370,7 @@ impl<'a> SubMapping<'a> {
     /// Pread from `file` into the mapping.
     pub fn pread(
         &self,
-        file: &File,
+        file: &impl AsRawFd,
         length: usize,
         offset: i64,
     ) -> Result<usize> {
@@ -456,7 +455,7 @@ impl<'a> SubMapping<'a> {
     /// Pwrite from the mapping to `file`.
     pub fn pwrite(
         &self,
-        file: &File,
+        file: &impl AsRawFd,
         length: usize,
         offset: i64,
     ) -> Result<usize> {

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -231,7 +231,7 @@ impl<'a> MachineInitializer<'a> {
     pub fn initialize_qemu_debug_port(&self) -> Result<(), Error> {
         let dbg = QemuDebugPort::create(self.mctx.pio());
         let debug_file = std::fs::File::create("debug.out")?;
-        let poller = chardev::BlockingFileOutput::new(debug_file)?;
+        let poller = chardev::BlockingFileOutput::new(debug_file);
         poller.attach(Arc::clone(&dbg) as Arc<dyn BlockingSource>, self.disp);
         self.inv.register(&dbg)?;
         Ok(())

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -24,7 +24,6 @@ use tokio_tungstenite::tungstenite::protocol::{Role, WebSocketConfig};
 use tokio_tungstenite::tungstenite::{self, handshake, Message};
 use tokio_tungstenite::WebSocketStream;
 
-use propolis::bhyve_api;
 use propolis::dispatch::AsyncCtx;
 use propolis::hw::pci;
 use propolis::hw::uart::LpcUart;
@@ -547,28 +546,6 @@ async fn instance_ensure(
             .map_err(<_ as Into<HttpError>>::into)?;
         Some(res)
     } else {
-        instance.on_transition(Box::new(move |next_state, _, _inv, ctx| {
-            match next_state {
-                propolis::instance::State::Boot => {
-                    // Set vCPUs to their proper boot (INIT) state
-                    for vcpu in ctx.mctx.vcpus() {
-                        vcpu.reboot_state().unwrap();
-                        vcpu.activate().unwrap();
-                        // Set BSP to start up
-                        if vcpu.is_bsp() {
-                            vcpu.set_run_state(bhyve_api::VRS_RUN).unwrap();
-                            vcpu.set_reg(
-                                bhyve_api::vm_reg_name::VM_REG_GUEST_RIP,
-                                0xfff0,
-                            )
-                            .unwrap();
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }));
-
         None
     };
 

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -272,7 +272,7 @@ async fn instance_ensure(
         state: propolis::instance::State::Initialize,
     });
 
-    instance.on_transition(Box::new(move |next_state, _inv, _ctx| {
+    instance.on_transition(Box::new(move |next_state, _, _inv, _ctx| {
         let last = (*tx.borrow()).clone();
         let _ = tx.send(StateChange { gen: last.gen + 1, state: next_state });
     }));
@@ -547,7 +547,7 @@ async fn instance_ensure(
             .map_err(<_ as Into<HttpError>>::into)?;
         Some(res)
     } else {
-        instance.on_transition(Box::new(move |next_state, _inv, ctx| {
+        instance.on_transition(Box::new(move |next_state, _, _inv, ctx| {
             match next_state {
                 propolis::instance::State::Boot => {
                     // Set vCPUs to their proper boot (INIT) state

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -131,7 +131,7 @@ fn api_to_propolis_state(
         ApiState::Run => PropolisState::Run,
         ApiState::Stop => PropolisState::Halt,
         ApiState::Reboot => PropolisState::Reset,
-        ApiState::MigrateStart => PropolisState::StartMigrate,
+        ApiState::MigrateStart => PropolisState::MigrateStart,
     }
 }
 

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "3.2", features = ["derive"] }
+ctrlc = "3.2"
 libc = "0.2"
 toml = "0.5"
 serde = "1.0"

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -13,8 +13,7 @@ clap = { version = "3.2", features = ["derive"] }
 ctrlc = "3.2"
 libc = "0.2"
 toml = "0.5"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 propolis = { path = "../propolis", default-features = false }
 erased-serde = "0.3"
 serde_json = "1.0"

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 anyhow = "1.0"
 clap = { version = "3.2", features = ["derive"] }
 ctrlc = "3.2"
+futures = "0.3"
 libc = "0.2"
 toml = "0.5"
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "3.2", features = ["derive", "env"] }
+clap = { version = "3.2", features = ["derive"] }
 libc = "0.2"
 toml = "0.5"
 serde = "1.0"

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -14,7 +14,7 @@ ctrlc = "3.2"
 futures = "0.3"
 libc = "0.2"
 toml = "0.5"
-tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["io-util", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }
 propolis = { path = "../propolis", default-features = false }
 erased-serde = "0.3"

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "3.2", features = ["derive"] }
 ctrlc = "3.2"
 libc = "0.2"
 toml = "0.5"
+tokio = { version = "1", features = ["rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }
 propolis = { path = "../propolis", default-features = false }
 erased-serde = "0.3"

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pico-args = "0.3"
+anyhow = "1.0"
+clap = { version = "3.2", features = ["derive", "env"] }
 libc = "0.2"
 toml = "0.5"
 serde = "1.0"

--- a/standalone/src/config.rs
+++ b/standalone/src/config.rs
@@ -29,16 +29,8 @@ struct Main {
     memory: usize,
 }
 
-#[derive(Default)]
-pub struct Opts {
-    /// Should the device state of the instance be dumped (to a named file) when
-    /// the instance reaches the quiesce state.
-    pub dump_state: Option<String>,
-}
-
 pub struct Config {
     inner: Top,
-    pub opts: Opts,
 }
 impl Config {
     pub fn get_name(&self) -> &String {
@@ -140,7 +132,7 @@ impl<'a> Iterator for IterDevs<'a> {
 pub fn parse(path: &str) -> Config {
     let file_data = std::fs::read(path).unwrap();
     let top = toml::from_slice::<Top>(&file_data).unwrap();
-    Config { inner: top, opts: Opts::default() }
+    Config { inner: top }
 }
 
 pub fn parse_bdf(v: &str) -> Option<pci::Bdf> {

--- a/standalone/src/config.rs
+++ b/standalone/src/config.rs
@@ -3,6 +3,7 @@ use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use anyhow::Context;
 use serde_derive::Deserialize;
 
 use crate::hw::pci;
@@ -129,10 +130,11 @@ impl<'a> Iterator for IterDevs<'a> {
     }
 }
 
-pub fn parse(path: &str) -> Config {
-    let file_data = std::fs::read(path).unwrap();
-    let top = toml::from_slice::<Top>(&file_data).unwrap();
-    Config { inner: top }
+pub fn parse(path: &str) -> anyhow::Result<Config> {
+    let file_data =
+        std::fs::read(path).context("Failed to read given config.toml")?;
+    let top = toml::from_slice::<Top>(&file_data)?;
+    Ok(Config { inner: top })
 }
 
 pub fn parse_bdf(v: &str) -> Option<pci::Bdf> {

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -318,8 +318,17 @@ fn run(config: config::Config) -> anyhow::Result<()> {
 #[derive(clap::Parser)]
 /// Propolis command-line frontend for running a VM.
 struct Args {
-    /// Path to VM config file.
-    config: String,
+    /// Either the VM config file or a previously captured snapshot image.
+    #[clap(value_name = "CONFIG|SNAPSHOT", action)]
+    target: String,
+
+    /// Take a snapshot on Ctrl-C before exiting.
+    #[clap(short, long, action)]
+    snapshot: bool,
+
+    /// Restore previously captured snapshot.
+    #[clap(short, long, action)]
+    restore: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -327,8 +336,13 @@ fn main() -> anyhow::Result<()> {
     register_probes().context("Failed to setup USDT probes")?;
 
     let args = Args::parse();
-    let config = config::parse(&args.config)?;
-    run(config)?;
+
+    if args.restore {
+        todo!();
+    } else {
+        let config = config::parse(&args.target)?;
+        run(config)?;
+    }
 
     Ok(())
 }

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -366,10 +366,7 @@ fn main() -> anyhow::Result<()> {
         if let Some(inst) = inst_weak.upgrade() {
             if snapshot {
                 if SNAPSHOT.is_completed() {
-                    slog::warn!(
-                        signal_log,
-                        "already snapshotted; ignoring subsequent Ctrl-C"
-                    );
+                    slog::warn!(signal_log, "snapshot already in progress");
                 } else {
                     let snap_log = signal_log.new(o!("task" => "snapshot"));
                     let snap_rt_handle = signal_rt_handle.clone();

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -349,7 +349,7 @@ fn main() -> anyhow::Result<()> {
 
     // Create the VM afresh or restore it from a snapshot
     let (config, inst) = if restore {
-        todo!("restore VM from snapshot")
+        rt_handle.block_on(snapshot::restore(log.clone(), &target))?
     } else {
         let config = config::parse(&target)?;
         let inst =

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -381,9 +381,7 @@ fn main() -> anyhow::Result<()> {
                                     .context("Failed to save snapshot of VM")
                             {
                                 slog::error!(snap_log, "{:?}", err);
-                                inst.set_target_state(ReqState::Halt).expect(
-                                    "Failed to stop VM after snapshot error",
-                                );
+                                let _ = inst.set_target_state(ReqState::Halt);
                             }
                         });
                     });

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -372,11 +372,12 @@ fn main() -> anyhow::Result<()> {
     let (log, _log_async_guard) = build_log();
 
     // Create the VM afresh or restore it from a snapshot
-    let inst = if restore {
-        todo!()
+    let (_config, inst) = if restore {
+        todo!("restore VM from snapshot")
     } else {
         let config = config::parse(&target)?;
-        setup_instance(log.clone(), config, snapshot)?
+        let inst = setup_instance(log.clone(), config.clone(), snapshot)?;
+        (config, inst)
     };
 
     // Register a Ctrl-C handler so we can snapshot before exiting if needed

--- a/standalone/src/snapshot.rs
+++ b/standalone/src/snapshot.rs
@@ -263,9 +263,13 @@ pub async fn restore(
     };
 
     // We have enough to create the instance so let's do that first
-    let (inst, com1_sock) =
-        super::setup_instance(log.clone(), config.clone(), Handle::current())
-            .context("Failed to create Instance with config in snapshot")?;
+    let (inst, com1_sock) = super::setup_instance(
+        log.clone(),
+        config.clone(),
+        Handle::current(),
+        false,
+    )
+    .context("Failed to create Instance with config in snapshot")?;
 
     // Next are the devices
     let device_states = {

--- a/standalone/src/snapshot.rs
+++ b/standalone/src/snapshot.rs
@@ -4,8 +4,10 @@ use std::sync::Arc;
 
 use propolis::instance::{Instance, ReqState};
 
-pub fn save(log: slog::Logger, inst: Arc<Instance>) -> anyhow::Result<()> {
-
+pub async fn save(
+    log: slog::Logger,
+    inst: Arc<Instance>,
+) -> anyhow::Result<()> {
     // Clean up instance.
     inst.set_target_state(ReqState::Halt)?;
 

--- a/standalone/src/snapshot.rs
+++ b/standalone/src/snapshot.rs
@@ -1,13 +1,101 @@
 //! Routines and types for saving and restoring a snapshot of a VM.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
-use propolis::instance::{Instance, ReqState};
+use anyhow::Context;
+use futures::future;
+use propolis::{
+    instance::{Instance, MigratePhase, MigrateRole, ReqState, State},
+    inventory::Order,
+};
+use slog::{error, info};
+use tokio::{task, time};
 
 pub async fn save(
     log: slog::Logger,
     inst: Arc<Instance>,
 ) -> anyhow::Result<()> {
+    info!(log, "saving snapshot of VM");
+
+    // Grab AsyncCtx so we can get to the Dispatcher
+    let async_ctx = inst.async_ctx();
+
+    // Mimic state transitions propolis-server would go through for a live migration
+    // TODO(luqmana): refactor and share implementation with propolis-server
+    let state_change_fut = {
+        // Start waiting before we request the transition lest we miss it
+        let inst = inst.clone();
+        task::spawn_blocking(move || {
+            inst.wait_for_state(State::Migrate(
+                MigrateRole::Source,
+                MigratePhase::Start,
+            ));
+        })
+    };
+    inst.set_target_state(ReqState::StartMigrate)?;
+    state_change_fut.await?;
+
+    // Grab reference to all the devices that are a part of this Instance
+    let mut devices = vec![];
+    let _ = inst.inv().for_each_node(Order::Post, |_, rec| {
+        devices.push((rec.name().to_owned(), Arc::clone(rec.entity())));
+        Ok::<_, ()>(())
+    });
+
+    // Ask the instance to begin transitioning to the paused state
+    // This will inform each device to pause
+    info!(log, "Pausing devices");
+    let (pause_tx, pause_rx) = std::sync::mpsc::channel();
+    inst.migrate_pause(async_ctx.context_id(), pause_rx)?;
+
+    // Ask each device for a future indicating they've finishing pausing
+    let mut migrate_ready_futs = vec![];
+    for (name, device) in &devices {
+        let log = log.new(slog::o!("device" => name.clone()));
+        let device = Arc::clone(device);
+        let pause_fut = device.paused();
+        migrate_ready_futs.push(task::spawn(async move {
+            if let Err(_) =
+                time::timeout(Duration::from_secs(2), pause_fut).await
+            {
+                error!(log, "Timed out pausing device");
+                return Err(device);
+            }
+            info!(log, "Paused device");
+            Ok(())
+        }));
+    }
+
+    // Now we wait for all the devices to have paused
+    let pause = future::join_all(migrate_ready_futs)
+        .await
+        // Hoist out the JoinError's
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>();
+    let timed_out = match pause {
+        Ok(future_res) => {
+            // Grab just the ones that failed
+            future_res
+                .into_iter()
+                .filter(Result::is_err)
+                .map(Result::unwrap_err)
+                .collect::<Vec<_>>()
+        }
+        Err(err) => {
+            return Err(err).context("Failed to join paused devices future");
+        }
+    };
+
+    // Bail out if any devices timed out
+    if !timed_out.is_empty() {
+        anyhow::bail!("Failed to pause all devices: {timed_out:?}");
+    }
+
+    // Inform the instance state machine we're done pausing
+    pause_tx.send(()).unwrap();
+
+    // TODO(luqmana): extract device state and save to disk
+
     // Clean up instance.
     inst.set_target_state(ReqState::Halt)?;
 

--- a/standalone/src/snapshot.rs
+++ b/standalone/src/snapshot.rs
@@ -225,7 +225,8 @@ pub async fn save(
         file.write_u64(0).await?;
     }
 
-    drop(file);
+    file.flush().await?;
+
     info!(log, "Snapshot saved to {}", snapshot);
 
     // Clean up instance.

--- a/standalone/src/snapshot.rs
+++ b/standalone/src/snapshot.rs
@@ -12,6 +12,7 @@
 //!     3   - High Mem
 
 use std::convert::TryInto;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -220,4 +221,13 @@ pub async fn save(
     inst.set_target_state(ReqState::Halt)?;
 
     Ok(())
+}
+
+/// Create an instance from a previously saved snapshot.
+pub async fn restore(
+    log: slog::Logger,
+    path: impl AsRef<Path>,
+) -> anyhow::Result<(Config, Arc<Instance>)> {
+    info!(log, "restoring snapshot of VM from {}", path.as_ref().display());
+    todo!()
 }

--- a/standalone/src/snapshot.rs
+++ b/standalone/src/snapshot.rs
@@ -277,13 +277,9 @@ pub async fn restore(
     };
 
     // We have enough to create the instance so let's do that first
-    let (inst, com1_sock) = super::setup_instance(
-        log.clone(),
-        config.clone(),
-        Handle::current(),
-        false,
-    )
-    .context("Failed to create Instance with config in snapshot")?;
+    let (inst, com1_sock) =
+        super::setup_instance(log.clone(), config.clone(), Handle::current())
+            .context("Failed to create Instance with config in snapshot")?;
 
     // Next are the devices
     let device_states = {

--- a/standalone/src/snapshot.rs
+++ b/standalone/src/snapshot.rs
@@ -12,11 +12,19 @@ use propolis::{
 use slog::{error, info};
 use tokio::{task, time};
 
+use crate::config::Config;
+
 pub async fn save(
     log: slog::Logger,
     inst: Arc<Instance>,
+    config: Config,
 ) -> anyhow::Result<()> {
-    info!(log, "saving snapshot of VM");
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_millis();
+    let snapshot = format!("{}-{}.bin", config.get_name(), now);
+
+    info!(log, "saving snapshot of VM to {}", snapshot);
 
     // Grab AsyncCtx so we can get to the Dispatcher
     let async_ctx = inst.async_ctx();

--- a/standalone/src/snapshot.rs
+++ b/standalone/src/snapshot.rs
@@ -1,0 +1,13 @@
+//! Routines and types for saving and restoring a snapshot of a VM.
+
+use std::sync::Arc;
+
+use propolis::instance::{Instance, ReqState};
+
+pub fn save(log: slog::Logger, inst: Arc<Instance>) -> anyhow::Result<()> {
+
+    // Clean up instance.
+    inst.set_target_state(ReqState::Halt)?;
+
+    Ok(())
+}


### PR DESCRIPTION
This set of changes adds some new flags to `propolis-standalone` to allow taking a snapshot of a running VM, saving it to a file and being able to later restore it:

```console
$ ./target/debug/propolis-standalone --help
propolis-standalone 
Propolis command-line frontend for running a VM

USAGE:
    propolis-standalone [OPTIONS] <CONFIG|SNAPSHOT>

ARGS:
    <CONFIG|SNAPSHOT>    Either the VM config file or a previously captured snapshot image

OPTIONS:
    -h, --help        Print help information
    -r, --restore     Restore previously captured snapshot
    -s, --snapshot    Take a snapshot on Ctrl-C before exiting
```

Running the snapshot/restore requires Illumos bits currently in review: https://code.illumos.org/c/illumos-gate/+/2061 & https://code.illumos.org/c/illumos-gate/+/2157.

Also, thanks to Patrick and Greg for a lot of the device import/export bits.

Depends on: https://github.com/oxidecomputer/propolis/pull/140