### PR TITLE
Replace structopt with clap

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,13 +8,13 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+clap = { version = "3.1", features = ["derive"] }
 futures = "0.3"
 libc = "0.2"
 propolis-client = { path = "../client" }
 slog = "2.7"
 slog-async = "2.7"
 slog-term = "2.8"
-structopt = "0.3"
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.17"
 uuid = "1.0.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,7 +13,6 @@ schemars = { version = "0.8.10", features = [ "uuid1" ] }
 serde = "1.0"
 serde_json = "1.0"
 slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_debug" ] }
-structopt = "0.3"
 thiserror = "1.0"
 uuid = { version = "1.0.0", features = [ "serde", "v4" ] }
 crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "cd74a23ea42ce5e673923a00faf31b0a920191cc" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = "0.1.53"
 bit_field = "0.10.1"
 bitvec = "1.0"
 bytes = "1.1"
+clap = { version = "3.1", features = ["derive"] }
 const_format = "0.2"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
 erased-serde = "0.3"
@@ -39,7 +40,6 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 slog = "2.7"
-structopt = { version = "0.3", default-features = false }
 propolis = { path = "../propolis", features = ["crucible"], default-features = false }
 propolis-client = { path = "../client" }
 rfb = { git = "https://github.com/oxidecomputer/rfb", branch = "main" }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -6,6 +6,7 @@
 )]
 
 use anyhow::anyhow;
+use clap::Parser;
 use dropshot::{
     ConfigDropshot, ConfigLogging, ConfigLoggingLevel, HttpServerStarter,
 };
@@ -14,25 +15,22 @@ use propolis::usdt::register_probes;
 use slog::info;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
 use propolis_server::vnc::setup_vnc;
 use propolis_server::{config, server};
 
-#[derive(Debug, StructOpt)]
-#[structopt(
-    name = "propolis-server",
-    about = "An HTTP server providing access to Propolis"
-)]
+#[derive(Debug, Parser)]
+#[clap(about, version)]
+/// An HTTP server providing access to Propolis
 enum Args {
     /// Generates the OpenAPI specification.
     OpenApi,
     /// Runs the Propolis server.
     Run {
-        #[structopt(parse(from_os_str))]
+        #[clap(parse(from_os_str))]
         cfg: PathBuf,
 
-        #[structopt(name = "PROPOLIS_IP:PORT", parse(try_from_str))]
+        #[clap(name = "PROPOLIS_IP:PORT", parse(try_from_str))]
         propolis_addr: SocketAddr,
     },
 }
@@ -53,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
     register_probes().unwrap();
 
     // Command line arguments.
-    let args = Args::from_args();
+    let args = Args::parse();
 
     match args {
         Args::OpenApi => run_openapi()


### PR DESCRIPTION
Structopt has been in [maintenance mode](https://docs.rs/structopt/latest/structopt/#maintenance) with basically all its features in clap. We already use clap in some places so might as well consolidate and prune some deps.