### PR TITLE
Use fourcc value from the guest to set pixel format for VNC.

### DIFF
--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -506,8 +506,8 @@ async fn instance_ensure(
 
     // Initialize framebuffer data for the VNC server.
     let vnc_hdl = Arc::clone(&server_context.vnc_server);
-    let (addr, width, height) = ramfb.as_ref().unwrap().get_framebuffer_info();
-    let fb = vnc::RamFb::new(addr, width, height);
+    let fb_spec = ramfb.as_ref().unwrap().get_framebuffer_spec();
+    let fb = vnc::RamFb::new(fb_spec.clone());
     let actx = instance.async_ctx();
     let vnc_server = vnc_hdl.lock().await;
     vnc_server.server.set_async_ctx(actx).await;
@@ -519,7 +519,7 @@ async fn instance_ensure(
         let h = Arc::clone(&hdl);
         rt.block_on(async move {
             let vnc = h.lock().await;
-            vnc.server.update(config, is_valid).await;
+            vnc.server.update(&vnc, config, is_valid).await;
         });
     }));
 

--- a/server/src/lib/vnc.rs
+++ b/server/src/lib/vnc.rs
@@ -1,27 +1,34 @@
 use async_trait::async_trait;
 use propolis::common::GuestAddr;
 use propolis::dispatch::AsyncCtx;
-use propolis::hw::qemu::ramfb::Config;
+use propolis::hw::qemu::ramfb::{Config, FramebufferSpec};
 use rfb::encodings::RawEncoding;
+use rfb::pixel_formats::fourcc;
 use rfb::rfb::{
     FramebufferUpdate, ProtoVersion, Rectangle, SecurityType, SecurityTypes,
 };
 use rfb::server::{Server, VncServer, VncServerConfig, VncServerData};
-use slog::{debug, error, o, Logger};
+use slog::{debug, error, info, o, Logger};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct RamFb {
     addr: u64,
     width: u32,
     height: u32,
+    fourcc: u32,
 }
 
 impl RamFb {
-    pub fn new(addr: u64, width: u32, height: u32) -> Self {
-        Self { addr, width, height }
+    pub fn new(fb_spec: FramebufferSpec) -> Self {
+        Self {
+            addr: fb_spec.addr,
+            width: fb_spec.width,
+            height: fb_spec.height,
+            fourcc: fb_spec.fourcc,
+        }
     }
 }
 
@@ -40,6 +47,8 @@ pub struct PropolisVncServer {
     framebuffer: Arc<Mutex<Framebuffer>>,
     actx: Arc<Mutex<Option<AsyncCtx>>>,
     log: Logger,
+
+    vnc_server: Arc<Mutex<Option<VncServer<PropolisVncServer>>>>,
 }
 
 impl PropolisVncServer {
@@ -50,7 +59,16 @@ impl PropolisVncServer {
             ))),
             actx: Arc::new(Mutex::new(None)),
             log,
+            vnc_server: Arc::new(Mutex::new(None)),
         }
+    }
+
+    pub async fn set_vnc_server(
+        &self,
+        vnc_server: VncServer<PropolisVncServer>,
+    ) {
+        let mut locked = self.vnc_server.lock().await;
+        *locked = Some(vnc_server);
     }
 
     pub async fn set_async_ctx(&self, actx: AsyncCtx) {
@@ -65,12 +83,30 @@ impl PropolisVncServer {
         }
     }
 
