### PR TITLE
Move inner VNC server state behind a single lock.

### DIFF
--- a/propolis/Cargo.toml
+++ b/propolis/Cargo.toml
@@ -23,6 +23,7 @@ usdt = { version = "0.3.2", default-features = false }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 anyhow = "1"
+rfb = { git = "https://github.com/oxidecomputer/rfb", branch = "main" }
 slog = "2.7"
 serde = { version = "1" }
 serde_arrays = "0.1"

--- a/propolis/src/hw/qemu/ramfb.rs
+++ b/propolis/src/hw/qemu/ramfb.rs
@@ -37,7 +37,7 @@ lazy_static! {
 fn fourcc_bytepp(fourcc: u32) -> Option<u32> {
     match fourcc {
         // The edk2 default: XR24, little-endian xRGB with 4 bytes per pixel.
-        0x34325258 => Some(4),
+        rfb::pixel_formats::fourcc::FOURCC_XR24 => Some(4),
         _ => None,
     }
 }

--- a/server/src/lib/server.rs
+++ b/server/src/lib/server.rs
@@ -432,8 +432,7 @@ async fn instance_ensure(
     let fb = vnc::RamFb::new(fb_spec.clone());
     let actx = instance.async_ctx();
     let vnc_server = vnc_hdl.lock().await;
-    vnc_server.server.set_async_ctx(actx).await;
-    vnc_server.server.initialize_framebuffer(fb).await;
+    vnc_server.server.initialize(fb, actx, vnc_server.clone()).await;
 
     let rt = rt_handle.unwrap();
     let hdl = Arc::clone(&vnc_hdl);
@@ -441,7 +440,7 @@ async fn instance_ensure(
         let h = Arc::clone(&hdl);
         rt.block_on(async move {
             let vnc = h.lock().await;
-            vnc.server.update(&vnc, config, is_valid).await;
+            vnc.server.update(config, is_valid).await;
         });
     }));
 


### PR DESCRIPTION
This is a follow up PR to https://github.com/oxidecomputer/propolis/pull/151 that addresses @gjcolombo's feedback about a possible race in state on the VNC server (see this comment: https://github.com/oxidecomputer/propolis/pull/151#discussion_r911525611). To address this, I've simplified this code a bit by putting all of the state on the vnc server behind a single lock, which I hope makes this code easier to reason about.