### PR TITLE
Upgrade to clap 3.2 and fix deprecation warnings.

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 futures = "0.3"
 libc = "0.2"
 propolis-client = { path = "../client" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -27,15 +27,15 @@ use uuid::Uuid;
 /// A simple CLI tool to manipulate propolis-server
 struct Opt {
     /// propolis-server address
-    #[clap(short, long, parse(try_from_str = resolve_host))]
+    #[clap(short, long, value_parser = resolve_host)]
     server: IpAddr,
 
     /// propolis-server port
-    #[clap(short, long, default_value = "12400")]
+    #[clap(short, long, default_value = "12400", action)]
     port: u16,
 
     /// Enable debugging
-    #[clap(short, long)]
+    #[clap(short, long, action)]
     debug: bool,
 
     #[clap(subcommand)]
@@ -47,26 +47,27 @@ enum Command {
     /// Create a new propolis instance
     New {
         /// Instance name
+        #[clap(action)]
         name: String,
 
         /// Instance uuid (if specified)
-        #[clap(short = 'u')]
+        #[clap(short = 'u', action)]
         uuid: Option<Uuid>,
 
         /// Number of vCPUs allocated to instance
-        #[clap(short = 'c', default_value = "4")]
+        #[clap(short = 'c', default_value = "4", action)]
         vcpus: u8,
 
         /// Memory allocated to instance (MiB)
-        #[clap(short, default_value = "1024")]
+        #[clap(short, default_value = "1024", action)]
         memory: u64,
 
         // file with a JSON array of DiskRequest structs
-        #[clap(long, parse(from_os_str))]
+        #[clap(long, action)]
         crucible_disks: Option<PathBuf>,
 
         // cloud_init ISO file
-        #[clap(long, parse(from_os_str))]
+        #[clap(long, action)]
         cloud_init: Option<PathBuf>,
     },
 
@@ -76,7 +77,7 @@ enum Command {
     /// Transition the instance to a new state
     State {
         /// The requested state
-        #[clap(parse(try_from_str = parse_state))]
+        #[clap(value_parser = parse_state)]
         state: InstanceStateRequested,
     },
 
@@ -86,15 +87,15 @@ enum Command {
     /// Migrate instance to new propolis-server
     Migrate {
         /// Destination propolis-server address
-        #[clap(parse(try_from_str = resolve_host))]
+        #[clap(value_parser = resolve_host)]
         dst_server: IpAddr,
 
         /// Destination propolis-server port
-        #[clap(short = 'p', default_value = "12400")]
+        #[clap(short = 'p', default_value = "12400", action)]
         dst_port: u16,
 
         /// Uuid for the destination instance
-        #[clap(short = 'u')]
+        #[clap(short = 'u', action)]
         dst_uuid: Option<Uuid>,
     },
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,7 +22,7 @@ async-trait = "0.1.53"
 bit_field = "0.10.1"
 bitvec = "1.0"
 bytes = "1.1"
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 const_format = "0.2"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
 erased-serde = "0.3"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -27,16 +27,16 @@ enum Args {
     OpenApi,
     /// Runs the Propolis server.
     Run {
-        #[clap(parse(from_os_str))]
+        #[clap(action)]
         cfg: PathBuf,
 
-        #[clap(name = "PROPOLIS_IP:PORT", parse(try_from_str))]
+        #[clap(name = "PROPOLIS_IP:PORT", action)]
         propolis_addr: SocketAddr,
 
         #[clap(
             name = "VNC_IP:PORT",
-            parse(try_from_str),
             default_value_t = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 5900),
+            action
         )]
         vnc_addr: SocketAddr,
     },


### PR DESCRIPTION
Turns out clap 3.2 came out today and with it a bunch of deprecations.