### PR TITLE
PHD: add affordance for marking tests as skipped

### DIFF
--- a/phd-tests/testcase/src/lib.rs
+++ b/phd-tests/testcase/src/lib.rs
@@ -1,9 +1,16 @@
 pub use anyhow::Result;
 pub use inventory::submit as inventory_submit;
 pub use phd_framework;
-pub use phd_testcase_macros::phd_testcase;
+pub use phd_testcase_macros::*;
+use thiserror::Error;
 
 use phd_framework::test_vm::factory::VmFactory;
+
+#[derive(Debug, Error)]
+pub enum TestSkippedError {
+    #[error("Test skipped: {0:?}")]
+    TestSkipped(Option<String>),
+}
 
 /// The outcome from executing a specific test case.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Define a `phd_skip!` macro that allows a test to mark itself as skipped.

This is useful in cases where a test case discovers that the runner was invoked in a configuration that prevents the test case from verifying anything meaningful. (For example, a test that wants to persist data on disk across a reboot may mark itself as skipped if the runner executes it with a guest image backed by a read-only file system.)

Fixes #175.