### PR TITLE
Add line numbers to PHD logging output

### DIFF
--- a/phd-tests/runner/src/main.rs
+++ b/phd-tests/runner/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
     // Set up a tracing subscriber.
     let filter = EnvFilter::builder()
         .with_default_directive(tracing::Level::INFO.into());
-    let stdout_log = tracing_subscriber::fmt::layer();
+    let stdout_log = tracing_subscriber::fmt::layer().with_line_number(true);
     let subscriber =
         Registry::default().with(filter.from_env_lossy()).with(stdout_log);
     tracing::subscriber::set_global_default(subscriber).unwrap();


### PR DESCRIPTION
This makes it considerably easier (IMO, anyway) to correlate log messages with source locations (the module path is already in the log output).