-    pub async fn update(&self, config: &Config, is_valid: bool) {
+    pub async fn update(
+        &self,
+        vnc_server: &VncServer<PropolisVncServer>,
+        config: &Config,
+        is_valid: bool,
+    ) {
         if is_valid {
             debug!(self.log, "updating framebuffer");
-            let (addr, w, h) = config.get_framebuffer_info();
-            let fb = RamFb::new(addr, w, h);
-            self.initialize_framebuffer(fb).await;
+            let fb_spec = config.get_framebuffer_spec();
+            let fb = RamFb::new(fb_spec);
+            self.initialize_framebuffer(fb.clone()).await;
+
+            match fourcc::fourcc_to_pixel_format(fb.fourcc) {
+                Ok(pf) => {
+                    vnc_server.set_pixel_format(pf).await;
+                    info!(
+                        self.log,
+                        "pixel format set to fourcc={:#04x}", fb.fourcc
+                    );
+                }
+                Err(e) => {
+                    error!(self.log, "could not set pixel format: {:?}", e);
+                }
+            }
         } else {
             error!(self.log, "invalid config update");
         }
@@ -88,6 +124,7 @@ impl Server for PropolisVncServer {
                 // Display a white screen if the guest isn't ready yet.
                 let len: usize = fb.width as usize * fb.height as usize * 4;
                 let pixels = vec![0xffu8; len];
+
                 let r = Rectangle::new(
                     0,
                     0,
@@ -98,7 +135,7 @@ impl Server for PropolisVncServer {
                 FramebufferUpdate::new(vec![r])
             }
             Framebuffer::Initialized(fb) => {
-                debug!(self.log, "framebuffer initialized={:?}", fb);
+                debug!(self.log, "framebuffer initialized: fb={:?}", fb);
 
                 let len = fb.height as usize * fb.width as usize * 4;
                 let mut buf = vec![0u8; len];
@@ -128,7 +165,6 @@ impl Server for PropolisVncServer {
 }
 
 // Default VNC server configuration.
-// XXX: Do we want to specify this information in the config file?
 pub fn setup_vnc(
     log: &Logger,
     addr: SocketAddr,
@@ -147,7 +183,13 @@ pub fn setup_vnc(
         ]),
         name: "propolis-vnc".to_string(),
     };
-    let data = VncServerData { width: initial_width, height: initial_height };
+
+    let pf = fourcc::fourcc_to_pixel_format(fourcc::FOURCC_XR24).unwrap();
+    let data = VncServerData {
+        width: initial_width,
+        height: initial_height,
+        input_pixel_format: pf,
+    };
     let pvnc = PropolisVncServer::new(
         initial_width,
         initial_height,


### PR DESCRIPTION
### Summary

This PR uses the new interfaces added in https://github.com/oxidecomputer/rfb/pull/6 to set the pixel format for the VNC server based on the guest's fourcc. Fourcc is a 4-byte code that maps to a pixel format. Support for understanding these codes has been added into the rfb crate.

### Details

Previously, when booting a windows VM and viewing its framebuffer with VNC, one might see orange where the screen should be blue (such as the "Orange Screen of Death"). Here is an image of an orange screen that should be blue: 
![ksnip_20220503-093009](https://user-images.githubusercontent.com/6669371/176527678-38f8c6a7-6970-4d28-b403-b7a0049e923b.png)

The problem here was two-fold: first, the VNC server in the rfb crate didn't have a way for consumers to specify what the input pixel format is (which in this case, we get from the fourcc value of the guest). Second, the rfb protocol allows for clients to request an alternate pxiel format, and the rfb crate didn't have support for translating between formats. So the client would display pixels in the format it requested, by the pixels wouldn't actually be in that format. Both of these issues are addressed for our purposes in https://github.com/oxidecomputer/rfb/pull/6.

### Testing
Here's an example of the windows lock screen before -- note that the sky is orange (orange where there should be blue):
![ksnip_20220429-200648](https://user-images.githubusercontent.com/6669371/176533561-cc23ba4c-a1e3-40e6-85a4-f05332370964.png)

Now, when we connect to a windows VM, the colors look correct, regardless of the pixel format requested by the client.

Example from noVNC (which requests pixel format little-endian xBGR):
![ksnip_20220629-125435](https://user-images.githubusercontent.com/6669371/176533063-5f14525f-0188-4c67-8af2-7d182d046b1b.png)

Example from tigervnc (which requests pixel format little-endian xRGB): 
![ksnip_20220629-125742](https://user-images.githubusercontent.com/6669371/176533883-276a62ba-b453-48ad-b612-02f620191d7e.png)

