### PR TITLE
Update crucible to include crucible-client-types crate

### DIFF
--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -44,7 +44,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 slog = "2.7"
-propolis = { path = "../../lib/propolis", features = ["crucible", "crucible-client-types", "oximeter"], default-features = false }
+propolis = { path = "../../lib/propolis", features = ["crucible-full", "oximeter"], default-features = false }
 propolis-client = { path = "../../lib/propolis-client" }
 rfb = { git = "https://github.com/oxidecomputer/rfb", branch = "main" }
 uuid = "1.0.0"

--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -44,7 +44,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 slog = "2.7"
-propolis = { path = "../../lib/propolis", features = ["crucible", "oximeter"], default-features = false }
+propolis = { path = "../../lib/propolis", features = ["crucible", "crucible-client-types", "oximeter"], default-features = false }
 propolis-client = { path = "../../lib/propolis-client" }
 rfb = { git = "https://github.com/oxidecomputer/rfb", branch = "main" }
 uuid = "1.0.0"

--- a/lib/propolis-client/Cargo.toml
+++ b/lib/propolis-client/Cargo.toml
@@ -16,4 +16,4 @@ serde_json = "1.0"
 slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_debug" ] }
 thiserror = "1.0"
 uuid = { version = "1.0.0", features = [ "serde", "v4" ] }
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "2add0de8489f1d4de901bfe98fc28b0a6efcc3ea" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "1d67a53042f19ff7ca30dd20a04da94b7715ed7c" }

--- a/lib/propolis-client/src/api.rs
+++ b/lib/propolis-client/src/api.rs
@@ -9,8 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use uuid::Uuid;
 
-// Re-export types that are of a public struct
-pub use crucible::VolumeConstructionRequest;
+pub use crucible_client_types::VolumeConstructionRequest;
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
 pub struct InstanceNameParams {
@@ -240,7 +239,8 @@ pub struct DiskRequest {
 
     // Crucible related opts
     pub gen: u64,
-    pub volume_construction_request: crucible::VolumeConstructionRequest,
+    pub volume_construction_request:
+        crucible_client_types::VolumeConstructionRequest,
 }
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]

--- a/lib/propolis-client/src/api.rs
+++ b/lib/propolis-client/src/api.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use uuid::Uuid;
 
+// Re-export types that are of a public struct
 pub use crucible_client_types::VolumeConstructionRequest;
 
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]

--- a/lib/propolis-client/src/instance_spec.rs
+++ b/lib/propolis-client/src/instance_spec.rs
@@ -50,7 +50,7 @@ use std::convert::TryFrom;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-pub use crucible::VolumeConstructionRequest;
+pub use crucible_client_types::VolumeConstructionRequest;
 pub use propolis_types::PciPath;
 
 /// Type alias for keys in the instance spec's maps.
@@ -261,8 +261,7 @@ impl MigrationCompatible for Board {
 /// A description of a Crucible volume construction request.
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct CrucibleRequestContents {
-    /// A [`crucible::VolumeConstructionRequest`], serialized as JSON.
-    //
+    /// A [`crucible_client_types::VolumeConstructionRequest`], serialized as JSON.
     // Storing volume construction requests in serialized form allows external
     // types to change without causing a breaking change to instance specs.
     // Consider the following scenario, assuming the VolumeConstructionRequest
@@ -294,7 +293,9 @@ pub struct CrucibleRequestContents {
     pub json: String,
 }
 
-impl TryFrom<&CrucibleRequestContents> for crucible::VolumeConstructionRequest {
+impl TryFrom<&CrucibleRequestContents>
+    for crucible_client_types::VolumeConstructionRequest
+{
     type Error = serde_json::Error;
 
     fn try_from(value: &CrucibleRequestContents) -> Result<Self, Self::Error> {
@@ -302,11 +303,13 @@ impl TryFrom<&CrucibleRequestContents> for crucible::VolumeConstructionRequest {
     }
 }
 
-impl TryFrom<&crucible::VolumeConstructionRequest> for CrucibleRequestContents {
+impl TryFrom<&crucible_client_types::VolumeConstructionRequest>
+    for CrucibleRequestContents
+{
     type Error = serde_json::Error;
 
     fn try_from(
-        value: &crucible::VolumeConstructionRequest,
+        value: &crucible_client_types::VolumeConstructionRequest,
     ) -> Result<Self, Self::Error> {
         Ok(Self { json: serde_json::to_string(value)? })
     }

--- a/lib/propolis-client/src/instance_spec.rs
+++ b/lib/propolis-client/src/instance_spec.rs
@@ -262,6 +262,7 @@ impl MigrationCompatible for Board {
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct CrucibleRequestContents {
     /// A [`crucible_client_types::VolumeConstructionRequest`], serialized as JSON.
+    //
     // Storing volume construction requests in serialized form allows external
     // types to change without causing a breaking change to instance specs.
     // Consider the following scenario, assuming the VolumeConstructionRequest

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -56,3 +56,4 @@ rand = "0.8"
 [features]
 default = ["dtrace-probes"]
 dtrace-probes = ["usdt/asm"]
+crucible-full = ["crucible", "crucible-client-types"]

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -31,9 +31,14 @@ erased-serde = "0.3"
 serde_json = "1.0"
 uuid = "1.0.0"
 
+[dependencies.crucible-client-types]
+git = "https://github.com/oxidecomputer/crucible"
+rev = "1d67a53042f19ff7ca30dd20a04da94b7715ed7c"
+optional = true
+
 [dependencies.crucible]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "2add0de8489f1d4de901bfe98fc28b0a6efcc3ea"
+rev = "1d67a53042f19ff7ca30dd20a04da94b7715ed7c"
 optional = true
 
 [dependencies.oximeter]

--- a/lib/propolis/src/block/crucible.rs
+++ b/lib/propolis/src/block/crucible.rs
@@ -13,8 +13,8 @@ use uuid::Uuid;
 
 use crucible::{
     crucible_bail, BlockIO, Buffer, CrucibleError, SnapshotDetails, Volume,
-    VolumeConstructionRequest,
 };
+use crucible_client_types::VolumeConstructionRequest;
 use oximeter::types::ProducerRegistry;
 
 /// Helper function, because Rust couldn't derive the types


### PR DESCRIPTION
This updates the version of crucible to use the new `crucible-client-types` crate

Part of fixing https://github.com/oxidecomputer/omicron/issues/1537
