### PR TITLE
PHD: turn local artifact root into a command line option

### DIFF
--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -59,7 +59,8 @@ ls $propolis
 	run \
 	--propolis-server-cmd $propolis \
 	--artifact-toml-path $artifacts \
-	--tmp-directory $tmpdir | \
+	--tmp-directory $tmpdir \
+    --artifact-directory $tmpdir | \
 	tee /tmp/phd-runner.log)
 
 failcount=$?

--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -60,7 +60,7 @@ ls $propolis
 	--propolis-server-cmd $propolis \
 	--artifact-toml-path $artifacts \
 	--tmp-directory $tmpdir \
-    --artifact-directory $tmpdir | \
+	--artifact-directory $tmpdir | \
 	tee /tmp/phd-runner.log)
 
 failcount=$?

--- a/phd-tests/artifacts.toml
+++ b/phd-tests/artifacts.toml
@@ -1,4 +1,3 @@
-local_root = "/tmp/propolis-phd"
 remote_root = "https://oxide-omicron-build.s3.amazonaws.com"
 
 [guest_images.alpine]

--- a/phd-tests/quickstart.sh
+++ b/phd-tests/quickstart.sh
@@ -14,5 +14,5 @@ pfexec cargo run --profile=phd -p phd-runner -- \
 	run \
 	--artifact-toml-path ./sample_artifacts.toml \
 	--tmp-directory $PHD_QUICKSTART_DIR \
-    --artifact-directory $PHD_QUICKSTART_DIR \
+	--artifact-directory $PHD_QUICKSTART_DIR \
 	--propolis-server-cmd $1

--- a/phd-tests/quickstart.sh
+++ b/phd-tests/quickstart.sh
@@ -14,4 +14,5 @@ pfexec cargo run --profile=phd -p phd-runner -- \
 	run \
 	--artifact-toml-path ./sample_artifacts.toml \
 	--tmp-directory $PHD_QUICKSTART_DIR \
+    --artifact-directory $PHD_QUICKSTART_DIR \
 	--propolis-server-cmd $1

--- a/phd-tests/runner/src/config.rs
+++ b/phd-tests/runner/src/config.rs
@@ -48,6 +48,11 @@ pub struct RunOptions {
     #[clap(long, value_parser)]
     pub tmp_directory: PathBuf,
 
+    /// The directory in which artifacts (guest OS images, bootroms, etc.)
+    /// are to be stored.
+    #[clap(long, value_parser)]
+    pub artifact_directory: PathBuf,
+
     /// If true, direct Propolis servers created by the runner to log to
     /// stdout/stderr handles inherited from the runner.
     ///

--- a/phd-tests/runner/src/fixtures.rs
+++ b/phd-tests/runner/src/fixtures.rs
@@ -26,11 +26,10 @@ impl<'a> TestFixtures<'a> {
             .zfs_fs_name
             .as_ref()
             .map(|zfs_name| {
-                let local_root = artifact_store
-                    .get_local_root()
-                    .to_string_lossy()
-                    .to_string();
-                ZfsFixture::new(zfs_name.clone(), &local_root)
+                ZfsFixture::new(
+                    zfs_name.clone(),
+                    run_opts.artifact_directory.to_string_lossy().as_ref(),
+                )
             })
             .transpose()?;
 

--- a/phd-tests/runner/src/main.rs
+++ b/phd-tests/runner/src/main.rs
@@ -40,8 +40,11 @@ fn main() {
 }
 
 fn run_tests(run_opts: &RunOptions) -> ExecutionStats {
-    let artifact_store =
-        ArtifactStore::from_file(&run_opts.artifact_toml_path).unwrap();
+    let artifact_store = ArtifactStore::from_file(
+        &run_opts.artifact_toml_path,
+        run_opts.artifact_directory.clone(),
+    )
+    .unwrap();
 
     // Convert the command-line config and artifact store into a VM factory
     // definition.


### PR DESCRIPTION
Instead of making the local PHD artifact root part of the artifact TOML, make it a command-line option, which is more in keeping with PHD's general pattern of using command-line parameters to describe the local runtime environment.

Closes #194.