### PR TITLE
PHD: Add initial migration scaffolding

### DIFF
--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -54,7 +54,7 @@ ls $runner
 ls $artifacts
 ls $propolis
 
-(RUST_BACKTRACE=1 ptime -m $runner \
+(RUST_BACKTRACE=1 ptime -m pfexec $runner \
 	--emit-bunyan \
 	run \
 	--propolis-server-cmd $propolis \

--- a/phd-tests/README.md
+++ b/phd-tests/README.md
@@ -30,13 +30,22 @@ To get started running PHD tests:
 That's it! PHD will obtain a guest OS image and a bootrom and run its tests
 against them.
 
-## Building the runner
+## Building & executing the runner
 
-`cargo [build|run] --bin=phd-runner --profile=phd -- <OPTIONS>`
+To build:
+
+`cargo build -p phd-runner --profile=phd`
 
 Note that `--profile=phd` is required to allow the runner to catch assertions
 from test cases (the default Propolis profile aborts on panic instead of
 unwinding).
+
+To run:
+
+`pfexec cargo run -p phd-runner --profile=phd -- [OPTIONS]`
+
+Running under pfexec is required to allow PHD to ensure the host system is
+correctly configured to run live migration tests.
 
 ## Runtime options
 

--- a/phd-tests/framework/Cargo.toml
+++ b/phd-tests/framework/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.58"
 backoff = "0.4.0"
+cfg-if = "1.0.0"
 errno = "0.2.8"
 futures = "0.3"
 hex = "0.4.3"

--- a/phd-tests/framework/Cargo.toml
+++ b/phd-tests/framework/Cargo.toml
@@ -10,8 +10,10 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.58"
 backoff = "0.4.0"
+errno = "0.2.8"
 futures = "0.3"
 hex = "0.4.3"
+libc = "0.2.129"
 propolis-client = { path = "../../lib/propolis-client" }
 propolis-server-config = { path = "../../crates/propolis-server-config" }
 propolis_types = { path = "../../crates/propolis-types" }

--- a/phd-tests/framework/src/host_api/kvm.rs
+++ b/phd-tests/framework/src/host_api/kvm.rs
@@ -29,11 +29,11 @@ impl Default for nlist {
     fn default() -> Self {
         Self {
             name: std::ptr::null(),
-            n_value: 0x77777777_77777777,
-            n_scnum: 0x6666 as i16,
-            n_type: 0x5555 as u16,
-            n_sclass: 0x44 as i8,
-            n_numaux: 0x33 as i8,
+            n_value: 0,
+            n_scnum: 0,
+            n_type: 0,
+            n_sclass: 0,
+            n_numaux: 0,
         }
     }
 }
@@ -109,12 +109,11 @@ impl Drop for KvmHdl {
 /// Returns the virtual address of the symbol with the supplied name, suitable
 /// for later use in a call to kvm_kread or kvm_kwrite.
 fn find_symbol_va(kvm_hdl: &KvmHdl, symbol: &str) -> Result<uintptr_t> {
-    // Create a C-compatible representation of the symbol name. Note that this
-    // has to outlive the nlist that refers to it (the nlist stores a raw
-    // pointer to the string's contents).
-    let symbol_str = CString::new(symbol)?;
+    // N.B. This string must be created out-of-line so that it outlives the
+    //      nlist that includes a pointer to its buffer.
+    let symbol = CString::new(symbol)?;
     let nlist = vec![
-        nlist { name: symbol_str.as_ptr(), ..Default::default() },
+        nlist { name: symbol.as_ptr(), ..Default::default() },
         // nlist expects an array of structures terminated by one with a NULL
         // name pointer (or an empty name string).
         nlist::default(),

--- a/phd-tests/framework/src/host_api/kvm.rs
+++ b/phd-tests/framework/src/host_api/kvm.rs
@@ -1,0 +1,221 @@
+use std::ffi::CString;
+
+use anyhow::{anyhow, Result};
+use errno::errno;
+use libc::{
+    c_char, c_int, c_long, c_short, c_ushort, c_void, size_t, ssize_t,
+    uintptr_t, O_RDWR,
+};
+
+/// The structure used to query symbol values from `kvm_nlist`. See the man page
+/// for nm(1) for more context.
+#[allow(non_camel_case_types)]
+#[derive(Debug)]
+#[repr(C)]
+struct nlist {
+    /// The name of the symbol to query, or NULL for the sentinel entry in an
+    /// array of entries.
+    name: *const c_char,
+
+    /// The virtual address of the symbol.
+    n_value: c_long,
+    n_scnum: c_short,
+    n_type: c_ushort,
+    n_sclass: c_char,
+    n_numaux: c_char,
+}
+
+impl Default for nlist {
+    fn default() -> Self {
+        Self {
+            name: std::ptr::null(),
+            n_value: 0x77777777_77777777,
+            n_scnum: 0x6666 as i16,
+            n_type: 0x5555 as u16,
+            n_sclass: 0x44 as i8,
+            n_numaux: 0x33 as i8,
+        }
+    }
+}
+
+#[link(name = "kvm")]
+extern "C" {
+    fn kvm_open(
+        namelist: *const c_char,
+        corefile: *const c_char,
+        swapfile: *const c_char,
+        flag: c_int,
+        errstr: *const c_char,
+    ) -> *const c_void;
+
+    fn kvm_close(kd: *const c_void) -> c_int;
+
+    fn kvm_nlist(kd: *const c_void, nl: *mut nlist) -> c_int;
+
+    fn kvm_kread(
+        kd: *const c_void,
+        addr: uintptr_t,
+        buf: *mut c_void,
+        nbytes: size_t,
+    ) -> ssize_t;
+
+    fn kvm_kwrite(
+        kd: *const c_void,
+        addr: uintptr_t,
+        buf: *mut c_void,
+        nbytes: size_t,
+    ) -> ssize_t;
+}
+
+/// RAII wrapper for libkvm handles.
+struct KvmHdl {
+    hdl: *const c_void,
+}
+
+impl KvmHdl {
+    fn open() -> Result<Self> {
+        // Per the docs, kvm_open(3KVM) defaults to using /dev/ksyms as a symbol
+        // file when no symbol table is specified.
+        let kvm_hdl = unsafe {
+            kvm_open(
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+                O_RDWR,
+                std::ptr::null(),
+            )
+        };
+
+        if kvm_hdl == std::ptr::null() {
+            Err(anyhow!(
+                "kvm_open failed with code {} ({})",
+                errno().0,
+                errno()
+            ))
+        } else {
+            Ok(Self { hdl: kvm_hdl })
+        }
+    }
+}
+
+impl Drop for KvmHdl {
+    fn drop(&mut self) {
+        unsafe {
+            kvm_close(self.hdl);
+        }
+    }
+}
+
+/// Returns the virtual address of the symbol with the supplied name, suitable
+/// for later use in a call to kvm_kread or kvm_kwrite.
+fn find_symbol_va(kvm_hdl: &KvmHdl, symbol: &str) -> Result<uintptr_t> {
+    // Create a C-compatible representation of the symbol name. Note that this
+    // has to outlive the nlist that refers to it (the nlist stores a raw
+    // pointer to the string's contents).
+    let symbol_str = CString::new(symbol)?;
+    let nlist = vec![
+        nlist { name: symbol_str.as_ptr(), ..Default::default() },
+        // nlist expects an array of structures terminated by one with a NULL
+        // name pointer (or an empty name string).
+        nlist::default(),
+    ];
+
+    let mut slice = nlist.into_boxed_slice();
+    let err = unsafe { kvm_nlist(kvm_hdl.hdl, slice.as_mut_ptr()) };
+    if err != 0 {
+        return Err(anyhow!(
+            "kvm_nlist returned {}, errno {} ({})",
+            err,
+            errno().0,
+            errno()
+        ));
+    }
+
+    Ok(slice[0].n_value as uintptr_t)
+}
+
+/// Reads a u32-sized value from the supplied kernel VA.
+fn read_u32_from_va(kvm_hdl: &KvmHdl, va: uintptr_t) -> Result<u32> {
+    let mut buf = [0u8; 4];
+    let bytes_read = unsafe {
+        kvm_kread(kvm_hdl.hdl, va, buf.as_mut_ptr() as *mut c_void, 4)
+    };
+
+    match bytes_read {
+        isize::MIN..=-1 => Err(anyhow!(
+            "kvm_kread returned {}, errno {} ({})",
+            bytes_read,
+            errno().0,
+            errno()
+        )),
+        4 => Ok(u32::from_le_bytes(buf)),
+        _ => Err(anyhow!("kvm_kread read {} bytes, expected 4", bytes_read)),
+    }
+}
+
+/// Writes a u32-sized value to the supplied kernel VA.
+fn write_u32_to_va(kvm_hdl: &KvmHdl, va: uintptr_t, value: u32) -> Result<()> {
+    let bytes_written = unsafe {
+        kvm_kwrite(
+            kvm_hdl.hdl,
+            va,
+            value.to_le_bytes().as_mut_ptr() as *mut c_void,
+            4,
+        )
+    };
+
+    match bytes_written {
+        isize::MIN..=-1 => Err(anyhow!(
+            "kvm_kwrite returned {}, errno {} ({})",
+            bytes_written,
+            errno().0,
+            errno()
+        )),
+        4 => Ok(()),
+        _ => {
+            Err(anyhow!("kvm_kwrite wrote {} bytes, expected 4", bytes_written))
+        }
+    }
+}
+
+/// RAII guard for enabling VMM state writes. On drop, restores the state of the
+/// `vmm_allow_state_writes` flag observed when the guard was created.
+pub struct VmmStateWriteGuard {
+    previous: VmmStateWritePrevious,
+}
+
+enum VmmStateWritePrevious {
+    WasDisabled(KvmHdl),
+    WasEnabled,
+}
+
+impl Drop for VmmStateWriteGuard {
+    fn drop(&mut self) {
+        if let VmmStateWritePrevious::WasDisabled(kvm_hdl) = &self.previous {
+            let va = find_symbol_va(&kvm_hdl, "vmm_allow_state_writes")
+                .expect("couldn't find vmm_allow_state_writes");
+            write_u32_to_va(&kvm_hdl, va, 0)
+                .expect("couldn't clear vmm_allow_state_writes");
+        }
+    }
+}
+
+/// Ensures that VMM state writes are enabled on the runner's system, which is
+/// required for live migration.
+pub fn enable_vmm_state_writes() -> Result<VmmStateWriteGuard> {
+    let kvm_hdl = KvmHdl::open()?;
+    let va = find_symbol_va(&kvm_hdl, "vmm_allow_state_writes")?;
+    let was_enabled = match read_u32_from_va(&kvm_hdl, va)? {
+        0 => false,
+        _ => true,
+    };
+
+    if was_enabled {
+        Ok(VmmStateWriteGuard { previous: VmmStateWritePrevious::WasEnabled })
+    } else {
+        write_u32_to_va(&kvm_hdl, va, 1)?;
+        Ok(VmmStateWriteGuard {
+            previous: VmmStateWritePrevious::WasDisabled(kvm_hdl),
+        })
+    }
+}

--- a/phd-tests/framework/src/host_api/mod.rs
+++ b/phd-tests/framework/src/host_api/mod.rs
@@ -1,11 +1,9 @@
-#[cfg(target_os = "illumos")]
-mod kvm;
-
-#[cfg(target_os = "illumos")]
-pub use kvm::*;
-
-#[cfg(not(target_os = "illumos"))]
-mod stubs;
-
-#[cfg(not(target_os = "illumos"))]
-pub use stubs::*;
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "illumos")] {
+        mod kvm;
+        pub use kvm::*;
+    } else {
+        mod stubs;
+        pub use stubs::*;
+    }
+}

--- a/phd-tests/framework/src/host_api/mod.rs
+++ b/phd-tests/framework/src/host_api/mod.rs
@@ -1,0 +1,11 @@
+#[cfg(target_os = "illumos")]
+mod kvm;
+
+#[cfg(target_os = "illumos")]
+pub use kvm::*;
+
+#[cfg(not(target_os = "illumos"))]
+mod stubs;
+
+#[cfg(not(target_os = "illumos"))]
+pub use stubs::*;

--- a/phd-tests/framework/src/host_api/stubs.rs
+++ b/phd-tests/framework/src/host_api/stubs.rs
@@ -1,0 +1,7 @@
+use anyhow::{anyhow, Result};
+
+pub struct VmmStateWriteGuard;
+
+pub fn enable_vmm_state_writes() -> Result<VmmStateWriteGuard> {
+    Err(anyhow!("enable_vmm_state_writes requires illumos"))
+}

--- a/phd-tests/framework/src/lib.rs
+++ b/phd-tests/framework/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod artifacts;
 pub mod guest_os;
+pub mod host_api;
 mod serial;
 pub mod test_vm;
 

--- a/phd-tests/framework/src/test_vm/factory.rs
+++ b/phd-tests/framework/src/test_vm/factory.rs
@@ -14,7 +14,7 @@ use tracing::info;
 
 use crate::{
     artifacts::ArtifactStore, guest_os::GuestOsKind,
-    test_vm::ServerProcessParameters,
+    test_vm::server::ServerProcessParameters,
 };
 
 use super::{vm_config, TestVm};

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -124,6 +124,7 @@ impl TestVm {
         &self,
         migrate: Option<InstanceMigrateInitiateRequest>,
     ) -> Result<SerialConsole> {
+        let _span = self.tracing_span.enter();
         let (vcpus, memory_mib) = match self.state {
             VmState::New { vcpus, memory_mib } => (vcpus, memory_mib),
             VmState::Ensured { .. } => {

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -256,7 +256,8 @@ impl TestVm {
             .with_context(|| anyhow!("failed to query instance properties"))
     }
 
-    ///
+    /// Starts this instance by issuing an ensure request that specifies a
+    /// migration from `source` and then running the target.
     pub fn migrate_from(
         &mut self,
         source: &Self,

--- a/phd-tests/framework/src/test_vm/server.rs
+++ b/phd-tests/framework/src/test_vm/server.rs
@@ -34,10 +34,11 @@ pub struct ServerProcessParameters<'a, T: Into<Stdio>> {
 
 pub struct PropolisServer {
     server: std::process::Child,
+    address: SocketAddrV4,
 }
 
 impl PropolisServer {
-    pub fn new<T: Into<Stdio> + Debug>(
+    pub(crate) fn new<T: Into<Stdio> + Debug>(
         process_params: ServerProcessParameters<T>,
     ) -> Result<Self> {
         let ServerProcessParameters {
@@ -68,10 +69,15 @@ impl PropolisServer {
                 .stdout(server_stdout)
                 .stderr(server_stderr)
                 .spawn()?,
+            address: server_addr,
         };
 
         info!("Launched server with pid {}", server.server.id());
         Ok(server)
+    }
+
+    pub(crate) fn server_addr(&self) -> SocketAddrV4 {
+        self.address
     }
 }
 

--- a/phd-tests/quickstart.sh
+++ b/phd-tests/quickstart.sh
@@ -10,7 +10,7 @@ if [ ! -d "$PHD_QUICKSTART_DIR" ]; then
 	mkdir $PHD_QUICKSTART_DIR
 fi
 
-cargo run --profile=phd -p phd-runner -- \
+pfexec cargo run --profile=phd -p phd-runner -- \
 	run \
 	--artifact-toml-path ./sample_artifacts.toml \
 	--tmp-directory $PHD_QUICKSTART_DIR \

--- a/phd-tests/runner/src/fixtures.rs
+++ b/phd-tests/runner/src/fixtures.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use phd_framework::{artifacts::ArtifactStore, host_api::VmmStateWriteGuard};
+use phd_framework::artifacts::ArtifactStore;
 use tracing::instrument;
 
 use crate::TestContext;
@@ -12,7 +12,6 @@ pub struct TestFixtures<'a> {
     artifact_store: &'a ArtifactStore,
     test_context: &'a TestContext,
     zfs: Option<ZfsFixture>,
-    _vmm_state_write_guard: VmmStateWriteGuard,
 }
 
 impl<'a> TestFixtures<'a> {
@@ -35,13 +34,7 @@ impl<'a> TestFixtures<'a> {
             })
             .transpose()?;
 
-        let vmm_guard = phd_framework::host_api::enable_vmm_state_writes()?;
-        Ok(Self {
-            artifact_store,
-            test_context,
-            zfs,
-            _vmm_state_write_guard: vmm_guard,
-        })
+        Ok(Self { artifact_store, test_context, zfs })
     }
 
     /// Calls fixture routines that need to run before any tests run.

--- a/phd-tests/runner/src/fixtures.rs
+++ b/phd-tests/runner/src/fixtures.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use phd_framework::artifacts::ArtifactStore;
+use phd_framework::{artifacts::ArtifactStore, host_api::VmmStateWriteGuard};
 use tracing::instrument;
 
 use crate::TestContext;
@@ -12,6 +12,7 @@ pub struct TestFixtures<'a> {
     artifact_store: &'a ArtifactStore,
     test_context: &'a TestContext,
     zfs: Option<ZfsFixture>,
+    _vmm_state_write_guard: VmmStateWriteGuard,
 }
 
 impl<'a> TestFixtures<'a> {
@@ -34,7 +35,13 @@ impl<'a> TestFixtures<'a> {
             })
             .transpose()?;
 
-        Ok(Self { artifact_store, test_context, zfs })
+        let vmm_guard = phd_framework::host_api::enable_vmm_state_writes()?;
+        Ok(Self {
+            artifact_store,
+            test_context,
+            zfs,
+            _vmm_state_write_guard: vmm_guard,
+        })
     }
 
     /// Calls fixture routines that need to run before any tests run.

--- a/phd-tests/runner/src/main.rs
+++ b/phd-tests/runner/src/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use config::{ListOptions, ProcessArgs, RunOptions};
 use phd_framework::artifacts::ArtifactStore;
 use phd_tests::phd_testcase::TestContext;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{EnvFilter, Registry};
@@ -18,6 +18,14 @@ use crate::fixtures::TestFixtures;
 fn main() {
     let runner_args = ProcessArgs::parse();
     set_tracing_subscriber(&runner_args);
+
+    let state_write_guard = phd_framework::host_api::enable_vmm_state_writes();
+    if let Err(e) = state_write_guard {
+        warn!(
+            error = ?e,
+            "Failed to enable VMM state writes, migration tests may not work",
+        );
+    }
 
     info!(?runner_args);
 

--- a/phd-tests/tests/src/lib.rs
+++ b/phd-tests/tests/src/lib.rs
@@ -1,4 +1,5 @@
 pub use phd_testcase;
 
+mod migrate;
 mod server_state_machine;
 mod smoke;

--- a/phd-tests/tests/src/migrate.rs
+++ b/phd-tests/tests/src/migrate.rs
@@ -1,0 +1,24 @@
+use std::time::Duration;
+
+use phd_testcase::*;
+
+#[phd_testcase]
+fn smoke_test(ctx: &TestContext) {
+    let mut source = ctx
+        .vm_factory
+        .new_vm("migration_smoke_source", ctx.vm_factory.default_vm_config())?;
+
+    source.launch()?;
+    source.wait_to_boot()?;
+    let lsout = source.run_shell_command("ls foo.bar 2> /dev/null")?;
+    assert_eq!(lsout, "");
+    source.run_shell_command("touch foo.bar")?;
+
+    let mut target = ctx
+        .vm_factory
+        .new_vm("migration_smoke_target", ctx.vm_factory.default_vm_config())?;
+
+    target.migrate_from(&source, Duration::from_secs(60))?;
+    let lsout = target.run_shell_command("ls foo.bar")?;
+    assert_eq!(lsout, "foo.bar");
+}

--- a/phd-tests/tests/src/migrate.rs
+++ b/phd-tests/tests/src/migrate.rs
@@ -26,11 +26,11 @@ fn smoke_test(ctx: &TestContext) {
 #[phd_testcase]
 fn incompatible_vms(ctx: &TestContext) {
     let configs = vec![
-        ("cpus", ctx.vm_factory.default_vm_config().set_cpus(8)),
-        ("memory", ctx.vm_factory.default_vm_config().set_memory_mib(1024)),
+        ctx.vm_factory.default_vm_config().set_cpus(8),
+        ctx.vm_factory.default_vm_config().set_memory_mib(1024),
     ];
 
-    for (i, (name, cfg)) in configs.into_iter().enumerate() {
+    for (i, cfg) in configs.into_iter().enumerate() {
         let mut source = ctx.vm_factory.new_vm(
             format!("migration_incompatible_source_{}", i).as_str(),
             ctx.vm_factory.default_vm_config().set_cpus(4).set_memory_mib(512),
@@ -39,7 +39,7 @@ fn incompatible_vms(ctx: &TestContext) {
         source.launch()?;
 
         let mut target = ctx.vm_factory.new_vm(
-            format!("migration_incompatible_target_{}", name).as_str(),
+            format!("migration_incompatible_target_{}", i).as_str(),
             cfg,
         )?;
 

--- a/phd-tests/tests/src/server_state_machine.rs
+++ b/phd-tests/tests/src/server_state_machine.rs
@@ -7,15 +7,12 @@ use propolis_client::{api::InstanceState, Error as ClientError};
 
 #[phd_testcase]
 fn instance_start_stop_test(ctx: &TestContext) {
-    let vm = ctx.vm_factory.new_vm(
+    let mut vm = ctx.vm_factory.new_vm(
         "instance_ensure_running_test",
         ctx.vm_factory.default_vm_config(),
     )?;
 
-    let instance = vm.get()?.instance;
-    assert_eq!(instance.state, InstanceState::Creating);
-
-    vm.run()?;
+    vm.launch()?;
     vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
 
     vm.stop()?;
@@ -24,28 +21,31 @@ fn instance_start_stop_test(ctx: &TestContext) {
 
 #[phd_testcase]
 fn instance_stop_causes_destroy_test(ctx: &TestContext) {
-    let vm = ctx.vm_factory.new_vm(
+    let mut vm = ctx.vm_factory.new_vm(
         "instance_stop_causes_destroy_test",
         ctx.vm_factory.default_vm_config(),
     )?;
 
-    vm.run()?;
+    vm.launch()?;
     vm.stop()?;
     vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))?;
 
-    assert!(matches!(vm.run().unwrap_err(), ClientError::Status(500)));
+    assert!(matches!(
+        vm.launch().unwrap_err().downcast_ref::<ClientError>().unwrap(),
+        ClientError::Status(500)
+    ));
     assert!(matches!(vm.stop().unwrap_err(), ClientError::Status(500)));
     assert!(matches!(vm.reset().unwrap_err(), ClientError::Status(500)));
 }
 
 #[phd_testcase]
 fn instance_reset_returns_to_running_test(ctx: &TestContext) {
-    let vm = ctx.vm_factory.new_vm(
+    let mut vm = ctx.vm_factory.new_vm(
         "instance_stop_returns_to_running_test",
         ctx.vm_factory.default_vm_config(),
     )?;
 
-    vm.run()?;
+    vm.launch()?;
     vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
     vm.reset()?;
     vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;

--- a/phd-tests/tests/src/server_state_machine.rs
+++ b/phd-tests/tests/src/server_state_machine.rs
@@ -12,6 +12,10 @@ fn instance_start_stop_test(ctx: &TestContext) {
         ctx.vm_factory.default_vm_config(),
     )?;
 
+    vm.instance_ensure()?;
+    let instance = vm.get()?.instance;
+    assert_eq!(instance.state, InstanceState::Creating);
+
     vm.launch()?;
     vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
 
@@ -30,10 +34,7 @@ fn instance_stop_causes_destroy_test(ctx: &TestContext) {
     vm.stop()?;
     vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))?;
 
-    assert!(matches!(
-        vm.launch().unwrap_err().downcast_ref::<ClientError>().unwrap(),
-        ClientError::Status(500)
-    ));
+    assert!(matches!(vm.run().unwrap_err(), ClientError::Status(500)));
     assert!(matches!(vm.stop().unwrap_err(), ClientError::Status(500)));
     assert!(matches!(vm.reset().unwrap_err(), ClientError::Status(500)));
 }

--- a/phd-tests/tests/src/smoke.rs
+++ b/phd-tests/tests/src/smoke.rs
@@ -2,10 +2,10 @@ use phd_testcase::*;
 
 #[phd_testcase]
 fn nproc_test(ctx: &TestContext) {
-    let vm = ctx
+    let mut vm = ctx
         .vm_factory
         .new_vm("nproc_test", ctx.vm_factory.default_vm_config().set_cpus(6))?;
-    vm.run()?;
+    vm.launch()?;
     vm.wait_to_boot()?;
 
     let nproc = vm.run_shell_command("nproc")?;
@@ -14,7 +14,7 @@ fn nproc_test(ctx: &TestContext) {
 
 #[phd_testcase]
 fn multiple_vms_test(ctx: &TestContext) {
-    let vms = (0..5)
+    let mut vms = (0..5)
         .into_iter()
         .map(|i| {
             let name = format!("multiple_vms_test_vm{}", i);
@@ -22,8 +22,8 @@ fn multiple_vms_test(ctx: &TestContext) {
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    for vm in &vms {
-        vm.run()?;
+    for vm in &mut vms {
+        vm.launch()?;
     }
 
     for vm in &vms {


### PR DESCRIPTION
Add PHD affordances to test live migration.

This PR has a few distinct parts:

- `framework/src/host_api` introduces some code to set/clear the host kernel's `vmm_allow_state_writes` value programmatically. Once state writes are on by default, this module can be removed entirely, along with the few lines in `runner/src/main.rs` that depend on it. (The runner changes are designed to make this excision as painless as possible. In particular, the runner won't break if the `vmm_allow_state_writes` symbol disappears completely: it will just soldier on trying to run the tests, come what may.)
- In `framework/src/test_vm`:
  - Server process management now lives in its own module, `server.rs`. This introduces no new code.
  - `TestVm` is refactored so that `TestVm::new` only launches a server process without invoking `instance_ensure` or `run` on it. This is needed because decisions about whether to migrate or not are made via the `instance_ensure` parameters. The new `launch` function implicitly ensures and runs a new VM.
  - `TestVm::migrate_from` now lets one VM launch by migrating from another.

The new `migrate` module in the test suite exercises this functionality.

The changes in this PR assume that PHD will now run under `pfexec`. The README, quickstart script, and buildomat script are updated accordingly.

Tested via local and buildomat PHD runs.