### PR TITLE
propolis-server should use VMM reservoir when available

### DIFF
--- a/bhyve-api/src/ioctls.rs
+++ b/bhyve-api/src/ioctls.rs
@@ -11,6 +11,11 @@ pub const VMM_DESTROY_VM: i32 = VMMCTL_IOC_BASE | 0x02;
 pub const VMM_VM_SUPPORTED: i32 = VMMCTL_IOC_BASE | 0x03;
 pub const VMM_INTERFACE_VERSION: i32 = VMMCTL_IOC_BASE | 0x04;
 
+// VMM memory reservoir operations
+pub const VMM_RESV_QUERY: i32 = VMMCTL_IOC_BASE | 0x10;
+pub const VMM_RESV_ADD: i32 = VMMCTL_IOC_BASE | 0x11;
+pub const VMM_RESV_REMOVE: i32 = VMMCTL_IOC_BASE | 0x12;
+
 // Operations performed in the context of a given vCPU
 pub const VM_RUN: i32 = VMM_CPU_IOC_BASE | 0x01;
 pub const VM_SET_REGISTER: i32 = VMM_CPU_IOC_BASE | 0x02;

--- a/bhyve-api/src/structs.rs
+++ b/bhyve-api/src/structs.rs
@@ -429,3 +429,12 @@ impl vm_destroy_req {
         res
     }
 }
+
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct vmm_resv_query {
+    pub vrq_free_sz: size_t,
+    pub vrq_alloc_sz: size_t,
+    pub vrq_alloc_transient_sz: size_t,
+    pub vrq_limit: size_t,
+}

--- a/propolis/src/vmm/machine.rs
+++ b/propolis/src/vmm/machine.rs
@@ -12,7 +12,9 @@ use crate::mmio::MmioBus;
 use crate::pio::PioBus;
 use crate::util::aspace::ASpace;
 use crate::vcpu::Vcpu;
-use crate::vmm::{create_vm, GuardSpace, Mapping, Prot, SubMapping, VmmHdl};
+use crate::vmm::{
+    create_vm, CreateOpts, GuardSpace, Mapping, Prot, SubMapping, VmmHdl,
+};
 
 // XXX: Arbitrary limits for now
 pub const MAX_PHYSMEM: usize = 0x80_0000_0000;
