### PR TITLE
Split instance spec builder into generic and server-specific pieces

### DIFF
--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -27,7 +27,7 @@ use tokio::sync::{mpsc, oneshot, MappedMutexGuard, Mutex, MutexGuard};
 use tokio_tungstenite::tungstenite::protocol::{Role, WebSocketConfig};
 use tokio_tungstenite::WebSocketStream;
 
-use crate::spec::{SpecBuilder, SpecBuilderError};
+use crate::spec::{ServerSpecBuilder, ServerSpecBuilderError};
 use crate::vm::VmController;
 use crate::vnc::PropolisVncServer;
 
@@ -237,7 +237,7 @@ impl DropshotEndpointContext {
 #[derive(Debug, Error)]
 enum SpecCreationError {
     #[error(transparent)]
-    SpecBuilderError(#[from] SpecBuilderError),
+    SpecBuilderError(#[from] ServerSpecBuilderError),
 }
 
 /// Creates an instance spec from an ensure request. (Both types are foreign to
@@ -246,7 +246,9 @@ fn instance_spec_from_request(
     request: &api::InstanceEnsureRequest,
     toml_config: &VmTomlConfig,
 ) -> Result<InstanceSpec, SpecCreationError> {
-    let mut spec_builder = SpecBuilder::new(&request.properties, toml_config)?;
+    let mut spec_builder =
+        ServerSpecBuilder::new(&request.properties, toml_config)?;
+
     for nic in &request.nics {
         spec_builder.add_nic_from_request(nic)?;
     }

--- a/bin/propolis-server/src/lib/spec.rs
+++ b/bin/propolis-server/src/lib/spec.rs
@@ -14,7 +14,7 @@ use crate::config;
 /// Errors that can occur while building an instance spec from component parts.
 #[derive(Debug, Error)]
 pub enum ServerSpecBuilderError {
-    #[error("Interior spec builder returned an error: {0}")]
+    #[error(transparent)]
     InnerBuilderError(#[from] SpecBuilderError),
 
     #[error("The string {0} could not be converted to a PCI path")]

--- a/bin/propolis-server/src/lib/spec.rs
+++ b/bin/propolis-server/src/lib/spec.rs
@@ -17,7 +17,6 @@ pub enum ServerSpecBuilderError {
     #[error("Interior spec builder returned an error: {0}")]
     InnerBuilderError(#[from] SpecBuilderError),
 
-
     #[error("The string {0} could not be converted to a PCI path")]
     PciPathNotParseable(String),
 
@@ -265,51 +264,10 @@ impl ServerSpecBuilder {
     ) -> Result<(), ServerSpecBuilderError> {
         let name = "cloud-init";
         let pci_path = slot_to_pci_path(api::Slot(0), SlotType::CloudInit)?;
-        self.register_pci_device(pci_path)?;
+        let backend_name = name.to_string();
 
-        if self
-            .spec
-            .backends
-            .storage_backends
-            .insert(
-                name.to_string(),
-                StorageBackend {
-                    kind: StorageBackendKind::InMemory { base64 },
-                    readonly: true,
-                },
-            )
-            .is_some()
-        {
-            return Err(SpecBuilderError::BackendNameInUse(name.to_string()));
-        }
-
-        if self
-            .spec
-            .devices
-            .storage_devices
-            .insert(
-                name.to_string(),
-                StorageDevice {
-                    kind: StorageDeviceKind::Virtio,
-                    backend_name: name.to_string(),
-                    pci_path,
-                },
-            )
-            .is_some()
-        {
-            return Err(SpecBuilderError::DeviceNameInUse(name.to_string()));
-        }
-
-        Ok(())
-    }
-
-    fn add_storage_backend_from_config(
-        &mut self,
-        name: &str,
-        backend: &config::BlockDevice,
-    ) -> Result<(), SpecBuilderError> {
         let backend_spec = StorageBackend {
-            kind: StorageBackendKind::InMemory { bytes },
+            kind: StorageBackendKind::InMemory { base64 },
             readonly: true,
         };
 

--- a/lib/propolis-client/src/instance_spec/builder.rs
+++ b/lib/propolis-client/src/instance_spec/builder.rs
@@ -1,0 +1,167 @@
+use std::collections::BTreeSet;
+
+use propolis_types::PciPath;
+use thiserror::Error;
+
+use super::{Board, Chipset, InstanceSpec, SerialPort, SerialPortNumber};
+
+/// Errors that can arise while building an instance spec from component parts.
+#[derive(Debug, Error)]
+pub enum SpecBuilderError {
+    #[error("A device with name {0} already exists")]
+    DeviceNameInUse(String),
+
+    #[error("A backend with name {0} already exists")]
+    BackendNameInUse(String),
+
+    #[error("A PCI device is already attached at {0:?}")]
+    PciPathInUse(PciPath),
+
+    #[error("Serial port {0:?} is already specified")]
+    SerialPortInUse(SerialPortNumber),
+}
+
+/// A builder that constructs instance specs incrementally and catches basic
+/// errors, such as specifying duplicate device or backend names or specifying
+/// multiple devices with the same PCI path.
+pub struct SpecBuilder {
+    spec: InstanceSpec,
+    pci_paths: BTreeSet<PciPath>,
+}
+
+impl SpecBuilder {
+    /// Creates a new instance spec with the supplied board configuration.
+    pub fn new(cpus: u8, memory_mb: u64, enable_pcie: bool) -> Self {
+        let board =
+            Board { cpus, memory_mb, chipset: Chipset::I440Fx { enable_pcie } };
+
+        Self {
+            spec: InstanceSpec {
+                devices: super::DeviceSpec { board, ..Default::default() },
+                ..Default::default()
+            },
+            pci_paths: Default::default(),
+        }
+    }
+
+    /// Adds a PCI path to this builder's record of PCI locations with an
+    /// attached device. If the path is already in use, returns an error.
+    fn register_pci_device(
+        &mut self,
+        pci_path: PciPath,
+    ) -> Result<(), SpecBuilderError> {
+        if self.pci_paths.contains(&pci_path) {
+            Err(SpecBuilderError::PciPathInUse(pci_path))
+        } else {
+            self.pci_paths.insert(pci_path);
+            Ok(())
+        }
+    }
+
+    /// Adds a storage device with an associated backend.
+    pub fn add_storage_device(
+        &mut self,
+        device_name: String,
+        device_spec: super::devices::StorageDevice,
+        backend_name: String,
+        backend_spec: super::backends::StorageBackend,
+    ) -> Result<&Self, SpecBuilderError> {
+        if self.spec.devices.storage_devices.contains_key(&device_name) {
+            return Err(SpecBuilderError::DeviceNameInUse(device_name));
+        }
+
+        if self.spec.backends.storage_backends.contains_key(&backend_name) {
+            return Err(SpecBuilderError::BackendNameInUse(backend_name));
+        }
+
+        self.register_pci_device(device_spec.pci_path)?;
+        let _old =
+            self.spec.devices.storage_devices.insert(device_name, device_spec);
+        assert!(_old.is_none());
+        let _old = self
+            .spec
+            .backends
+            .storage_backends
+            .insert(backend_name, backend_spec);
+        assert!(_old.is_none());
+        Ok(self)
+    }
+
+    /// Adds a network device with an associated backend.
+    pub fn add_network_device(
+        &mut self,
+        device_name: String,
+        device_spec: super::devices::NetworkDevice,
+        backend_name: String,
+        backend_spec: super::backends::NetworkBackend,
+    ) -> Result<&Self, SpecBuilderError> {
+        if self.spec.devices.network_devices.contains_key(&device_name) {
+            return Err(SpecBuilderError::DeviceNameInUse(device_name));
+        }
+
+        if self.spec.backends.network_backends.contains_key(&backend_name) {
+            return Err(SpecBuilderError::BackendNameInUse(backend_name));
+        }
+
+        self.register_pci_device(device_spec.pci_path)?;
+        let _old =
+            self.spec.devices.network_devices.insert(device_name, device_spec);
+        assert!(_old.is_none());
+        let _old = self
+            .spec
+            .backends
+            .network_backends
+            .insert(backend_name, backend_spec);
+        assert!(_old.is_none());
+        Ok(self)
+    }
+
+    /// Adds a PCI-PCI bridge.
+    pub fn add_pci_bridge(
+        &mut self,
+        bridge_name: String,
+        bridge_spec: super::devices::PciPciBridge,
+    ) -> Result<&Self, SpecBuilderError> {
+        if self.spec.devices.pci_pci_bridges.contains_key(&bridge_name) {
+            return Err(SpecBuilderError::DeviceNameInUse(bridge_name));
+        }
+
+        self.register_pci_device(bridge_spec.pci_path)?;
+        let _old =
+            self.spec.devices.pci_pci_bridges.insert(bridge_name, bridge_spec);
+        assert!(_old.is_none());
+        Ok(self)
+    }
+
+    /// Adds a serial port.
+    pub fn add_serial_port(
+        &mut self,
+        port: SerialPortNumber,
+    ) -> Result<&Self, SpecBuilderError> {
+        if self
+            .spec
+            .devices
+            .serial_ports
+            .insert(
+                match port {
+                    SerialPortNumber::Com1 => "com1",
+                    SerialPortNumber::Com2 => "com2",
+                    SerialPortNumber::Com3 => "com3",
+                    SerialPortNumber::Com4 => "com4",
+                }
+                .to_string(),
+                SerialPort { num: port },
+            )
+            .is_some()
+        {
+            Err(SpecBuilderError::SerialPortInUse(port))
+        } else {
+            Ok(self)
+        }
+    }
+
+    /// Yields the completed spec, consuming the builder.
+    pub fn finish(self) -> InstanceSpec {
+        self.spec
+    }
+}

--- a/lib/propolis-client/src/instance_spec/builder.rs
+++ b/lib/propolis-client/src/instance_spec/builder.rs
@@ -77,12 +77,14 @@ impl SpecBuilder {
         self.register_pci_device(device_spec.pci_path)?;
         let _old =
             self.spec.devices.storage_devices.insert(device_name, device_spec);
+
         assert!(_old.is_none());
         let _old = self
             .spec
             .backends
             .storage_backends
             .insert(backend_name, backend_spec);
+
         assert!(_old.is_none());
         Ok(self)
     }
@@ -106,12 +108,14 @@ impl SpecBuilder {
         self.register_pci_device(device_spec.pci_path)?;
         let _old =
             self.spec.devices.network_devices.insert(device_name, device_spec);
+
         assert!(_old.is_none());
         let _old = self
             .spec
             .backends
             .network_backends
             .insert(backend_name, backend_spec);
+
         assert!(_old.is_none());
         Ok(self)
     }
@@ -129,6 +133,7 @@ impl SpecBuilder {
         self.register_pci_device(bridge_spec.pci_path)?;
         let _old =
             self.spec.devices.pci_pci_bridges.insert(bridge_name, bridge_spec);
+
         assert!(_old.is_none());
         Ok(self)
     }

--- a/lib/propolis-client/src/instance_spec/mod.rs
+++ b/lib/propolis-client/src/instance_spec/mod.rs
@@ -65,9 +65,11 @@ pub use crucible_client_types::VolumeConstructionRequest;
 pub use propolis_types::PciPath;
 
 mod backends;
+mod builder;
 mod devices;
 
 pub use backends::*;
+pub use builder::*;
 pub use devices::*;
 
 /// Type alias for keys in the instance spec's maps.


### PR DESCRIPTION
Today, propolis-server has code to build an `InstanceSpec` out of the parameters in an `InstanceEnsureRequest` and the information in the server's configuration TOML. This code has two logical layers: one converts inputs to `InstanceSpec` components, and the other incrementally builds the spec, checking for errors at each step (e.g. duplicating a component name or PCI path).

Refactor so that the "incrementally build a spec" code lives in a spec builder in propolis-client (where the other instance spec code lives) and the "convert Propolis parameters to spec elements" logic calls it. This sets up other clients (PHD in the short term, Nexus in the long term) with an incremental spec builder that they can use to construct specs to send to Propolis.

Tested via PHD & ad hoc testing of a Windows Server 2022 VM.