### PR TITLE
Unify cleanup for external Stop request and guest-initiated shutdown.

### DIFF
--- a/bin/propolis-cli/Cargo.toml
+++ b/bin/propolis-cli/Cargo.toml
@@ -18,6 +18,7 @@ slog-term = "2.8"
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.17"
 uuid = "1.0.0"
+reqwest = "0.11.12"
 serde = "1.0"
 serde_json = "1.0"
 base64 = "0.13"


### PR DESCRIPTION
We were only cleaning up the server-side resources if we got an
explicity external Stop request. But if the guest initiated a shutdown
we would correctly marked the VM as `Stopped` but never cleanup the
server's `ServiceProviders` nor ever mark it as `Destroyed`.

Instead this introduces a task that will trigger the cleanup when
the VM state worker exits.