### PR TITLE
propolis-server: make held vCPUs check for new events before re-entering the guest

### DIFF
--- a/bin/propolis-server/src/lib/vcpu_tasks.rs
+++ b/bin/propolis-server/src/lib/vcpu_tasks.rs
@@ -107,6 +107,7 @@ impl VcpuTasks {
                 Some(Event::Hold) => {
                     info!(log, "vCPU paused");
                     task.hold();
+                    info!(log, "vCPU released from hold");
 
                     // If the VM was reset while the CPU was paused, clear out
                     // any re-entry reasons from the exit that occurred prior to
@@ -116,6 +117,11 @@ impl VcpuTasks {
                         entry = VmEntry::Run;
                         local_gen = current_gen;
                     }
+
+                    // This hold might have been satisfied by a request for the
+                    // CPU to exit. Check for other pending events before
+                    // re-entering the guest.
+                    continue;
                 }
                 Some(Event::Exit) => break,
                 None => {}


### PR DESCRIPTION
This came up in #233. Without this, vCPUs on a migration source can run briefly before noticing that they're supposed to exit. This means that after a migration, the preserved vCPU state from the source VM (assuming there is some) can differ from what was sent to the target, which isn't great for debugging.