### PR TITLE
Run PHD tests in buildomat

### DIFF
--- a/.github/buildomat/jobs/phd-build.sh
+++ b/.github/buildomat/jobs/phd-build.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#:
+#: name = "phd-build"
+#: variety = "basic"
+#: target = "helios"
+#: rust_toolchain = "stable"
+#: output_rules = [
+#:   "/out/*",
+#: ]
+#:
+#: [[publish]]
+#: series = "image"
+#: name = "propolis-server-debug.tar.gz"
+#: from_output = "/out/propolis-server-debug.tar.gz"
+#:
+#: [[publish]]
+#: series = "image"
+#: name = "propolis-server-debug.sha256.txt"
+#: from_output = "/out/propolis-server-debug.sha256.txt"
+#:
+#: [[publish]]
+#: series = "image"
+#: name = "phd-runner.tar.gz"
+#: from_output = "/out/phd-runner.tar.gz"
+#:
+#: [[publish]]
+#: series = "image"
+#: name = "phd-runner.sha256.txt"
+#: from_output = "/out/phd-runner.sha256.txt"
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+outdir="/out"
+
+cargo --version
+rustc --version
+
+# Build the Propolis server binary in debug mode to enable assertions
+# that should fire during tests.
+banner build-propolis
+ptime -m cargo build --verbose -p propolis-server
+
+# Build the PHD runner with the phd profile to enable unwind on panic,
+# which the framework requires to catch certain test failures.
+banner build-phd
+ptime -m cargo build --verbose -p phd-runner --profile=phd
+
+banner contents
+tar -czvf target/debug/propolis-server-debug.tar.gz \
+	-C target/debug propolis-server
+
+tar -czvf target/phd/phd-runner.tar.gz \
+	-C target/phd phd-runner \
+	-C phd-tests/buildomat buildomat_artifacts.toml
+
+banner copy
+pfexec mkdir -p $outdir
+pfexec chown "$UID" $outdir
+mv target/debug/propolis-server-debug.tar.gz \
+	$outdir/propolis-server-debug.tar.gz
+mv target/phd/phd-runner.tar.gz $outdir/phd-runner.tar.gz
+cd $outdir
+digest -a sha256 propolis-server-debug.tar.gz > \
+	propolis-server-debug.sha256.txt
+digest -a sha256 phd-runner.tar.gz > phd-runner.sha256.txt

--- a/.github/buildomat/jobs/phd-build.sh
+++ b/.github/buildomat/jobs/phd-build.sh
@@ -7,26 +7,6 @@
 #: output_rules = [
 #:   "/out/*",
 #: ]
-#:
-#: [[publish]]
-#: series = "image"
-#: name = "propolis-server-debug.tar.gz"
-#: from_output = "/out/propolis-server-debug.tar.gz"
-#:
-#: [[publish]]
-#: series = "image"
-#: name = "propolis-server-debug.sha256.txt"
-#: from_output = "/out/propolis-server-debug.sha256.txt"
-#:
-#: [[publish]]
-#: series = "image"
-#: name = "phd-runner.tar.gz"
-#: from_output = "/out/phd-runner.tar.gz"
-#:
-#: [[publish]]
-#: series = "image"
-#: name = "phd-runner.sha256.txt"
-#: from_output = "/out/phd-runner.sha256.txt"
 
 set -o errexit
 set -o pipefail

--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -6,6 +6,7 @@
 #: output_rules = [
 #:	"/tmp/propolis-phd/*.log",
 #:	"/tmp/propolis-phd/*.toml",
+#:	"/tmp/phd-runner.log",
 #: ]
 #: skip_clone = true
 #:
@@ -55,11 +56,12 @@ ls $artifacts
 ls $propolis
 
 if RUST_BACKTRACE=1 ptime -m $runner \
+	--disable-ansi \
 	run \
 	--propolis-server-cmd $propolis \
 	--artifact-toml-path $artifacts \
 	--tmp-directory $tmpdir | \
-	tee $tmpdir/runner.out; then
+	tee /tmp/phd-runner.log; then
 
 	echo
 	echo "ALL TESTS PASSED"