@@ -498,10 +500,14 @@ impl<'a, T: Copy> Iterator for MemMany<'a, T> {
 /// # Example
 ///
 /// ```no_run
-/// use propolis::vmm::{Builder, Prot};
+/// use propolis::vmm::{Builder, Prot, CreateOpts};
 /// use propolis::instance::Instance;
 ///
-/// let builder = Builder::new("my-machine", true).unwrap()
+/// let opts = CreateOpts {
+///     // Override any desired VM creation options
+///     ..Default::default()
+/// };
+/// let builder = Builder::new("my-machine", opts).unwrap()
 ///     .max_cpus(4).unwrap()
 ///     .add_mem_region(0, 0xc000_0000, Prot::ALL, "lowmem").unwrap()
 ///     .add_mem_region(0x1_0000_0000, 0xc000_0000, Prot::ALL, "highmem").unwrap()
@@ -528,8 +534,8 @@ impl Builder {
     /// # Arguments
     /// - `name`: The name for the new instance.
     /// - `force`: If true, deletes the VM if it already exists.
-    pub fn new(name: &str, force: bool) -> Result<Self> {
-        let hdl = create_vm(name, force)?;
+    pub fn new(name: &str, opts: CreateOpts) -> Result<Self> {
+        let hdl = create_vm(name, opts)?;
         Ok(Self {
             inner_hdl: Some(hdl),
             max_cpu: 1,

--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -55,9 +55,11 @@ pub fn build_instance(
     max_cpu: u8,
     lowmem: usize,
     highmem: usize,
+    use_reservoir: bool,
     log: slog::Logger,
 ) -> Result<Arc<Instance>> {
-    let mut builder = Builder::new(name, true)?
+    let create_opts = propolis::vmm::CreateOpts { force: true, use_reservoir };
+    let mut builder = Builder::new(name, create_opts)?
         .max_cpus(max_cpu)?
         .add_mem_region(0, lowmem, Prot::ALL, "lowmem")?
         .add_rom_region(

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -100,6 +100,7 @@ pub struct Context {
     config: Config,
     log: Logger,
     pub(crate) vnc_server: Arc<Mutex<VncServer<PropolisVncServer>>>,
+    pub(crate) use_reservoir: bool,
 }
 
 impl Context {
@@ -107,6 +108,7 @@ impl Context {
     pub fn new(
         config: Config,
         vnc_server: VncServer<PropolisVncServer>,
+        use_reservoir: bool,
         log: Logger,
     ) -> Self {
         Context {
@@ -115,6 +117,7 @@ impl Context {
             config,
             log,
             vnc_server: Arc::new(Mutex::new(vnc_server)),
+            use_reservoir,
         }
     }
 }
@@ -257,6 +260,7 @@ async fn instance_ensure(
         properties.vcpus,
         lowmem,
         highmem,
+        server_context.use_reservoir,
         vmm_log,
     )
     .map_err(|err| {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -80,9 +80,14 @@ async fn main() -> anyhow::Result<()> {
 
             let vnc_server = setup_vnc(&log, vnc_addr);
             let vnc_server_hdl = vnc_server.clone();
+            let use_reservoir = config::reservoir_decide(&log);
 
-            let context =
-                server::Context::new(config, vnc_server, log.new(slog::o!()));
+            let context = server::Context::new(
+                config,
+                vnc_server,
+                use_reservoir,
+                log.new(slog::o!()),
+            );
 
             info!(log, "Starting server...");
             let server = HttpServerStarter::new(

--- a/server/tests/integration_tests.rs
+++ b/server/tests/integration_tests.rs
@@ -71,7 +71,13 @@ async fn initialize_server(log: &Logger) -> HttpServer<server::Context> {
         block_devices,
         vec![],
     );
-    let context = server::Context::new(config, vnc_server, log.new(slog::o!()));
+    let use_reservoir = propolis_server::config::reservoir_decide(log);
+    let context = server::Context::new(
+        config,
+        vnc_server,
+        use_reservoir,
+        log.new(slog::o!()),
+    );
 
     let config_dropshot = ConfigDropshot {
         bind_address: "127.0.0.1:0".parse().unwrap(),

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -59,22 +59,25 @@ fn build_instance(
     highmem: usize,
     log: slog::Logger,
 ) -> Result<Arc<Instance>> {
-    let mut builder = Builder::new(name, true)?
-        .max_cpus(max_cpu)?
-        .add_mem_region(0, lowmem, Prot::ALL, "lowmem")?
-        .add_rom_region(
-            0x1_0000_0000 - MAX_ROM_SIZE,
-            MAX_ROM_SIZE,
-            Prot::READ | Prot::EXEC,
-            "bootrom",
-        )?
-        .add_mmio_region(0xc0000000_usize, 0x20000000_usize, "dev32")?
-        .add_mmio_region(0xe0000000_usize, 0x10000000_usize, "pcicfg")?
-        .add_mmio_region(
-            vmm::MAX_SYSMEM,
-            vmm::MAX_PHYSMEM - vmm::MAX_SYSMEM,
-            "dev64",
-        )?;
+    let mut builder = Builder::new(
+        name,
+        propolis::vmm::CreateOpts { force: true, ..Default::default() },
+    )?
+    .max_cpus(max_cpu)?
+    .add_mem_region(0, lowmem, Prot::ALL, "lowmem")?
+    .add_rom_region(
+        0x1_0000_0000 - MAX_ROM_SIZE,
+        MAX_ROM_SIZE,
+        Prot::READ | Prot::EXEC,
+        "bootrom",
+    )?
+    .add_mmio_region(0xc0000000_usize, 0x20000000_usize, "dev32")?
+    .add_mmio_region(0xe0000000_usize, 0x10000000_usize, "pcicfg")?
+    .add_mmio_region(
+        vmm::MAX_SYSMEM,
+        vmm::MAX_PHYSMEM - vmm::MAX_SYSMEM,
+        "dev64",
+    )?;
     if highmem > 0 {
         builder = builder.add_mem_region(
             0x1_0000_0000,


### PR DESCRIPTION
This should give us a path to using the VMM memory reservoir without immediately breaking those who do not have an allocation to it configured.