### PR TITLE
Derive vnic entity names in specs from their devices' PCI BDFs

### DIFF
--- a/crates/propolis-types/src/lib.rs
+++ b/crates/propolis-types/src/lib.rs
@@ -5,6 +5,7 @@
 //! can all use those types (and implement their own conversions to/from them)
 //! without any layering oddities.
 
+use std::fmt::Display;
 use std::io::{Error, ErrorKind};
 use std::str::FromStr;
 
@@ -93,13 +94,18 @@ impl FromStr for PciPath {
     }
 }
 
+impl Display for PciPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.0, self.1, self.2)
+    }
+}
+
 impl Serialize for PciPath {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serializer
-            .serialize_str(format!("{}.{}.{}", self.0, self.1, self.2).as_str())
+        serializer.serialize_str(format!("{}", self).as_str())
     }
 }
 


### PR DESCRIPTION
Two instance specs' network device and backend names must agree for the specs to be migration-compatible. Today, the spec generator derives these names from the name of the host vNIC to which the instance should bind, which name can and will change over a migration. Instead, generate network device/backend names from the NIC's PCI path, which is already not allowed to change during migration.

Tested via ad hoc migration of instances with NICs with different names.

Fixes #201.