### PR TITLE
Allow instance_serial_task to block after last client disconnects

### DIFF
--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -601,12 +601,10 @@ async fn instance_serial_task(
                 }
             }
 
-            // Receive bytes from connected WS clients to feed to the
-            // intermediate recv_ch
-            _ = ws_recv => {}
-
             // Receive bytes from the intermediate channel to be injected into
-            // the UART
+            // the UART. This needs to be checked before `ws_recv` so that
+            // "close" messages can be processed and their indicated
+            // sinks/streams removed before they are polled again.
             pair = recv_ch_fut => {
                 if let Some((i, msg)) = pair {
                     match msg {
@@ -622,6 +620,10 @@ async fn instance_serial_task(
                     }
                 }
             }
+
+            // Receive bytes from connected WS clients to feed to the
+            // intermediate recv_ch
+            _ = ws_recv => {}
         }
     }
     Ok(())


### PR DESCRIPTION
Each iteration of the Propolis server's serial task creates streams from its websocket stream/sink collections, passes these to `futures_util`'s `for_each_concurrent`, and then includes the resulting futures in its `select!` statement. If there are no active serial connections, these futures are trivially ready, so the serial task loops without blocking, which causes subsequent connections to the Propolis server to fail. Fix this by instead creating a terminated fused future to select on when these collections are empty.

In addition, reorder the serial task's `select!` block so that incoming data from the intermediate channel (the shared channel onto which clients' messages are pushed) is processed before new messages are read from the incoming streams. This prevents the same connection from being removed twice (without this the intermediate channel will fill with Close messages from the same client before the closure is processed, causing a double removal).

Tests:
- Verified that it's now possible to attach a serial client, detach it, and attach to the serial console again.
- Also verified that other CLI commands (e.g. `get`) work on an instance that has previously had a serial console attached.
- Verified that multiple serial clients work as expected (input on one client is reflected to the others, output from the guest is broadcast to all clients).

Closes #158.