### PR TITLE
fix existing clippy warnings from 52e0d2c

### DIFF
--- a/propolis/src/inventory.rs
+++ b/propolis/src/inventory.rs
@@ -534,7 +534,7 @@ pub trait Entity: Send + Sync + 'static {
     /// may implement the `Migrate` trait along with its export/import
     /// methods. A device which shouldn't be migrated should instead
     /// override this method and explicity return `Migrator::NonMigratable`.
-    fn migrate<'a>(&'a self) -> Migrator<'a> {
+    fn migrate(&'_ self) -> Migrator<'_> {
         Migrator::Simple
     }
 }

--- a/propolis/src/util/aspace.rs
+++ b/propolis/src/util/aspace.rs
@@ -96,11 +96,8 @@ impl<T> ASpace<T> {
     where
         P: FnMut(&T) -> bool,
     {
-        let (&k, _) = self
-            .map
-            .iter()
-            .filter(|(_, (_, entry))| predicate(entry))
-            .next()?;
+        let (&k, _) =
+            self.map.iter().find(|(_, (_, entry))| predicate(entry))?;
         Some(k)
     }
 
@@ -108,12 +105,8 @@ impl<T> ASpace<T> {
     where
         P: FnMut(&T) -> bool,
     {
-        let (&k, &(len, _)) = self
-            .map
-            .iter()
-            .rev()
-            .filter(|(_, (_, entry))| predicate(entry))
-            .next()?;
+        let (&k, &(len, _)) =
+            self.map.iter().rev().find(|(_, (_, entry))| predicate(entry))?;
         Some(k + len - 1)
     }
 

--- a/server/src/lib/migrate/mod.rs
+++ b/server/src/lib/migrate/mod.rs
@@ -362,7 +362,7 @@ pub async fn dest_initiate(
     let log = rqctx.log.new(o!(
         "migration_id" => migration_id.to_string(),
         "migrate_role" => "destination",
-        "migrate_src_addr" => migrate_info.src_addr.clone()
+        "migrate_src_addr" => migrate_info.src_addr
     ));
     info!(log, "Migration Destination");
 

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -496,7 +496,7 @@ async fn instance_ensure(
     vnc_server.server.set_async_ctx(actx).await;
     vnc_server.server.initialize_framebuffer(fb).await;
 
-    let rt = rt_handle.unwrap().clone();
+    let rt = rt_handle.unwrap();
     let hdl = Arc::clone(&vnc_hdl);
     ramfb.unwrap().set_notifier(Box::new(move |config, is_valid| {
         let h = Arc::clone(&hdl);


### PR DESCRIPTION
`cargo clippy` has some concision suggestions and flags a couple of unnecessary `clone`s. This PR tidies these up.