### PR TITLE
Opt PHD into the progenitorized-client feature

### DIFF
--- a/phd-tests/framework/Cargo.toml
+++ b/phd-tests/framework/Cargo.toml
@@ -15,7 +15,7 @@ errno = "0.2.8"
 futures = "0.3"
 hex = "0.4.3"
 libc = "0.2.129"
-propolis-client = { path = "../../lib/propolis-client" }
+propolis-client = { path = "../../lib/propolis-client", features = ["generated"] }
 propolis-server-config = { path = "../../crates/propolis-server-config" }
 propolis_types = { path = "../../crates/propolis-types" }
 reqwest = { version = "0.11.12", features = ["blocking"] }

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -8,7 +8,7 @@ use crate::serial::SerialConsole;
 
 use anyhow::{anyhow, Context, Result};
 use core::result::Result as StdResult;
-use propolis_client::{
+use propolis_client::handmade::{
     api::{
         InstanceEnsureRequest, InstanceGetResponse,
         InstanceMigrateInitiateRequest, InstanceProperties, InstanceState,

--- a/phd-tests/tests/Cargo.toml
+++ b/phd-tests/tests/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-propolis-client = { path = "../../lib/propolis-client" }
+propolis-client = { path = "../../lib/propolis-client", features = ["generated"] }
 phd-testcase = { path = "../testcase" }

--- a/phd-tests/tests/src/server_state_machine.rs
+++ b/phd-tests/tests/src/server_state_machine.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use phd_testcase::*;
-use propolis_client::{api::InstanceState, Error as ClientError};
+use propolis_client::handmade::{api::InstanceState, Error as ClientError};
 
 #[phd_testcase]
 fn instance_start_stop_test(ctx: &TestContext) {


### PR DESCRIPTION
This ensures that PHD and the Propolis libraries agree on propolis-client's module structure. Without this, `cargo build --all` breaks when building PHD. (Cargo evidently decides in that scenario that the `propolis-client` it builds with `features = ["generated"]` should be usable with both the Propolis and PHD binaries; by contrast, running `cargo build` and then `cargo build -p phd-runner` causes Cargo to rebuild `propolis-client` for PHD with the expected feature set. I'm not sure if this is expected Cargo behavior, but in any case it seems generally good to me to have PHD using the same library features as the other binaries in the repo.)