### PR TITLE
Slim down the live migration preamble

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -266,19 +266,9 @@ impl<'a> MachineInitializer<'a> {
                     self.log,
                     "Creating Crucible disk from request {:?}", req
                 );
-                let creq = req.try_into().map_err(|e| {
-                    Error::new(
-                        ErrorKind::InvalidData,
-                        format!(
-                            "Failed to deserialize Crucible volume \
-                                   construction request: {}",
-                            e
-                        ),
-                    )
-                })?;
                 let be = propolis::block::CrucibleBackend::create(
                     *gen,
-                    creq,
+                    req.clone(),
                     backend_spec.readonly,
                     self.producer_registry.clone(),
                 )?;

--- a/bin/propolis-server/src/lib/migrate/destination.rs
+++ b/bin/propolis-server/src/lib/migrate/destination.rs
@@ -114,9 +114,8 @@ impl DestinationProtocol {
             }
         }?;
         info!(self.log(), "Destination read Preamble: {:?}", preamble);
-        if let Err(e) = preamble
-            .instance_spec
-            .is_migration_compatible(self.vm_controller.instance_spec())
+        if let Err(e) =
+            preamble.is_migration_compatible(self.vm_controller.instance_spec())
         {
             error!(
                 self.log(),

--- a/bin/propolis-server/src/lib/migrate/preamble.rs
+++ b/bin/propolis-server/src/lib/migrate/preamble.rs
@@ -1,14 +1,34 @@
-use propolis_client::instance_spec::InstanceSpec;
+use propolis_client::instance_spec::{
+    BackendNames, DeviceSpec, InstanceSpec, MigrationCompatibilityError,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub(crate) struct Preamble {
-    pub instance_spec: InstanceSpec,
+    pub device_spec: DeviceSpec,
+    pub backend_keys: BackendNames,
     pub blobs: Vec<Vec<u8>>,
 }
 
 impl Preamble {
     pub fn new(instance_spec: InstanceSpec) -> Preamble {
-        Preamble { instance_spec, blobs: Vec::new() }
+        Preamble {
+            device_spec: instance_spec.devices.clone(),
+            backend_keys: BackendNames::from(&instance_spec.backends),
+            blobs: Vec::new(),
+        }
+    }
+
+    pub fn is_migration_compatible(
+        &self,
+        other_spec: &InstanceSpec,
+    ) -> Result<(), MigrationCompatibilityError> {
+        self.device_spec.is_migration_compatible(&other_spec.devices)?;
+        let other_keys = BackendNames::from(&other_spec.backends);
+        self.backend_keys.is_migration_compatible(&other_keys)?;
+
+        // TODO: Compare opaque blobs.
+
+        Ok(())
     }
 }

--- a/bin/propolis-server/src/lib/migrate/preamble.rs
+++ b/bin/propolis-server/src/lib/migrate/preamble.rs
@@ -23,9 +23,9 @@ impl Preamble {
         &self,
         other_spec: &InstanceSpec,
     ) -> Result<(), MigrationCompatibilityError> {
-        self.device_spec.is_migration_compatible(&other_spec.devices)?;
+        self.device_spec.can_migrate_devices_from(&other_spec.devices)?;
         let other_keys = BackendNames::from(&other_spec.backends);
-        self.backend_keys.is_migration_compatible(&other_keys)?;
+        self.backend_keys.can_migrate_backends_from(&other_keys)?;
 
         // TODO: Compare opaque blobs.
 

--- a/bin/propolis-server/src/lib/spec.rs
+++ b/bin/propolis-server/src/lib/spec.rs
@@ -1,7 +1,6 @@
 //! Helper functions for building instance specs from server parameters.
 
 use std::collections::BTreeSet;
-use std::convert::TryInto;
 use std::str::FromStr;
 
 use propolis_client::handmade::api::{
@@ -21,9 +20,6 @@ pub enum SpecBuilderError {
 
     #[error("A backend with name {0} already exists")]
     BackendNameInUse(String),
-
-    #[error("The opaque description of backend {0} was not serializable: {1}")]
-    BackendSpecNotSerializable(String, serde_json::error::Error),
 
     #[error("A PCI device is already attached at {0:?}")]
     PciPathInUse(PciPath),
@@ -208,14 +204,7 @@ impl SpecBuilder {
                 StorageBackend {
                     kind: StorageBackendKind::Crucible {
                         gen: disk.gen,
-                        req: (&disk.volume_construction_request)
-                            .try_into()
-                            .map_err(|e| {
-                                SpecBuilderError::BackendSpecNotSerializable(
-                                    disk.name.to_string(),
-                                    e,
-                                )
-                            })?,
+                        req: disk.volume_construction_request.clone(),
                     },
                     readonly: disk.read_only,
                 },

--- a/lib/propolis-client/src/instance_spec/backends.rs
+++ b/lib/propolis-client/src/instance_spec/backends.rs
@@ -126,23 +126,27 @@ impl From<&BackendSpec> for BackendNames {
 impl BackendNames {
     /// Indicates whether two backend specs with the supplied named backends are
     /// migration-compatible with each other.
-    pub fn is_migration_compatible(
+    pub fn can_migrate_backends_from(
         &self,
         other: &Self,
     ) -> Result<(), MigrationCompatibilityError> {
-        self.storage.is_migration_compatible(&other.storage).map_err(|e| {
-            MigrationCompatibilityError::CollectionMismatch(
-                "storage backends".to_string(),
-                e,
-            )
-        })?;
+        self.storage.can_migrate_from_collection(&other.storage).map_err(
+            |e| {
+                MigrationCompatibilityError::CollectionMismatch(
+                    "storage backends".to_string(),
+                    e,
+                )
+            },
+        )?;
 
-        self.network.is_migration_compatible(&other.network).map_err(|e| {
-            MigrationCompatibilityError::CollectionMismatch(
-                "network backends".to_string(),
-                e,
-            )
-        })?;
+        self.network.can_migrate_from_collection(&other.network).map_err(
+            |e| {
+                MigrationCompatibilityError::CollectionMismatch(
+                    "network backends".to_string(),
+                    e,
+                )
+            },
+        )?;
 
         Ok(())
     }

--- a/lib/propolis-client/src/instance_spec/backends.rs
+++ b/lib/propolis-client/src/instance_spec/backends.rs
@@ -1,70 +1,39 @@
 //! Backend configuration data: the structs that tell Propolis how to configure
 //! its components to talk to other services supplied by the host OS or the
 //! larger rack.
+//!
+//! # Foreign types
+//!
+//! A full [`BackendSpec`] contains maps from backend names to backend
+//! parameters that describe how to set up each backend. This crate assumes that
+//! backend parameter versioning is handled by the crate's users: a Propolis
+//! client that wants to send a full [`BackendSpec`] is responsible for
+//! instantiating a Propolis version that will accept the [`BackendSpec`]
+//! definition that the client wants to send (or for setting up a
+//! [`BackendSpec`] that its Propolis will understand).
+//!
+//! During live migration, Propolis makes sure that the source and target have
+//! the same backend names and categories, but allows their definitions to
+//! differ. The [`BackendNames`] helper type converts from a full
+//! [`BackendSpec`] to a collection of backend names that implements an
+//! `is_migration_compatible` compatibility check.
+//!
+//! # Versioning
+//!
+//! This scheme means that the Propolis live migration procedure does not need
+//! to deserialize any backend definitions sent from another Propolis. This
+//! means that these definitions can change freely without creating a new
+//! version of the `InstanceSpec` (provided that Nexus can still set up both
+//! Propolis instances' [`BackendSpec`]s according to the rules above).
+//!
+//! [`BackendNames`] are, by contrast, a load-bearing part of the migration
+//! protocol and need some care to be versioned correctly. See the struct
+//! comments below for more information.
 
-use std::collections::BTreeMap;
-use std::convert::TryFrom;
+use std::collections::{BTreeMap, BTreeSet};
 
-use super::{MigrationCompatible, SpecKey, SpecMismatchDetails};
+use super::{MigrationCollection, MigrationCompatibilityError, SpecKey};
 use serde::{Deserialize, Serialize};
-
-/// A description of a Crucible volume construction request.
-#[derive(Clone, Deserialize, Serialize, Debug)]
-pub struct CrucibleRequestContents {
-    /// A [`crucible_client_types::VolumeConstructionRequest`], serialized as JSON.
-    //
-    // Storing volume construction requests in serialized form allows external
-    // types to change without causing a breaking change to instance specs.
-    // Consider the following scenario, assuming the VolumeConstructionRequest
-    // struct is used directly:
-    //
-    // - Sled agent v1 starts Propolis v1 using Crucible request v1.
-    // - Sled agent v2 (on some other sled with newer software) starts Propolis
-    //   v2 using Crucible request v2, which has a new field not present in v1.
-    // - Nexus orders a migration from v1 to v2. This requires someone to
-    //   compare the two instances' specs for migratability.
-    //
-    // Migration compatibility is normally checked by the two Propolis servers
-    // involved: one server sends its instance spec to the other, and the
-    // recipient compares the specs to see if they're compatible. In this case,
-    // v2 can't deserialize v1's spec (a field is missing), and v1 can't
-    // deserialize v2's (an extra field is present), so migration will always
-    // fail.
-    //
-    // Storing a serialized request avoids this problem as follows:
-    //
-    // - Sled agent v2 starts Propolis v2 with spec v2. It deserializes the
-    //   request contents in the spec body into a v2 construction request.
-    // - Migration begins. Propolis v2 can now deserialize the v1 instance spec
-    //   and check it for compatibility. It can't deserialize the v1 *request
-    //   contents*, but this can be dealt with separately (e.g. by having the v1
-    //   and v2 Crucible components in the Propolis server negotiate
-    //   compatibility themselves, which is an affordance the migration protocol
-    //   allows).
-    pub json: String,
-}
-
-impl TryFrom<&CrucibleRequestContents>
-    for crucible_client_types::VolumeConstructionRequest
-{
-    type Error = serde_json::Error;
-
-    fn try_from(value: &CrucibleRequestContents) -> Result<Self, Self::Error> {
-        serde_json::from_str(&value.json)
-    }
-}
-
-impl TryFrom<&crucible_client_types::VolumeConstructionRequest>
-    for CrucibleRequestContents
-{
-    type Error = serde_json::Error;
-
-    fn try_from(
-        value: &crucible_client_types::VolumeConstructionRequest,
-    ) -> Result<Self, Self::Error> {
-        Ok(Self { json: serde_json::to_string(value)? })
-    }
-}
 
 /// A kind of storage backend: a connection to on-sled resources or other
 /// services that provide the functions storage devices need to implement their
@@ -74,7 +43,7 @@ impl TryFrom<&crucible_client_types::VolumeConstructionRequest>
 pub enum StorageBackendKind {
     /// A Crucible-backed device, containing a generation number and a
     /// construction request.
-    Crucible { gen: u64, req: CrucibleRequestContents },
+    Crucible { gen: u64, req: crucible_client_types::VolumeConstructionRequest },
 
     /// A device backed by a file on the host machine. The payload is a path to
     /// this file.
@@ -84,22 +53,6 @@ pub enum StorageBackendKind {
     /// contents of this buffer are supplied out-of-band, either at
     /// instance initialization time or from a migration source.
     InMemory,
-}
-
-impl MigrationCompatible for StorageBackendKind {
-    fn is_migration_compatible(
-        &self,
-        other: &Self,
-    ) -> Result<(), SpecMismatchDetails> {
-        if std::mem::discriminant(self) != std::mem::discriminant(other) {
-            Err(SpecMismatchDetails::StorageBackendKind(
-                self.clone(),
-                other.clone(),
-            ))
-        } else {
-            Ok(())
-        }
-    }
 }
 
 /// A storage backend.
@@ -113,23 +66,6 @@ pub struct StorageBackend {
     pub readonly: bool,
 }
 
-impl MigrationCompatible for StorageBackend {
-    fn is_migration_compatible(
-        &self,
-        other: &Self,
-    ) -> Result<(), SpecMismatchDetails> {
-        self.kind.is_migration_compatible(&other.kind)?;
-        if self.readonly != other.readonly {
-            Err(SpecMismatchDetails::StorageBackendReadonly(
-                self.readonly,
-                other.readonly,
-            ))
-        } else {
-            Ok(())
-        }
-    }
-}
-
 /// A kind of network backend: a connection to an on-sled networking resource
 /// that provides the functions needed for guest network adapters to implement
 /// their contracts.
@@ -141,24 +77,6 @@ pub enum NetworkBackendKind {
     Virtio { vnic_name: String },
 }
 
-impl MigrationCompatible for NetworkBackendKind {
-    fn is_migration_compatible(
-        &self,
-        other: &Self,
-    ) -> Result<(), SpecMismatchDetails> {
-        // Two network backends are compatible if they have the same kind,
-        // irrespective of their configurations.
-        if std::mem::discriminant(self) != std::mem::discriminant(other) {
-            return Err(SpecMismatchDetails::NetworkBackendKind(
-                self.clone(),
-                other.clone(),
-            ));
-        }
-
-        Ok(())
-    }
-}
-
 /// A network backend.
 #[derive(Clone, Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -166,33 +84,65 @@ pub struct NetworkBackend {
     pub kind: NetworkBackendKind,
 }
 
-impl MigrationCompatible for NetworkBackend {
-    fn is_migration_compatible(
-        &self,
-        other: &Self,
-    ) -> Result<(), SpecMismatchDetails> {
-        self.kind.is_migration_compatible(&other.kind)
-    }
-}
-
+/// A wrapper type for all the backends in an instance spec.
 #[derive(Default, Clone, Deserialize, Serialize, Debug)]
 pub struct BackendSpec {
     pub storage_backends: BTreeMap<SpecKey, StorageBackend>,
     pub network_backends: BTreeMap<SpecKey, NetworkBackend>,
 }
 
-impl BackendSpec {
+/// A helper type representing just the names of the backends in a particular
+/// [`BackendSpec`].
+//
+// This struct is marked `deny_unknown_fields` so that if a new backend type is
+// added in version N, version N-1 will refuse to deserialize it (desirable
+// since version N-1 presumably does not know how to instantiate such a
+// backend).
+//
+// If version N's new collection is empty, version N-1 has no backends to
+// instantiate, so the field can be completely omitted using
+// `skip_serializing_if`. This in turn requires the struct to be marked with
+// `serde(default)` so that serde can deserialize structs with omitted
+// name sets.
+#[derive(Default, Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct BackendNames {
+    #[serde(skip_serializing_if = "BTreeSet::is_empty")]
+    storage: BTreeSet<SpecKey>,
+
+    #[serde(skip_serializing_if = "BTreeSet::is_empty")]
+    network: BTreeSet<SpecKey>,
+}
+
+impl From<&BackendSpec> for BackendNames {
+    fn from(spec: &BackendSpec) -> Self {
+        Self {
+            storage: spec.storage_backends.keys().cloned().collect(),
+            network: spec.network_backends.keys().cloned().collect(),
+        }
+    }
+}
+
+impl BackendNames {
+    /// Indicates whether two backend specs with the supplied named backends are
+    /// migration-compatible with each other.
     pub fn is_migration_compatible(
         &self,
         other: &Self,
-    ) -> Result<(), (String, SpecMismatchDetails)> {
-        self.storage_backends
-            .is_migration_compatible(&other.storage_backends)
-            .map_err(|e| ("storage backends".to_string(), e))?;
+    ) -> Result<(), MigrationCompatibilityError> {
+        self.storage.is_migration_compatible(&other.storage).map_err(|e| {
+            MigrationCompatibilityError::CollectionMismatch(
+                "storage backends".to_string(),
+                e,
+            )
+        })?;
 
-        self.network_backends
-            .is_migration_compatible(&other.network_backends)
-            .map_err(|e| ("network backends".to_string(), e))?;
+        self.network.is_migration_compatible(&other.network).map_err(|e| {
+            MigrationCompatibilityError::CollectionMismatch(
+                "network backends".to_string(),
+                e,
+            )
+        })?;
 
         Ok(())
     }

--- a/lib/propolis-client/src/instance_spec/devices.rs
+++ b/lib/propolis-client/src/instance_spec/devices.rs
@@ -72,7 +72,7 @@ impl Default for Board {
 }
 
 impl MigrationElement for Board {
-    fn is_migration_compatible(
+    fn can_migrate_from_element(
         &self,
         other: &Self,
     ) -> Result<(), ElementCompatibilityError> {
@@ -133,7 +133,7 @@ pub struct StorageDevice {
 }
 
 impl MigrationElement for StorageDevice {
-    fn is_migration_compatible(
+    fn can_migrate_from_element(
         &self,
         other: &Self,
     ) -> Result<(), ElementCompatibilityError> {
@@ -174,7 +174,7 @@ pub struct NetworkDevice {
 }
 
 impl MigrationElement for NetworkDevice {
-    fn is_migration_compatible(
+    fn can_migrate_from_element(
         &self,
         other: &Self,
     ) -> Result<(), ElementCompatibilityError> {
@@ -219,7 +219,7 @@ pub struct SerialPort {
 }
 
 impl MigrationElement for SerialPort {
-    fn is_migration_compatible(
+    fn can_migrate_from_element(
         &self,
         other: &Self,
     ) -> Result<(), ElementCompatibilityError> {
@@ -247,7 +247,7 @@ pub struct PciPciBridge {
 }
 
 impl MigrationElement for PciPciBridge {
-    fn is_migration_compatible(
+    fn can_migrate_from_element(
         &self,
         other: &Self,
     ) -> Result<(), ElementCompatibilityError> {
@@ -279,16 +279,16 @@ pub struct DeviceSpec {
 }
 
 impl DeviceSpec {
-    pub fn is_migration_compatible(
+    pub fn can_migrate_devices_from(
         &self,
         other: &Self,
     ) -> Result<(), MigrationCompatibilityError> {
-        self.board.is_migration_compatible(&other.board).map_err(|e| {
+        self.board.can_migrate_from_element(&other.board).map_err(|e| {
             MigrationCompatibilityError::ElementMismatch("board".to_string(), e)
         })?;
 
         self.storage_devices
-            .is_migration_compatible(&other.storage_devices)
+            .can_migrate_from_collection(&other.storage_devices)
             .map_err(|e| {
                 MigrationCompatibilityError::CollectionMismatch(
                     "storage devices".to_string(),
@@ -297,7 +297,7 @@ impl DeviceSpec {
             })?;
 
         self.network_devices
-            .is_migration_compatible(&other.network_devices)
+            .can_migrate_from_collection(&other.network_devices)
             .map_err(|e| {
                 MigrationCompatibilityError::CollectionMismatch(
                     "network devices".to_string(),
@@ -306,7 +306,7 @@ impl DeviceSpec {
             })?;
 
         self.serial_ports
-            .is_migration_compatible(&other.serial_ports)
+            .can_migrate_from_collection(&other.serial_ports)
             .map_err(|e| {
                 MigrationCompatibilityError::CollectionMismatch(
                     "serial ports".to_string(),
@@ -315,7 +315,7 @@ impl DeviceSpec {
             })?;
 
         self.pci_pci_bridges
-            .is_migration_compatible(&other.pci_pci_bridges)
+            .can_migrate_from_collection(&other.pci_pci_bridges)
             .map_err(|e| {
                 MigrationCompatibilityError::CollectionMismatch(
                     "PCI bridges".to_string(),

--- a/lib/propolis-client/src/instance_spec/mod.rs
+++ b/lib/propolis-client/src/instance_spec/mod.rs
@@ -167,7 +167,7 @@ pub enum MigrationCompatibilityError {
 }
 
 /// Implementors of this trait are individual devices or VMM components who can
-/// describe inconsistencies using a [`SpecElementMismatchDetails`] enumerant.
+/// describe inconsistencies using a [`SpecElementMismatchDetails`] variant.
 trait MigrationElement {
     /// Returns true if `self` and `other` describe spec elements that are
     /// similar enough to permit migration of this element from one VMM to


### PR DESCRIPTION
This PR includes the following work:

1. Change the migration preamble to transmit a VM's device spec and the names of its backends, but not the backend types or their configuration.
2. Use this change to remove extra code to serialize and re-deserialize Crucible volume construction requests during instance setup.
3. Refactor instance spec error types to distinguish more clearly between "collection-level" errors (wrong number of items in a collection or a naming mismatch) and "element-level" errors (two devices are not compatible with each other).
4. Update doc comments in the device/backend modules to explain more about their versioning strategies and what types can be used in each portion of the spec.

The most important things to review in this change are the doc comments in (4) and the overall design direction implemented in (1). RFD 283 describes some of that direction, but below are some additional notes on what changes (1) and (2) do and why.

This change has one significant drawback: the migration preamble can no longer check to make sure that two backends with the same name also have the same kind. That is: suppose that there's a "StorageFoo" backend on both the source and target, but the source thinks it's a File backend and the target thinks it's an InMemory backend. Prior to this change, these instances would fail their migration compatibility check; now they will pass it. IMO, the benefits described below outweigh this cost, especially because the sync protocol gives backends other ways to check their compatibility with each other. If I have this tradeoff wrong, we might be able to bring this check back somewhat by writing separate `XyzBackendKind` enums that encode backend type information but no payloads and using those enums in the preamble.

---

Some additional motivation: Before this change, instance specs were used in two ways:

1. `instance_ensure` would convert its parameters into a spec and pass them to the VM controller to tell it how to initialize an instance.
2. The LM preamble includes a source VM's instance spec; the target uses its spec's `is_migration_compatible` method to decide if it can accept a migration from the source.

Usage (1) requires the spec to contain all the information needed to configure backends, even when this isn't relevant to the compatibility check in (2). This is important because that backend data can be very large (e.g. it might specify the entire contents of an in-memory cloud-init ISO) and may depend on external types whose contents can change in a way that might break data structure versioning. Declining to transmit this data (and to make migration targets deserialize it) makes the preamble less expensive to send and allows backend specs to contain types external to the instance spec crate.

This change makes use of these new properties by removing a bunch of extra logic that took incoming `VolumeConstructionRequest`s, serialized them to JSON to get them into an instance spec, and then immediately deserialized them to pass them back to Crucible. Exposing an `instance_ensure` API that takes an instance spec would also have simplified this, but it would have pushed the serialization work to Nexus. Now both sides can just use the `VolumeConstructionRequest` type natively (provided they agree on what it is).