### PR TITLE
Split propolis-server config into separate crate

### DIFF
--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -46,6 +46,7 @@ serde_json = "1.0"
 slog = "2.7"
 propolis = { path = "../../lib/propolis", features = ["crucible-full", "oximeter"], default-features = false }
 propolis-client = { path = "../../lib/propolis-client" }
+propolis-server-config = { path = "../../crates/propolis-server-config" }
 rfb = { git = "https://github.com/oxidecomputer/rfb", branch = "main" }
 uuid = "1.0.0"
 base64 = "0.13"

--- a/bin/propolis-server/src/lib/config.rs
+++ b/bin/propolis-server/src/lib/config.rs
@@ -1,249 +1,66 @@
 //! Describes a server config which may be parsed from a TOML file.
 
-use std::collections::{btree_map, BTreeMap};
 use std::num::NonZeroUsize;
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
 use std::sync::Arc;
-
-use serde_derive::{Deserialize, Serialize};
-use thiserror::Error;
 
 use propolis::block;
 use propolis::dispatch::Dispatcher;
 use propolis::inventory;
+pub use propolis_server_config::*;
 
-/// Errors which may be returned when parsing the server configuration.
-#[derive(Error, Debug)]
-pub enum ParseError {
-    #[error("Cannot parse toml: {0}")]
-    Toml(#[from] toml::de::Error),
-
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
-
-    #[error("Key {0} not found in {1}")]
-    KeyNotFound(String, String),
-
-    #[error("Could not unmarshall {0} with function {1}")]
-    AsError(String, String),
+pub fn create_backend_for_block(
+    config: &Config,
+    name: &str,
+    disp: &Dispatcher,
+) -> Result<(Arc<dyn block::Backend>, inventory::ChildRegister), ParseError> {
+    let entry = config.block_devs.get(name).ok_or_else(|| {
+        ParseError::KeyNotFound(name.to_string(), "block_dev".to_string())
+    })?;
+    blockdev_backend(entry, disp)
 }
 
-/// Configuration for the Propolis server.
-// NOTE: This is expected to change over time; portions of the hard-coded
-// configuration will likely become more dynamic.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct Config {
-    bootrom: PathBuf,
+fn blockdev_backend(
+    dev: &BlockDevice,
+    _disp: &Dispatcher,
+) -> Result<(Arc<dyn block::Backend>, inventory::ChildRegister), ParseError> {
+    match &dev.bdtype as &str {
+        "file" => {
+            let path = dev
+                .options
+                .get("path")
+                .ok_or_else(|| {
+                    ParseError::KeyNotFound(
+                        "path".to_string(),
+                        "options".to_string(),
+                    )
+                })?
+                .as_str()
+                .ok_or_else(|| {
+                    ParseError::AsError(
+                        "path".to_string(),
+                        "as_str".to_string(),
+                    )
+                })?;
 
-    #[serde(default, rename = "pci_bridge")]
-    pci_bridges: Vec<PciBridge>,
+            let readonly: bool = || -> Option<bool> {
+                match dev.options.get("readonly") {
+                    Some(toml::Value::Boolean(read_only)) => Some(*read_only),
+                    Some(toml::Value::String(v)) => v.parse().ok(),
+                    _ => None,
+                }
+            }()
+            .unwrap_or(false);
+            let nworkers = NonZeroUsize::new(8).unwrap();
+            let be =
+                propolis::block::FileBackend::create(path, readonly, nworkers)?;
+            let child =
+                inventory::ChildRegister::new(&be, Some(path.to_string()));
 
-    #[serde(default)]
-    chipset: Chipset,
-
-    #[serde(default, rename = "dev")]
-    devices: BTreeMap<String, Device>,
-
-    #[serde(default, rename = "block_dev")]
-    block_devs: BTreeMap<String, BlockDevice>,
-}
-
-impl Config {
-    /// Constructs a new configuration object.
-    ///
-    /// Typically, the configuration is parsed from a config
-    /// file via [`parse`], but this method allows an alternative
-    /// mechanism for initialization.
-    pub fn new<P: Into<PathBuf>>(
-        bootrom: P,
-        chipset: Chipset,
-        devices: BTreeMap<String, Device>,
-        block_devs: BTreeMap<String, BlockDevice>,
-        pci_bridges: Vec<PciBridge>,
-    ) -> Config {
-        Config {
-            bootrom: bootrom.into(),
-            pci_bridges,
-            chipset,
-            devices,
-            block_devs,
+            Ok((be, child))
         }
-    }
-
-    pub fn get_bootrom(&self) -> &Path {
-        &self.bootrom
-    }
-
-    pub fn get_chipset(&self) -> &Chipset {
-        &self.chipset
-    }
-
-    /// Returns an iterator over all [`Device`] entries in the config.
-    pub fn devs(&self) -> btree_map::Iter<String, Device> {
-        self.devices.iter()
-    }
-
-    /// Returns an iterator over all ['BlockDevice`] entries in the config.
-    pub fn block_devs(&self) -> btree_map::Iter<String, BlockDevice> {
-        self.block_devs.iter()
-    }
-
-    /// Returns an iterator over all [`PciBridge`]s in the config.
-    pub fn pci_bridges(&self) -> std::slice::Iter<PciBridge> {
-        self.pci_bridges.iter()
-    }
-
-    pub fn create_block_backend(
-        &self,
-        name: &str,
-        disp: &Dispatcher,
-    ) -> Result<(Arc<dyn block::Backend>, inventory::ChildRegister), ParseError>
-    {
-        let entry = self.block_devs.get(name).ok_or_else(|| {
-            ParseError::KeyNotFound(name.to_string(), "block_dev".to_string())
-        })?;
-        entry.create_block_backend(disp)
-    }
-}
-
-/// The instance's chipset.
-#[derive(Default, Serialize, Deserialize, Debug, PartialEq)]
-pub struct Chipset {
-    #[serde(flatten, default)]
-    pub options: BTreeMap<String, toml::Value>,
-}
-
-impl Chipset {
-    pub fn get_string<S: AsRef<str>>(&self, key: S) -> Option<&str> {
-        self.options.get(key.as_ref())?.as_str()
-    }
-
-    pub fn get<T: FromStr, S: AsRef<str>>(&self, key: S) -> Option<T> {
-        self.get_string(key)?.parse().ok()
-    }
-}
-
-/// A PCI-PCI bridge.
-#[derive(Default, Serialize, Deserialize, Debug, PartialEq)]
-pub struct PciBridge {
-    /// The bus/device/function of this bridge as a device in the PCI topology.
-    #[serde(rename = "pci-path")]
-    pub pci_path: String,
-
-    /// The logical bus number to assign to this bridge's downstream bus.
-    ///
-    /// Note: This bus number is only used at configuration time to attach
-    /// devices downstream of this bridge. The bridge's secondary bus number
-    /// (used by the guest to address traffic to devices on this bus) is
-    /// set by the guest at runtime.
-    #[serde(rename = "downstream-bus")]
-    pub downstream_bus: u8,
-}
-
-/// A hard-coded device, either enabled by default or accessible locally
-/// on a machine.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct Device {
-    pub driver: String,
-
-    #[serde(flatten, default)]
-    pub options: BTreeMap<String, toml::Value>,
-}
-
-impl Device {
-    pub fn get_string<S: AsRef<str>>(&self, key: S) -> Option<&str> {
-        self.options.get(key.as_ref())?.as_str()
-    }
-
-    pub fn get<T: FromStr, S: AsRef<str>>(&self, key: S) -> Option<T> {
-        self.get_string(key)?.parse().ok()
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct BlockDevice {
-    #[serde(default, rename = "type")]
-    pub bdtype: String,
-
-    #[serde(flatten, default)]
-    pub options: BTreeMap<String, toml::Value>,
-}
-
-impl BlockDevice {
-    pub fn create_block_backend(
-        &self,
-        _disp: &Dispatcher,
-    ) -> Result<(Arc<dyn block::Backend>, inventory::ChildRegister), ParseError>
-    {
-        match &self.bdtype as &str {
-            "file" => {
-                let path = self
-                    .options
-                    .get("path")
-                    .ok_or_else(|| {
-                        ParseError::KeyNotFound(
-                            "path".to_string(),
-                            "options".to_string(),
-                        )
-                    })?
-                    .as_str()
-                    .ok_or_else(|| {
-                        ParseError::AsError(
-                            "path".to_string(),
-                            "as_str".to_string(),
-                        )
-                    })?;
-
-                let readonly: bool = || -> Option<bool> {
-                    match self.options.get("readonly") {
-                        Some(toml::Value::Boolean(read_only)) => {
-                            Some(*read_only)
-                        }
-                        Some(toml::Value::String(v)) => v.parse().ok(),
-                        _ => None,
-                    }
-                }()
-                .unwrap_or(false);
-                let nworkers = NonZeroUsize::new(8).unwrap();
-                let be = propolis::block::FileBackend::create(
-                    path, readonly, nworkers,
-                )?;
-                let child =
-                    inventory::ChildRegister::new(&be, Some(path.to_string()));
-
-                Ok((be, child))
-            }
-            _ => {
-                panic!("unrecognized block dev type {}!", self.bdtype);
-            }
+        _ => {
+            panic!("unrecognized block dev type {}!", dev.bdtype);
         }
-    }
-}
-
-/// Parses a TOML file into a configuration object.
-pub fn parse<P: AsRef<Path>>(path: P) -> Result<Config, ParseError> {
-    let contents = std::fs::read_to_string(path.as_ref())?;
-    let cfg = toml::from_str::<Config>(&contents)?;
-    Ok(cfg)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn config_can_be_serialized_as_toml() {
-        let dummy_config = Config::new(
-            "/boot",
-            Chipset { options: BTreeMap::new() },
-            BTreeMap::new(),
-            BTreeMap::new(),
-            Vec::new(),
-        );
-        let serialized = toml::ser::to_string(&dummy_config).unwrap();
-        let deserialized: Config = toml::de::from_str(&serialized).unwrap();
-        assert_eq!(dummy_config, deserialized);
     }
 }
 

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -410,7 +410,7 @@ async fn instance_ensure(
                 &spec,
                 producer_registry.clone(),
             );
-            init.initialize_rom(server_context.config.get_bootrom())?;
+            init.initialize_rom(&server_context.config.bootrom)?;
             init.initialize_kernel_devs()?;
 
             let chipset = init.initialize_chipset()?;

--- a/bin/propolis-server/src/lib/spec.rs
+++ b/bin/propolis-server/src/lib/spec.rs
@@ -93,7 +93,7 @@ impl SpecBuilder {
         config: &config::Config,
     ) -> Result<Self, SpecBuilderError> {
         let enable_pcie =
-            config.get_chipset().options.get("enable-pcie").map_or_else(
+            config.chipset.options.get("enable-pcie").map_or_else(
                 || Ok(false),
                 |v| {
                     v.as_bool().ok_or_else(|| {
@@ -475,10 +475,10 @@ impl SpecBuilder {
         config: &config::Config,
     ) -> Result<(), SpecBuilderError> {
         // Initialize all the backends in the config file.
-        for (name, backend) in config.block_devs() {
+        for (name, backend) in config.block_devs.iter() {
             self.add_storage_backend_from_config(name, backend)?;
         }
-        for (name, device) in config.devs() {
+        for (name, device) in config.devices.iter() {
             let driver = device.driver.as_str();
             match driver {
                 "pci-virtio-block" => self.add_storage_device_from_config(
@@ -502,7 +502,7 @@ impl SpecBuilder {
                 }
             }
         }
-        for bridge in config.pci_bridges() {
+        for bridge in config.pci_bridges.iter() {
             self.add_pci_bridge_from_config(bridge)?;
         }
         Ok(())

--- a/crates/propolis-server-config/Cargo.toml
+++ b/crates/propolis-server-config/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "propolis-server-config"
+version = "0.0.0"
+license = "MPL-2.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = "1.0"
+serde_derive = "1.0"
+toml = "0.5"
+thiserror = "1.0"

--- a/crates/propolis-server-config/src/lib.rs
+++ b/crates/propolis-server-config/src/lib.rs
@@ -1,0 +1,153 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use serde_derive::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Configuration for the Propolis server.
+// NOTE: This is expected to change over time; portions of the hard-coded
+// configuration will likely become more dynamic.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct Config {
+    pub bootrom: PathBuf,
+
+    #[serde(default, rename = "pci_bridge")]
+    pub pci_bridges: Vec<PciBridge>,
+
+    #[serde(default)]
+    pub chipset: Chipset,
+
+    #[serde(default, rename = "dev")]
+    pub devices: BTreeMap<String, Device>,
+
+    #[serde(default, rename = "block_dev")]
+    pub block_devs: BTreeMap<String, BlockDevice>,
+}
+impl Config {
+    /// Constructs a new configuration object.
+    ///
+    /// Typically, the configuration is parsed from a config
+    /// file via [`parse`], but this method allows an alternative
+    /// mechanism for initialization.
+    pub fn new<P: Into<PathBuf>>(
+        bootrom: P,
+        chipset: Chipset,
+        devices: BTreeMap<String, Device>,
+        block_devs: BTreeMap<String, BlockDevice>,
+        pci_bridges: Vec<PciBridge>,
+    ) -> Config {
+        Config {
+            bootrom: bootrom.into(),
+            pci_bridges,
+            chipset,
+            devices,
+            block_devs,
+        }
+    }
+}
+
+/// The instance's chipset.
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq)]
+pub struct Chipset {
+    #[serde(flatten, default)]
+    pub options: BTreeMap<String, toml::Value>,
+}
+
+impl Chipset {
+    pub fn get_string<S: AsRef<str>>(&self, key: S) -> Option<&str> {
+        self.options.get(key.as_ref())?.as_str()
+    }
+
+    pub fn get<T: FromStr, S: AsRef<str>>(&self, key: S) -> Option<T> {
+        self.get_string(key)?.parse().ok()
+    }
+}
+
+/// A PCI-PCI bridge.
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq)]
+pub struct PciBridge {
+    /// The bus/device/function of this bridge as a device in the PCI topology.
+    #[serde(rename = "pci-path")]
+    pub pci_path: String,
+
+    /// The logical bus number to assign to this bridge's downstream bus.
+    ///
+    /// Note: This bus number is only used at configuration time to attach
+    /// devices downstream of this bridge. The bridge's secondary bus number
+    /// (used by the guest to address traffic to devices on this bus) is
+    /// set by the guest at runtime.
+    #[serde(rename = "downstream-bus")]
+    pub downstream_bus: u8,
+}
+
+/// A hard-coded device, either enabled by default or accessible locally
+/// on a machine.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct Device {
+    pub driver: String,
+
+    #[serde(flatten, default)]
+    pub options: BTreeMap<String, toml::Value>,
+}
+
+impl Device {
+    pub fn get_string<S: AsRef<str>>(&self, key: S) -> Option<&str> {
+        self.options.get(key.as_ref())?.as_str()
+    }
+
+    pub fn get<T: FromStr, S: AsRef<str>>(&self, key: S) -> Option<T> {
+        self.get_string(key)?.parse().ok()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct BlockDevice {
+    #[serde(default, rename = "type")]
+    pub bdtype: String,
+
+    #[serde(flatten, default)]
+    pub options: BTreeMap<String, toml::Value>,
+}
+
+/// Errors which may be returned when parsing the server configuration.
+#[derive(Error, Debug)]
+pub enum ParseError {
+    #[error("Cannot parse toml: {0}")]
+    Toml(#[from] toml::de::Error),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Key {0} not found in {1}")]
+    KeyNotFound(String, String),
+
+    #[error("Could not unmarshall {0} with function {1}")]
+    AsError(String, String),
+}
+
+/// Parses a TOML file into a configuration object.
+pub fn parse<P: AsRef<Path>>(path: P) -> Result<Config, ParseError> {
+    let contents = std::fs::read_to_string(path.as_ref())?;
+    let cfg = toml::from_str::<Config>(&contents)?;
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_can_be_serialized_as_toml() {
+        let dummy_config = Config::new(
+            "/boot",
+            Chipset { options: BTreeMap::new() },
+            BTreeMap::new(),
+            BTreeMap::new(),
+            Vec::new(),
+        );
+        let serialized = toml::ser::to_string(&dummy_config).unwrap();
+        let deserialized: Config = toml::de::from_str(&serialized).unwrap();
+        assert_eq!(dummy_config, deserialized);
+    }
+}

--- a/phd-tests/framework/Cargo.toml
+++ b/phd-tests/framework/Cargo.toml
@@ -13,9 +13,9 @@ backoff = "0.4.0"
 futures = "0.3"
 hex = "0.4.3"
 propolis-client = { path = "../../lib/propolis-client" }
-propolis-server = { path = "../../bin/propolis-server" }
+propolis-server-config = { path = "../../crates/propolis-server-config" }
 propolis_types = { path = "../../crates/propolis-types" }
-reqwest = "0.11.11"
+reqwest = { version = "0.11.11", features = ["blocking"] }
 ring = "0.16.20"
 serde = { version = "1.0.139", features = ["derive"] }
 serde_derive = "1.0.139"


### PR DESCRIPTION
When `phd-framework` was pulling in `propolis-server` for only the `Config` struct, it mean building the entirety of propolis-server _again_ because the phd profile differs from debug or release (using `panic = unwind`).  It'd be nice to split that config stuff out to avoid the extra building.