### PR TITLE
Bump crucible revs

### DIFF
--- a/lib/propolis-client/Cargo.toml
+++ b/lib/propolis-client/Cargo.toml
@@ -16,4 +16,4 @@ serde_json = "1.0"
 slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_debug" ] }
 thiserror = "1.0"
 uuid = { version = "1.0.0", features = [ "serde", "v4" ] }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "1d67a53042f19ff7ca30dd20a04da94b7715ed7c" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "bacffd142fc38a01fe255407b0c8d5d0aacfe778" }

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -33,12 +33,12 @@ uuid = "1.0.0"
 
 [dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "1d67a53042f19ff7ca30dd20a04da94b7715ed7c"
+rev = "bacffd142fc38a01fe255407b0c8d5d0aacfe778"
 optional = true
 
 [dependencies.crucible]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "1d67a53042f19ff7ca30dd20a04da94b7715ed7c"
+rev = "bacffd142fc38a01fe255407b0c8d5d0aacfe778"
 optional = true
 
 [dependencies.oximeter]


### PR DESCRIPTION
Pick up some important PRs:

    * bacffd1 - Support multiple read-only activations Downstairs (#411)
    * 29e210d - Scrubber part 3 (#414)
    * 975bd8f - Correctly modify generation number (#415)
    * b626959 - Remember to draw the rest of the owl (#412)
    * d7e17d3 - Identify Downstairs work by more than Upstairs ID (#406)
    * 1eac1be - Scrubber 2.5: write_unwritten at the volume layer (#405)

oxidecomputer/crucible#412 and oxidecomputer/crucible#415 are
particularly important bug fixes (even if the latter was introduced by
406!).