### PR TITLE
Fix PHD quickstart script

### DIFF
--- a/phd-tests/quickstart.sh
+++ b/phd-tests/quickstart.sh
@@ -10,7 +10,7 @@ if [ ! -d "$PHD_QUICKSTART_DIR" ]; then
 	mkdir $PHD_QUICKSTART_DIR
 fi
 
-cargo run --profile=phd --bin=phd-runner -- \
+cargo run --profile=phd -p phd-runner -- \
 	--artifact-toml-path ./sample_artifacts.toml \
 	--tmp-directory $PHD_QUICKSTART_DIR \
 	--propolis-server-cmd $1


### PR DESCRIPTION
Evidently `cargo run --bin` only lets you specify binary targets that are reachable through a workspace's default members, and I removed `phd-tests` from the default members before submitting #166. Oops. 

Fix this by specifying phd-runner as a package instead.