--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -55,7 +55,7 @@ ls $artifacts
 ls $propolis
 
 (RUST_BACKTRACE=1 ptime -m $runner \
-	--disable-ansi \
+	--emit-bunyan \
 	run \
 	--propolis-server-cmd $propolis \
 	--artifact-toml-path $artifacts \

--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -4,9 +4,8 @@
 #: variety = "basic"
 #: target = "lab"
 #: output_rules = [
-#:	"/tmp/propolis-phd/*.log",
-#:	"/tmp/propolis-phd/*.toml",
 #:	"/tmp/phd-runner.log",
+#:	"/tmp/phd-tmp-files.tar.gz",
 #: ]
 #: skip_clone = true
 #:
@@ -55,14 +54,21 @@ ls $runner
 ls $artifacts
 ls $propolis
 
-if RUST_BACKTRACE=1 ptime -m $runner \
+(RUST_BACKTRACE=1 ptime -m $runner \
 	--disable-ansi \
 	run \
 	--propolis-server-cmd $propolis \
 	--artifact-toml-path $artifacts \
 	--tmp-directory $tmpdir | \
-	tee /tmp/phd-runner.log; then
+	tee /tmp/phd-runner.log)
 
+failcount=$?
+
+tar -czvf /tmp/phd-tmp-files.tar.gz \
+	-C /tmp/propolis-phd /tmp/propolis-phd/*.log \
+	-C /tmp/propolis-phd /tmp/propolis-phd/*.toml
+
+if [ $failcount -eq 0 ]; then
 	echo
 	echo "ALL TESTS PASSED"
 	echo

--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#:
+#: name = "phd-run"
+#: variety = "basic"
+#: target = "lab"
+#: output_rules = [
+#:	"/tmp/propolis-phd/*.log",
+#:	"/tmp/propolis-phd/*.toml",
+#: ]
+#: skip_clone = true
+#:
+#: [dependencies.phd-build]
+#: job = "phd-build"
+#:
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+indir="/input"
+indir_suffix="phd-build/out/*.tar.gz"
+phddir="$PWD/phd-test"
+
+banner 'Inputs'
+find $indir -ls
+
+rm -rf "$phddir"
+mkdir "$phddir"
+
+for p in $indir/$indir_suffix; do
+	tar xzvf $p -C $phddir
+	for f in $(tar tf "$p"); do
+		chmod +x "$phddir/$f"
+	done
+done
+
+ls $phddir
+
+banner 'Setup'
+tmpdir="/tmp/propolis-phd"
+if [ ! -d "$tmpdir" ]; then
+	mkdir $tmpdir
+fi
+
+banner 'Tests'
+
+runner="$phddir/phd-runner"
+artifacts="$phddir/buildomat_artifacts.toml"
+propolis="$phddir/propolis-server"
+
+# TODO: Leverage ZFS artifact support in PHD.
+
+ls $runner
+ls $artifacts
+ls $propolis
+
+if RUST_BACKTRACE=1 ptime -m $runner \
+	run \
+	--propolis-server-cmd $propolis \
+	--artifact-toml-path $artifacts \
+	--tmp-directory $tmpdir | \
+	tee $tmpdir/runner.out; then
+
+	echo
+	echo "ALL TESTS PASSED"
+	echo
+	exit 0
+else
+	echo
+	echo "SOME TESTS FAILED"
+	echo
+	exit 1
+fi

--- a/.github/buildomat/jobs/tests-build.sh
+++ b/.github/buildomat/jobs/tests-build.sh
@@ -26,6 +26,16 @@ banner 'BuildTests'
 ptime -m cargo build --verbose --tests \
     --message-format json-render-diagnostics >/tmp/output.tests.json
 
+# For each entry in the supplied Cargo build log:
+# - Select all those entries with a reason of "compiler-artifact"
+# - Filter those entries as follows:
+#   - Look at the values in the target kind map
+#   - Map each value to true/false by comparing it to $2
+#   - Keep the entry only if at least one value matched the desired kind
+# - Get an array of the entries that passed the filter, preserving only their
+#   filename fields
+# - Flatten the array into an array of filenames
+# - Print the array entries unadorned, one to a line
 function artifacts_from {
 	/opt/ooce/bin/jq -r -s "
 		map(

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default-members = [
 exclude = [
   "crates/bhyve-api/header-check",
   "crates/viona-api/header-check",
+  "phd-tests/buildomat",
 ]
 
 [profile.dev]

--- a/phd-tests/buildomat/buildomat_artifacts.toml
+++ b/phd-tests/buildomat/buildomat_artifacts.toml
@@ -1,0 +1,14 @@
+local_root = "/tmp/propolis-phd"
+remote_root = "https://oxide-omicron-build.s3.amazonaws.com"
+
+[guest_images.alpine]
+guest_os_kind = "alpine"
+metadata.relative_local_path = "alpine.iso"
+metadata.expected_digest = "ba8007f74f9b54fbae3b2520da577831b4834778a498d732f091260c61aa7ca1"
+metadata.relative_remote_path = "alpine.iso"
+
+[bootroms.ovmf]
+relative_local_path = "OVMF_CODE.fd"
+expected_digest = "32b4ba73f302e6c1c1ebd7ed0fecab9fa1fcedac77765454aa91e66604c10d27"
+relative_remote_path = "OVMF_CODE.fd"
+

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -109,7 +109,7 @@ impl TestVm {
     ) -> Result<Self> {
         info!(?process_params, ?vm_config, ?guest_os_kind);
         let vm_id = Uuid::new_v4();
-        let span = info_span!(parent: None, "VM", name = ?vm_name);
+        let span = info_span!(parent: None, "VM", vm = ?vm_name);
         let rt =
             tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
 
@@ -129,6 +129,7 @@ impl TestVm {
             ?vm_config,
             "Launching Propolis server"
         );
+
         let server = ServerWrapper {
             server: std::process::Command::new("pfexec")
                 .args([

--- a/phd-tests/runner/Cargo.toml
+++ b/phd-tests/runner/Cargo.toml
@@ -13,5 +13,6 @@ phd-framework = { path = "../framework" }
 phd-tests = { path = "../tests" }
 tracing = "0.1.35"
 tracing-appender = "0.2.2"
+tracing-bunyan-formatter = "0.3.3"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 uuid = "1.1.2"

--- a/phd-tests/runner/src/config.rs
+++ b/phd-tests/runner/src/config.rs
@@ -15,6 +15,11 @@ pub enum Command {
 pub struct ProcessArgs {
     #[clap(subcommand)]
     pub command: Command,
+
+    /// If true, suppress the emission of terminal control codes in the runner's
+    /// log output.
+    #[clap(long, value_parser, default_value = "false")]
+    pub disable_ansi: bool,
 }
 
 #[derive(Args, Debug)]

--- a/phd-tests/runner/src/config.rs
+++ b/phd-tests/runner/src/config.rs
@@ -18,8 +18,22 @@ pub struct ProcessArgs {
 
     /// If true, suppress the emission of terminal control codes in the runner's
     /// log output.
-    #[clap(long, value_parser, default_value = "false")]
+    #[clap(
+        long,
+        value_parser,
+        default_value = "false",
+        conflicts_with = "emit-bunyan"
+    )]
     pub disable_ansi: bool,
+
+    /// If true, emit Bunyan-formatted logs.
+    #[clap(
+        long,
+        value_parser,
+        default_value = "false",
+        conflicts_with = "disable-ansi"
+    )]
+    pub emit_bunyan: bool,
 }
 
 #[derive(Args, Debug)]

--- a/phd-tests/runner/src/main.rs
+++ b/phd-tests/runner/src/main.rs
@@ -107,18 +107,17 @@ fn list_tests(list_opts: &ListOptions) {
 fn set_tracing_subscriber(args: &ProcessArgs) {
     let filter = EnvFilter::builder()
         .with_default_directive(tracing::Level::INFO.into());
+    let subscriber = Registry::default().with(filter.from_env_lossy());
     if args.emit_bunyan {
         let bunyan_layer =
             BunyanFormattingLayer::new("phd-runner".into(), std::io::stdout);
-        let subscriber =
-            Registry::default().with(JsonStorageLayer).with(bunyan_layer);
+        let subscriber = subscriber.with(JsonStorageLayer).with(bunyan_layer);
         tracing::subscriber::set_global_default(subscriber).unwrap();
     } else {
         let stdout_log = tracing_subscriber::fmt::layer()
             .with_line_number(true)
             .with_ansi(!args.disable_ansi);
-        let subscriber =
-            Registry::default().with(filter.from_env_lossy()).with(stdout_log);
+        let subscriber = subscriber.with(stdout_log);
         tracing::subscriber::set_global_default(subscriber).unwrap();
     }
 }

--- a/phd-tests/runner/src/main.rs
+++ b/phd-tests/runner/src/main.rs
@@ -15,16 +15,18 @@ use crate::execute::ExecutionStats;
 use crate::fixtures::TestFixtures;
 
 fn main() {
+    let runner_args = ProcessArgs::parse();
+
     // Set up a tracing subscriber.
     let filter = EnvFilter::builder()
         .with_default_directive(tracing::Level::INFO.into());
-    let stdout_log = tracing_subscriber::fmt::layer().with_line_number(true);
+    let stdout_log = tracing_subscriber::fmt::layer()
+        .with_line_number(true)
+        .with_ansi(!runner_args.disable_ansi);
     let subscriber =
         Registry::default().with(filter.from_env_lossy()).with(stdout_log);
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
-    // Set up global state: the command-line config and the artifact store.
-    let runner_args = ProcessArgs::parse();
     info!(?runner_args);
 
     match &runner_args.command {


### PR DESCRIPTION
Submitted with apologies for my unrefined shell scripting skills...

Set up Buildomat jobs to run PHD tests. These more or less follow the path laid out in `tests-build.sh` and `tests-run.sh`, with minor modifications to build PHD with the correct profile, plunk all of the necessary collateral onto the test runner, and extract the per-VM test logs from the runner when all the work is done. Once this merges, we can remove the Propolis integration tests that these supersede.

Tweak the PHD runner to exit with the number of failed tests as its exit code. Add an affordance to disable terminal control codes in `tracing`'s output, since they don't render especially nicely when reading raw logs.

Tested by checking Buildomat runs for the commits in this branch.