### PR TITLE
Replicate existing propolis-server integration tests in PHD

### DIFF
--- a/phd-tests/framework/Cargo.toml
+++ b/phd-tests/framework/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.58"
+backoff = "0.4.0"
 futures = "0.3"
 hex = "0.4.3"
 propolis-client = { path = "../../lib/propolis-client" }

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -217,14 +217,14 @@ impl TestVm {
     /// Starts the VM.
     pub fn run(&self) -> StdResult<(), PropolisClientError> {
         self.rt.block_on(async {
-            self.put_instance_state(InstanceStateRequested::Run).await
+            self.put_instance_state_async(InstanceStateRequested::Run).await
         })
     }
 
     /// Stops the VM.
     pub fn stop(&self) -> StdResult<(), PropolisClientError> {
         self.rt.block_on(async {
-            self.put_instance_state(InstanceStateRequested::Stop).await
+            self.put_instance_state_async(InstanceStateRequested::Stop).await
         })
     }
 
@@ -232,11 +232,11 @@ impl TestVm {
     /// distinct from requesting a reboot from within the guest).
     pub fn reset(&self) -> StdResult<(), PropolisClientError> {
         self.rt.block_on(async {
-            self.put_instance_state(InstanceStateRequested::Reboot).await
+            self.put_instance_state_async(InstanceStateRequested::Reboot).await
         })
     }
 
-    async fn put_instance_state(
+    async fn put_instance_state_async(
         &self,
         state: InstanceStateRequested,
     ) -> StdResult<(), PropolisClientError> {
@@ -280,7 +280,11 @@ impl TestVm {
 
             match backoff.next_backoff() {
                 Some(to_wait) => {
-                    info!("Waiting for state {:?}, got state {:?}, waiting {:#?} before trying again", target, current, to_wait);
+                    info!(
+                        "Waiting for state {:?}, got state {:?}, \
+                          waiting {:#?} before trying again",
+                        target, current, to_wait
+                    );
                     std::thread::sleep(to_wait);
                 }
                 None => {

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -7,6 +7,8 @@ use crate::guest_os::{self, CommandSequenceEntry, GuestOs, GuestOsKind};
 use crate::serial::SerialConsole;
 
 use anyhow::{anyhow, Context, Result};
+use backoff::backoff::Backoff;
+use propolis_client::api::InstanceState;
 use propolis_client::{
     api::{
         InstanceEnsureRequest, InstanceGetResponse, InstanceProperties,
@@ -213,30 +215,88 @@ impl TestVm {
 
     /// Starts the VM's guest.
     pub fn run(&self) -> Result<()> {
-        let _span = self.tracing_span.enter();
-        info!("Sending run request to server");
         self.rt.block_on(async {
-            self.client
-                .instance_state_put(InstanceStateRequested::Run)
-                .await
-                .with_context(|| {
-                anyhow!("failed to set instance state to running")
-            })?;
-
-            Ok(())
+            self.put_instance_state(InstanceStateRequested::Run).await
         })
+    }
+
+    /// Stops the VM.
+    pub fn stop(&self) -> Result<()> {
+        self.rt.block_on(async {
+            self.put_instance_state(InstanceStateRequested::Stop).await
+        })
+    }
+
+    /// Resets the VM by requesting the `Reboot` state from the server (as
+    /// distinct from requesting a reboot from within the guest).
+    pub fn reset(&self) -> Result<()> {
+        self.rt.block_on(async {
+            self.put_instance_state(InstanceStateRequested::Reboot).await
+        })
+    }
+
+    async fn put_instance_state(
+        &self,
+        state: InstanceStateRequested,
+    ) -> Result<()> {
+        let _span = self.tracing_span.enter();
+        info!(?state, "Requesting instance state change");
+        self.client
+            .instance_state_put(state)
+            .await
+            .with_context(|| anyhow!("failed to set instance state"))?;
+        Ok(())
     }
 
     /// Issues a Propolis client `instance_get` request.
     pub fn get(&self) -> Result<InstanceGetResponse> {
         let _span = self.tracing_span.enter();
         info!("Sending instance get request to server");
-        self.rt.block_on(async {
-            let res = self.client.instance_get().await.with_context(|| {
-                anyhow!("failed to query instance properties")
-            })?;
-            Ok(res)
-        })
+        self.rt.block_on(async { self.get_async().await })
+    }
+
+    async fn get_async(&self) -> Result<InstanceGetResponse> {
+        self.client
+            .instance_get()
+            .await
+            .with_context(|| anyhow!("failed to query instance properties"))
+    }
+
+    pub fn wait_for_state(
+        &self,
+        target: InstanceState,
+        timeout_duration: Duration,
+    ) -> Result<()> {
+        let _span = self.tracing_span.enter();
+        info!(
+            "Waiting {:?} for server to reach state {:?}",
+            timeout_duration, target
+        );
+
+        let mut backoff = backoff::ExponentialBackoff::default();
+        backoff.max_elapsed_time = Some(timeout_duration);
+        loop {
+            let current = self.get()?.instance.state;
+            if current == target {
+                return Ok(());
+            }
+
+            match backoff.next_backoff() {
+                Some(to_wait) => {
+                    info!("Waiting for state {:?}, got state {:?}, waiting {:#?} before trying again", target, current, to_wait);
+                    std::thread::sleep(to_wait);
+                }
+                None => {
+                    info!("Timed out waiting for state {:?}", target);
+                    break;
+                }
+            }
+        }
+
+        Err(anyhow!(
+            "Timed out waiting for instance to reach state {:?}",
+            target
+        ))
     }
 
     /// Waits for the guest to reach a login prompt and then logs in. Note that

--- a/phd-tests/tests/Cargo.toml
+++ b/phd-tests/tests/Cargo.toml
@@ -8,4 +8,3 @@ edition = "2021"
 [dependencies]
 propolis-client = { path = "../../lib/propolis-client" }
 phd-testcase = { path = "../testcase" }
-tracing = "0.1.35"

--- a/phd-tests/tests/Cargo.toml
+++ b/phd-tests/tests/Cargo.toml
@@ -6,4 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+propolis-client = { path = "../../lib/propolis-client" }
 phd-testcase = { path = "../testcase" }
+tracing = "0.1.35"

--- a/phd-tests/tests/src/lib.rs
+++ b/phd-tests/tests/src/lib.rs
@@ -1,3 +1,4 @@
 pub use phd_testcase;
 
+mod server_state_machine;
 mod smoke;

--- a/phd-tests/tests/src/server_state_machine.rs
+++ b/phd-tests/tests/src/server_state_machine.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use phd_testcase::*;
-use propolis_client::api::InstanceState;
+use propolis_client::{api::InstanceState, Error as ClientError};
 
 #[phd_testcase]
 fn instance_start_stop_test(ctx: &TestContext) {
@@ -33,9 +33,9 @@ fn instance_stop_causes_destroy_test(ctx: &TestContext) {
     vm.stop()?;
     vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))?;
 
-    assert!(vm.run().is_err());
-    assert!(vm.stop().is_err());
-    assert!(vm.reset().is_err());
+    assert!(matches!(vm.run().unwrap_err(), ClientError::Status(500)));
+    assert!(matches!(vm.stop().unwrap_err(), ClientError::Status(500)));
+    assert!(matches!(vm.reset().unwrap_err(), ClientError::Status(500)));
 }
 
 #[phd_testcase]

--- a/phd-tests/tests/src/server_state_machine.rs
+++ b/phd-tests/tests/src/server_state_machine.rs
@@ -1,0 +1,54 @@
+//! Tests verifying the server state machine.
+
+use std::time::Duration;
+
+use phd_testcase::*;
+use propolis_client::api::InstanceState;
+
+#[phd_testcase]
+fn instance_start_stop_test(ctx: &TestContext) {
+    let vm = ctx.vm_factory.new_vm(
+        "instance_ensure_running_test",
+        ctx.vm_factory.default_vm_config(),
+    )?;
+
+    let instance = vm.get()?.instance;
+    assert_eq!(instance.state, InstanceState::Creating);
+
+    vm.run()?;
+    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
+
+    vm.stop()?;
+    vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))?;
+}
+
+#[phd_testcase]
+fn instance_stop_causes_destroy_test(ctx: &TestContext) {
+    let vm = ctx.vm_factory.new_vm(
+        "instance_stop_causes_destroy_test",
+        ctx.vm_factory.default_vm_config(),
+    )?;
+
+    vm.run()?;
+    vm.stop()?;
+    vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))?;
+
+    assert!(vm.run().is_err());
+    assert!(vm.stop().is_err());
+    assert!(vm.reset().is_err());
+}
+
+#[phd_testcase]
+fn instance_reset_returns_to_running_test(ctx: &TestContext) {
+    let vm = ctx.vm_factory.new_vm(
+        "instance_stop_returns_to_running_test",
+        ctx.vm_factory.default_vm_config(),
+    )?;
+
+    vm.run()?;
+    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
+    vm.reset()?;
+    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
+    vm.stop()?;
+    vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))?;
+}


### PR DESCRIPTION
Port the existing propolis-server integration tests to the PHD framework, but don't delete the old ones yet--wait for Buildomat automation to come online first. (It's coming up next!)

These tests explicitly verify the error codes that Propolis returns when a client requests an invalid state change, so adjust some framework return types to allow these checks to be ported. (`anyhow` downcasting would have worked too but makes the tests more verbose.)

Tweak some routine names in `TestVm` for consistency, aiming for a world in which `foo_async` is the async function that does foo, and `foo` is the (usually public) wrapper function that wraps that function in a `block_on` statement. `TestVm` already used this pattern in some places, but it didn't use it consistently.

Tested with a local run of the new tests.