### PR TITLE
server: send close frames to serial websocket clients on instance stop

### DIFF
--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -633,7 +633,7 @@ async fn instance_serial(
             }
         });
 
-        super::serial::SerialTask { task, close_ch: close_ch, websocks_ch }
+        super::serial::SerialTask { task, close_ch, websocks_ch }
     });
 
     let config =


### PR DESCRIPTION
Try to gracefully inform any connected serial clients when a VM is stopped. Also remove the Drop impl on SerialTask as it would abort the serial task before it ever got the chance to handle the close message we send it.

This should get rid of the noise in the sled-agent log:

before:
>ERROR: SledAgent/InstanceManager/13728 on luq-helios: Reading TTY: Protocol(ResetWithoutClosingHandshake)

after:
>INFO: SledAgent/InstanceManager/29709 on luq-helios: Closing TTY connection: VM stopped (1001)