### PR TITLE
Bump Crucible rev to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,7 @@ panic = "abort"
 [profile.phd]
 inherits = "dev"
 panic = "unwind"
+
+#[patch."https://github.com/oxidecomputer/crucible"]
+#crucible = { path = "../crucible/upstairs" }
+#crucible-client-types = { path = "../crucible/crucible-client-types" }

--- a/lib/propolis-client/Cargo.toml
+++ b/lib/propolis-client/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1.0", features = [ "net" ], optional = true }
 
 [dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "144d8dafa41715e00b08a5929cc62140ff0eb561"
+rev = "00c1de9b165e8abff1eed6e26a5755465785fc07"
 
 [features]
 default = []

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -34,12 +34,12 @@ once_cell = "1.13"
 
 [dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "144d8dafa41715e00b08a5929cc62140ff0eb561"
+rev = "00c1de9b165e8abff1eed6e26a5755465785fc07"
 optional = true
 
 [dependencies.crucible]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "144d8dafa41715e00b08a5929cc62140ff0eb561"
+rev = "00c1de9b165e8abff1eed6e26a5755465785fc07"
 optional = true
 
 [dependencies.oximeter]


### PR DESCRIPTION
Pick up the following PRs:

- Implement the Pantry
- Compute better job dependencies Upstairs
- dsc updates
- slog in the downstairs
- First pass at setup for a nightly test
- Update test_perf.sh with better use of dsc program.
- Update Rust crate reedline to 0.12.0
- Add validation and flush tests
- Add encrypted option to dsc
- Return JoinHandles when spawning our services
- Crash consistent removal of block contexts
- Remove Guest's idea of active and locking in len
- Update Rust crate indicatif to 0.17.1
- Update Rust crate tokio to 1.21.2
- Update Rust crate libc to 0.2.134
- Update Rust crate reqwest to 0.11.12
- Update Rust crate schemars to 0.8.11
- Update Rust crate opentelemetry to 0.18.0
- Update Rust crate percent-encoding to 2.2

Also add commented out Cargo.toml patch for Crucible that points to a local checkout.