### PR TITLE
Allow in-memory disks' initial contents to be specified in a StorageBackendSpec

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -298,7 +298,6 @@ impl<'a> MachineInitializer<'a> {
                             req.clone(),
                             backend_spec.readonly,
                             self.producer_registry.clone(),
-                            self.log.new(slog::o!("component" => "crucible")),
                         )?;
                         let child = inventory::ChildRegister::new(
                             &be,

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -325,7 +325,17 @@ impl<'a> MachineInitializer<'a> {
                         );
                         StorageBackendInstance { be, child, crucible: None }
                     }
-                    StorageBackendKind::InMemory { bytes } => {
+                    StorageBackendKind::InMemory { base64 } => {
+                        let bytes = base64::decode(base64).map_err(|e| {
+                            Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                format!(
+                                    "failed to decode base64 contents of \
+                                     in-memory disk: {}",
+                                    e
+                                ),
+                            )
+                        })?;
                         info!(
                             self.log,
                             "Creating in-memory disk backend from {} bytes",

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -238,9 +238,6 @@ impl DropshotEndpointContext {
 enum SpecCreationError {
     #[error(transparent)]
     SpecBuilderError(#[from] SpecBuilderError),
-
-    #[error(transparent)]
-    Base64DecodeError(#[from] base64::DecodeError),
 }
 
 /// Creates an instance spec from an ensure request. (Both types are foreign to
@@ -258,9 +255,8 @@ fn instance_spec_from_request(
         spec_builder.add_disk_from_request(disk)?;
     }
 
-    if let Some(as_base64) = &request.cloud_init_bytes {
-        let bytes = base64::decode(as_base64)?;
-        spec_builder.add_cloud_init_from_request(bytes)?;
+    if let Some(base64) = &request.cloud_init_bytes {
+        spec_builder.add_cloud_init_from_request(base64.clone())?;
     }
 
     spec_builder.add_devices_from_config(toml_config)?;
@@ -407,7 +403,6 @@ async fn instance_ensure(
 
         vm_hdl.await.unwrap()
     }
-
     .map_err(|e| {
         HttpError::for_internal_error(format!(
             "failed to create instance: {}",

--- a/bin/propolis-server/src/lib/spec.rs
+++ b/bin/propolis-server/src/lib/spec.rs
@@ -252,6 +252,7 @@ impl SpecBuilder {
     /// into device/backend entries in the spec under construction.
     pub fn add_cloud_init_from_request(
         &mut self,
+        bytes: Vec<u8>,
     ) -> Result<(), SpecBuilderError> {
         let name = "cloud-init";
         let pci_path = slot_to_pci_path(api::Slot(0), SlotType::CloudInit)?;
@@ -264,7 +265,7 @@ impl SpecBuilder {
             .insert(
                 name.to_string(),
                 StorageBackend {
-                    kind: StorageBackendKind::InMemory,
+                    kind: StorageBackendKind::InMemory { bytes },
                     readonly: true,
                 },
             )

--- a/bin/propolis-server/src/lib/spec.rs
+++ b/bin/propolis-server/src/lib/spec.rs
@@ -252,7 +252,7 @@ impl SpecBuilder {
     /// into device/backend entries in the spec under construction.
     pub fn add_cloud_init_from_request(
         &mut self,
-        bytes: Vec<u8>,
+        base64: String,
     ) -> Result<(), SpecBuilderError> {
         let name = "cloud-init";
         let pci_path = slot_to_pci_path(api::Slot(0), SlotType::CloudInit)?;
@@ -265,7 +265,7 @@ impl SpecBuilder {
             .insert(
                 name.to_string(),
                 StorageBackend {
-                    kind: StorageBackendKind::InMemory { bytes },
+                    kind: StorageBackendKind::InMemory { base64 },
                     readonly: true,
                 },
             )

--- a/bin/propolis-server/src/lib/vm.rs
+++ b/bin/propolis-server/src/lib/vm.rs
@@ -477,7 +477,6 @@ impl VmController {
         properties: InstanceProperties,
         use_reservoir: bool,
         bootrom: PathBuf,
-        in_memory_disk_contents: BTreeMap<String, Vec<u8>>,
         oximeter_registry: Option<ProducerRegistry>,
         log: Logger,
         runtime_hdl: tokio::runtime::Handle,
@@ -529,8 +528,7 @@ impl VmController {
         let ps2ctrl: Option<Arc<PS2Ctrl>> = inv.get_concrete(ps2ctrl_id);
         init.initialize_qemu_debug_port()?;
         init.initialize_network_devices(&chipset)?;
-        let crucible_backends =
-            init.initialize_storage_devices(&chipset, in_memory_disk_contents)?;
+        let crucible_backends = init.initialize_storage_devices(&chipset)?;
         let framebuffer_id =
             init.initialize_fwcfg(instance_spec.devices.board.cpus)?;
         let framebuffer: Option<Arc<RamFb>> = inv.get_concrete(framebuffer_id);

--- a/lib/propolis-client/src/instance_spec/backends.rs
+++ b/lib/propolis-client/src/instance_spec/backends.rs
@@ -49,8 +49,9 @@ pub enum StorageBackendKind {
     /// this file.
     File { path: String },
 
-    /// A device backed by an in-memory buffer in the VMM process.
-    InMemory { bytes: Vec<u8> },
+    /// A device backed by an in-memory buffer in the VMM process. The initial
+    /// contents of the disk are a base64-encoded string.
+    InMemory { base64: String },
 }
 
 /// A storage backend.

--- a/lib/propolis-client/src/instance_spec/backends.rs
+++ b/lib/propolis-client/src/instance_spec/backends.rs
@@ -49,10 +49,8 @@ pub enum StorageBackendKind {
     /// this file.
     File { path: String },
 
-    /// A device backed by an in-memory buffer in the VMM process. The initial
-    /// contents of this buffer are supplied out-of-band, either at
-    /// instance initialization time or from a migration source.
-    InMemory,
+    /// A device backed by an in-memory buffer in the VMM process.
+    InMemory { bytes: Vec<u8> },
 }
 
 /// A storage backend.


### PR DESCRIPTION
#221 makes it much more acceptable for large chunks of data to live in an instance spec's `BackendSpec` members. Now that that has landed, move in-memory disk contents into the backend spec instead of dealing with them ad-hoc in propolis-server, and clean up the instance initialization code accordingly.