### PR TITLE
Use instance spec compatibility checks in migration sync phase

### DIFF
--- a/bin/propolis-server/src/lib/migrate/preamble.rs
+++ b/bin/propolis-server/src/lib/migrate/preamble.rs
@@ -1,75 +1,14 @@
-use propolis::instance::Instance;
+use propolis_client::instance_spec::InstanceSpec;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
-pub(crate) enum MemType {
-    RAM,
-    ROM,
-    Dev,
-    Res,
-}
-
-// Memory regions in the guest physical address space.
-#[derive(Deserialize, Serialize, Debug)]
-pub(crate) struct MemRegion {
-    pub start: u64,
-    pub end: u64,
-    pub typ: MemType,
-}
-
-// PCI vendor and device ID pairs.
-#[derive(Deserialize, Serialize, Debug)]
-pub(crate) struct PciId {
-    pub vendor: u16,
-    pub device: u16,
-}
-
-// PCI Bus/Device/Function.
-#[derive(Deserialize, Serialize, Debug)]
-pub(crate) struct PciBdf {
-    pub bus: u16,
-    pub device: u8,
-    pub function: u8,
-}
-
-// PIO ranges associated with some device.
-#[derive(Deserialize, Serialize, Debug)]
-pub(crate) struct DevPorts {
-    pub device: u32,
-    pub ports: Vec<u16>,
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-pub(crate) struct VmDescr {
-    pub vcpus: Vec<u32>,           // APIC IDs.
-    pub ioapics: Vec<u32>,         // IOAPICs.
-    pub mem: Vec<MemRegion>,       // Start, end, type
-    pub pci: Vec<(PciId, PciBdf)>, // Vendor/ID + BDF
-    pub ports: Vec<DevPorts>,
-}
-
-impl VmDescr {
-    pub fn new(_instance: &Instance) -> VmDescr {
-        // XXX: Just for demo purposes. We should get this from the instance.
-        let vcpus = vec![0, 1, 2, 3];
-        VmDescr {
-            vcpus,
-            ioapics: Vec::new(),
-            mem: Vec::new(),
-            pci: Vec::new(),
-            ports: Vec::new(),
-        }
-    }
-}
-
-#[derive(Deserialize, Serialize, Debug)]
 pub(crate) struct Preamble {
-    pub vm_descr: VmDescr,
+    pub instance_spec: InstanceSpec,
     pub blobs: Vec<Vec<u8>>,
 }
 
 impl Preamble {
-    pub fn new(instance: &Instance) -> Preamble {
-        Preamble { vm_descr: VmDescr::new(instance), blobs: Vec::new() }
+    pub fn new(instance_spec: InstanceSpec) -> Preamble {
+        Preamble { instance_spec, blobs: Vec::new() }
     }
 }

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -81,7 +81,7 @@ impl SourceProtocol {
 
     async fn sync(&mut self) -> Result<(), MigrateError> {
         self.mctx.set_state(MigrationState::Sync).await;
-        let preamble = Preamble::new(self.mctx.instance.as_ref());
+        let preamble = Preamble::new(self.mctx.instance_spec.clone());
         let s = ron::ser::to_string(&preamble)
             .map_err(codec::ProtocolError::from)?;
         self.send_msg(codec::Message::Serialized(s)).await?;

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -87,6 +87,7 @@ pub(crate) struct InstanceContext {
     // The instance, which may or may not be instantiated.
     pub instance: Arc<Instance>,
     pub properties: api::InstanceProperties,
+    pub spec: instance_spec::InstanceSpec,
     serial: Option<Arc<Serial<LpcUart>>>,
     state_watcher: watch::Receiver<StateChange>,
     serial_task: Option<SerialTask>,
@@ -448,6 +449,7 @@ async fn instance_ensure(
     *context = Some(InstanceContext {
         instance: instance.clone(),
         properties,
+        spec,
         serial: com1,
         state_watcher: rx,
         serial_task: None,


### PR DESCRIPTION
Stash an instance's spec in its server context. During a migration, have the source send its spec to the target, and have the target use `is_migration_compatible` to check the specs for compatibility.

Tested via:

- Manual migrations of Alpine Linux and WS2019 VMs
- Checked that migrations fail between servers with various incompatible device specifications
- cargo test