### PR TITLE
server: make vnc port a configurable parameter

### DIFF
--- a/server/src/lib/vnc.rs
+++ b/server/src/lib/vnc.rs
@@ -8,7 +8,7 @@ use rfb::rfb::{
 };
 use rfb::server::{Server, VncServer, VncServerConfig, VncServerData};
 use slog::{debug, error, o, Logger};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -129,12 +129,15 @@ impl Server for PropolisVncServer {
 
 // Default VNC server configuration.
 // XXX: Do we want to specify this information in the config file?
-pub fn setup_vnc(log: &Logger) -> VncServer<PropolisVncServer> {
+pub fn setup_vnc(
+    log: &Logger,
+    addr: SocketAddr,
+) -> VncServer<PropolisVncServer> {
     let initial_width = 1024;
     let initial_height = 768;
 
     let config = VncServerConfig {
-        addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 5900),
+        addr,
         version: ProtoVersion::Rfb38,
         // vncviewer won't work without offering VncAuth, even though it doesn't ask to use
         // it.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -32,6 +32,9 @@ enum Args {
 
         #[clap(name = "PROPOLIS_IP:PORT", parse(try_from_str))]
         propolis_addr: SocketAddr,
+
+        #[clap(name = "VNC_IP:PORT", parse(try_from_str))]
+        vnc_addr: SocketAddr,
     },
 }
 
@@ -56,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
     match args {
         Args::OpenApi => run_openapi()
             .map_err(|e| anyhow!("Cannot generate OpenAPI spec: {}", e)),
-        Args::Run { cfg, propolis_addr } => {
+        Args::Run { cfg, propolis_addr, vnc_addr } => {
             let config = config::parse(&cfg)?;
 
             // Dropshot configuration.
@@ -72,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
                 |error| anyhow!("failed to create logger: {}", error),
             )?;
 
-            let vnc_server = setup_vnc(&log);
+            let vnc_server = setup_vnc(&log, vnc_addr);
             let vnc_server_hdl = vnc_server.clone();
 
             let context =

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -13,7 +13,7 @@ use dropshot::{
 use futures::join;
 use propolis::usdt::register_probes;
 use slog::info;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 
 use propolis_server::vnc::setup_vnc;
@@ -33,7 +33,11 @@ enum Args {
         #[clap(name = "PROPOLIS_IP:PORT", parse(try_from_str))]
         propolis_addr: SocketAddr,
 
-        #[clap(name = "VNC_IP:PORT", parse(try_from_str))]
+        #[clap(
+            name = "VNC_IP:PORT",
+            parse(try_from_str),
+            default_value_t = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 5900),
+        )]
         vnc_addr: SocketAddr,
     },
 }

--- a/server/tests/integration_tests.rs
+++ b/server/tests/integration_tests.rs
@@ -10,6 +10,7 @@ use propolis_server::{
 };
 use slog::{o, Logger};
 use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 mod artifacts;
 
@@ -59,7 +60,10 @@ async fn initialize_server(log: &Logger) -> HttpServer<server::Context> {
     let mut devices = BTreeMap::new();
     devices.insert("block0".to_string(), dev);
 
-    let vnc_server = setup_vnc(&log);
+    let vnc_server = setup_vnc(
+        &log,
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 5900),
+    );
     let config = Config::new(
         artifacts.bootrom.path(),
         Chipset::default(),


### PR DESCRIPTION
This PR makes the VNC port a configurable parameter. Without this, multiple Propolis instances cannot run in a single zone. This came up when updating Falcon to the latest propolis revision.

~This change introduces a new flag to Propolis server, so it may have an impact on control plane machinery creating propolis-server instances.~