### PR TITLE
Better emulate memory size communication via CMOS

### DIFF
--- a/server/src/lib/initializer.rs
+++ b/server/src/lib/initializer.rs
@@ -149,7 +149,7 @@ impl<'a> MachineInitializer<'a> {
         let hdl = self.mctx.hdl();
 
         let rtc = &self.machine.kernel_devs.rtc;
-        rtc.memsize_to_nvram(lowmem, highmem, hdl)?;
+        rtc.memsize_to_nvram(lowmem as u32, highmem as u64, hdl)?;
         rtc.set_time(SystemTime::now(), hdl)?;
 
         Ok(())

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -137,7 +137,7 @@ pub fn setup_instance(
         })?;
 
         let rtc = &machine.kernel_devs.rtc;
-        rtc.memsize_to_nvram(lowmem, highmem, mctx.hdl())?;
+        rtc.memsize_to_nvram(lowmem as u32, highmem as u64, mctx.hdl())?;
         rtc.set_time(SystemTime::now(), mctx.hdl())?;
 
         let hdl = machine.get_hdl();


### PR DESCRIPTION
Since we are mimicking qemu, we could include all of the bits, including
the base and extended areas, in addition to the lowmem and highmem bits.

Fixes #110