### PR TITLE
Minor fixes to live migration protocol

### DIFF
--- a/bin/propolis-server/src/lib/migrate/destination.rs
+++ b/bin/propolis-server/src/lib/migrate/destination.rs
@@ -273,6 +273,12 @@ impl DestinationProtocol {
 
     async fn finish(&mut self) -> Result<(), MigrateError> {
         self.mctx.set_state(MigrationState::Finish).await;
+
+        // Allow the destination to be resumed now that the migration is
+        // complete.
+        self.mctx
+            .instance
+            .set_target_state(propolis::instance::ReqState::MigrateResume)?;
         self.send_msg(codec::Message::Okay).await?;
         let _ = self.read_ok().await; // A failure here is ok.
         Ok(())

--- a/bin/propolis-server/src/lib/migrate/mod.rs
+++ b/bin/propolis-server/src/lib/migrate/mod.rs
@@ -377,10 +377,8 @@ pub async fn dest_initiate(
 
     // TODO: https
     // TODO: We need to make sure the src_addr is a valid target
-    let src_migrate_url = format!(
-        "http://{}/instance/{}/migrate/start",
-        migrate_info.src_addr, migrate_info.src_uuid
-    );
+    let src_migrate_url =
+        format!("http://{}/instance/migrate/start", migrate_info.src_addr);
     info!(log, "Begin migration"; "src_migrate_url" => &src_migrate_url);
 
     let body = Body::from(

--- a/bin/propolis-server/src/lib/migrate/mod.rs
+++ b/bin/propolis-server/src/lib/migrate/mod.rs
@@ -375,7 +375,7 @@ pub async fn dest_initiate(
     // This should be a fresh propolis-server
     assert!(migrate_task.is_none());
 
-    // TODO: https
+    // TODO(#165): https
     // TODO: We need to make sure the src_addr is a valid target
     let src_migrate_url =
         format!("http://{}/instance/migrate/start", migrate_info.src_addr);

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -137,7 +137,7 @@ impl SourceProtocol {
         let end_gpa = req_end_gpa.min(vmm_ram_end.0);
         let step = bits.len() * 8 * 4096;
         for gpa in (start_gpa..end_gpa).step_by(step) {
-            self.track_dirty(GuestAddr(0), &mut bits).await?;
+            self.track_dirty(GuestAddr(gpa), &mut bits).await?;
             if bits.iter().all(|&b| b == 0) {
                 continue;
             }

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -6,7 +6,7 @@ use propolis::inventory::Order;
 use propolis::migrate::{MigrateStateError, Migrator};
 use slog::{error, info};
 use std::io;
-use std::ops::Range;
+use std::ops::{Range, RangeInclusive};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::{task, time};
@@ -127,17 +127,30 @@ impl SourceProtocol {
 
     async fn offer_ram(
         &mut self,
-        vmm_ram_range: Range<GuestAddr>,
+        vmm_ram_range: RangeInclusive<GuestAddr>,
         req_ram_range: Range<u64>,
     ) -> Result<(), MigrateError> {
         info!(self.log(), "offering ram");
-        let vmm_ram_start = vmm_ram_range.start;
-        let vmm_ram_end = vmm_ram_range.end;
+        let vmm_ram_start = *vmm_ram_range.start();
+        let vmm_ram_end = *vmm_ram_range.end();
         let mut bits = [0u8; 4096];
         let req_start_gpa = req_ram_range.start;
         let req_end_gpa = req_ram_range.end;
         let start_gpa = req_start_gpa.max(vmm_ram_start.0);
+
+        // The RAM bounds reported to this routine set the end of the range to
+        // the last valid address in the address space (e.g. 0x6FFF for a
+        // one-page range beginning at 0x6000), but this routine's callees
+        // expect the end address to be the first invalid (page-aligned) address
+        // (in our example, 0x7000 instead of 0x6FFF). Correct that here.
+        //
+        // N.B. This assumes that the guest address space is small enough to
+        //      add 1 in this fashion without overflowing, i.e. the last valid
+        //      GPA cannot be `u64::MAX`.
         let end_gpa = req_end_gpa.min(vmm_ram_end.0);
+        assert!(end_gpa < u64::MAX);
+        let end_gpa = end_gpa + 1;
+
         let step = bits.len() * 8 * 4096;
         for gpa in (start_gpa..end_gpa).step_by(step) {
             self.track_dirty(GuestAddr(gpa), &mut bits).await?;
@@ -314,7 +327,7 @@ impl SourceProtocol {
         let vmm_range = self.vmm_ram_bounds().await?;
         let mut bits = [0u8; 4096];
         let step = bits.len() * 8 * 4096;
-        for gpa in (vmm_range.start.0..vmm_range.end.0).step_by(step) {
+        for gpa in (vmm_range.start().0..vmm_range.end().0).step_by(step) {
             self.track_dirty(GuestAddr(gpa), &mut bits).await?;
             assert!(bits.iter().all(|&b| b == 0));
         }
@@ -384,7 +397,7 @@ impl SourceProtocol {
 
     async fn vmm_ram_bounds(
         &mut self,
-    ) -> Result<Range<GuestAddr>, MigrateError> {
+    ) -> Result<RangeInclusive<GuestAddr>, MigrateError> {
         let memctx = self
             .mctx
             .async_ctx

--- a/bin/propolis-standalone/src/snapshot.rs
+++ b/bin/propolis-standalone/src/snapshot.rs
@@ -186,7 +186,7 @@ pub async fn save(
     let mem_bounds = memctx
         .mem_bounds()
         .ok_or(anyhow::anyhow!("Failed to get VM RAM bounds"))?;
-    let len: usize = (mem_bounds.end.0 - mem_bounds.start.0 + 1).try_into()?;
+    let len: usize = (mem_bounds.end.0 - mem_bounds.start.0).try_into()?;
     let (lo, hi) = if len > 3 * GB {
         (3 * GB, Some(len.saturating_sub(4 * GB)))
     } else {

--- a/bin/propolis-standalone/src/snapshot.rs
+++ b/bin/propolis-standalone/src/snapshot.rs
@@ -186,7 +186,8 @@ pub async fn save(
     let mem_bounds = memctx
         .mem_bounds()
         .ok_or(anyhow::anyhow!("Failed to get VM RAM bounds"))?;
-    let len: usize = (mem_bounds.end.0 - mem_bounds.start.0).try_into()?;
+    let len: usize =
+        (mem_bounds.end().0 - mem_bounds.start().0 + 1).try_into()?;
     let (lo, hi) = if len > 3 * GB {
         (3 * GB, Some(len.saturating_sub(4 * GB)))
     } else {

--- a/lib/propolis/src/vmm/machine.rs
+++ b/lib/propolis/src/vmm/machine.rs
@@ -487,7 +487,7 @@ impl<'a> MemCtx<'a> {
             .map
             .highest_addr(|entry| matches!(entry.kind, MapKind::SysMem(_, _)))?
             as u64;
-        Some(RangeInclusive::new(GuestAddr(lowest), GuestAddr(highest)))
+        Some(GuestAddr(lowest)..=GuestAddr(highest))
     }
 }
 

--- a/lib/propolis/src/vmm/machine.rs
+++ b/lib/propolis/src/vmm/machine.rs
@@ -476,7 +476,7 @@ impl<'a> MemCtx<'a> {
         }
     }
 
-    /// Returns the [lowest, highest] memory addresses in the space, inclusive.
+    /// Returns the [lowest, highest + 1) memory addresses in the space.
     pub fn mem_bounds(&self) -> Option<Range<GuestAddr>> {
         let lowest = self
             .map
@@ -486,7 +486,7 @@ impl<'a> MemCtx<'a> {
             .map
             .highest_addr(|entry| matches!(entry.kind, MapKind::SysMem(_, _)))?
             as u64;
-        Some(GuestAddr(lowest)..GuestAddr(highest))
+        Some(GuestAddr(lowest)..GuestAddr(highest + 1))
     }
 }
 

--- a/lib/propolis/src/vmm/machine.rs
+++ b/lib/propolis/src/vmm/machine.rs
@@ -3,7 +3,7 @@
 use std::io::{Error, ErrorKind, Result};
 use std::marker::PhantomData;
 use std::mem::size_of;
-use std::ops::Range;
+use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use crate::common::{GuestAddr, GuestRegion};
@@ -476,8 +476,9 @@ impl<'a> MemCtx<'a> {
         }
     }
 
-    /// Returns the [lowest, highest + 1) memory addresses in the space.
-    pub fn mem_bounds(&self) -> Option<Range<GuestAddr>> {
+    /// Returns the [lowest, highest] memory addresses in the space as an
+    /// inclusive range.
+    pub fn mem_bounds(&self) -> Option<RangeInclusive<GuestAddr>> {
         let lowest = self
             .map
             .lowest_addr(|entry| matches!(entry.kind, MapKind::SysMem(_, _)))?
@@ -486,7 +487,7 @@ impl<'a> MemCtx<'a> {
             .map
             .highest_addr(|entry| matches!(entry.kind, MapKind::SysMem(_, _)))?
             as u64;
-        Some(GuestAddr(lowest)..GuestAddr(highest + 1))
+        Some(RangeInclusive::new(GuestAddr(lowest), GuestAddr(highest)))
     }
 }
 


### PR DESCRIPTION
This PR fixes a few small bugs in live migration:

- Make migration targets move to the correct "migrate destination" state after migration is finished so that they can be moved to the running state.
- Fix a URI disagreement between the Dropshot definitions in server.rs and the migration protocol initiation code in migrate/mod.rs.
- Change the VMM's `mem_bounds` routine to return the last GPA plus one as the upper bound on the address range. This prevents an assertion failure when constructing dirty bitmaps on the source.
- Iterate through GPAs correctly when computing dirty bitmaps on the source.
- Temporarily reorder migration steps on the source so that `pause` precedes `ram_push` instead of succeeding it. This ensures the source can't dirty pages once RAM is transferred. This lengthens blackout, but this process can be optimized to shorten it again. Assert at the end of source migration that there are no dirty pages left.

Tested by migrating an Alpine Linux VM with a virtio-block device and verifying that the target VM runs correctly and has an operable serial console and that the source doesn't assert.