### PR TITLE
Add affordance to wait for pre-pause device quiesce to finish

### DIFF
--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -194,9 +194,14 @@ impl SourceProtocol {
         // This will inform each device to pause.
         info!(self.log(), "Pausing devices");
         let (pause_tx, pause_rx) = std::sync::mpsc::channel();
-        self.mctx
-            .instance
-            .migrate_pause(self.mctx.async_ctx.context_id(), pause_rx)?;
+        let pause_done = Arc::new(tokio::sync::Notify::new());
+        let cb_pause_done = pause_done.clone();
+        self.mctx.instance.migrate_pause(
+            self.mctx.async_ctx.context_id(),
+            pause_rx,
+            Some(Box::new(move || cb_pause_done.notify_waiters())),
+        )?;
+        pause_done.notified().await;
 
         // Ask each device for a future indicating they've finishing pausing
         let mut migrate_ready_futs = vec![];

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -194,14 +194,11 @@ impl SourceProtocol {
         // This will inform each device to pause.
         info!(self.log(), "Pausing devices");
         let (pause_tx, pause_rx) = std::sync::mpsc::channel();
-        let pause_done = Arc::new(tokio::sync::Notify::new());
-        let cb_pause_done = pause_done.clone();
-        self.mctx.instance.migrate_pause(
-            self.mctx.async_ctx.context_id(),
-            pause_rx,
-            Some(Box::new(move || cb_pause_done.notify_waiters())),
-        )?;
-        pause_done.notified().await;
+        self.mctx
+            .instance
+            .migrate_pause(self.mctx.async_ctx.context_id(), pause_rx)?
+            .notified()
+            .await;
 
         // Ask each device for a future indicating they've finishing pausing
         let mut migrate_ready_futs = vec![];

--- a/bin/propolis-standalone/src/snapshot.rs
+++ b/bin/propolis-standalone/src/snapshot.rs
@@ -79,14 +79,7 @@ pub async fn save(
     // This will inform each device to pause
     info!(log, "Pausing devices");
     let (pause_tx, pause_rx) = std::sync::mpsc::channel();
-    let pause_done = Arc::new(tokio::sync::Notify::new());
-    let cb_pause_done = pause_done.clone();
-    inst.migrate_pause(
-        async_ctx.context_id(),
-        pause_rx,
-        Some(Box::new(move || cb_pause_done.notify_waiters())),
-    )?;
-    pause_done.notified().await;
+    inst.migrate_pause(async_ctx.context_id(), pause_rx)?.notified().await;
 
     // Ask each device for a future indicating they've finishing pausing
     let mut migrate_ready_futs = vec![];


### PR DESCRIPTION
During a migration, some devices expect to receive their `paused` calls from the migration task only after receiving a `pause` call from the instance state driver. `Instance::migrate_pause` directs the state driver to start pausing devices, but then returns immediately, allowing the migration task (`migrate_pause`'s caller) to race ahead of it and issue `paused` calls before devices are ready.

Add an affordance to `migrate_pause` that allows callers to supply a callback to invoke when the pause transition is completed. There are already some `Instance` members that are only relevant while migrating; take these and the new callback field and package them into a new `MigrateCtx` struct. Teach the migration task (and `standalone`'s snapshot code) to use this to wait for devices to get their pause notifications.

It likely makes some sense to have a more general "issue this state change and wait for it to finish" affordance than this one. I plan to think about that as part of a wholesale rethinking of the instance/migration state machines for #155.

Tested by adding an artificial delay to the state driver's transition callback path, verifying that this causes the race to repro 100% of the time, and verifying that the fix then mitigates the problem.

Fixes #184.