### PR TITLE
PHD: add gpt_track_dirty to the globals set before running tests

### DIFF
--- a/phd-tests/runner/src/main.rs
+++ b/phd-tests/runner/src/main.rs
@@ -18,11 +18,11 @@ fn main() {
     let runner_args = ProcessArgs::parse();
     set_tracing_subscriber(&runner_args);
 
-    let state_write_guard = phd_framework::host_api::enable_vmm_state_writes();
+    let state_write_guard = phd_framework::host_api::set_vmm_globals();
     if let Err(e) = state_write_guard {
         warn!(
             error = ?e,
-            "Failed to enable VMM state writes, migration tests may not work",
+            "Failed to enable one or more kernel options, some tests may not work",
         );
     }
 


### PR DESCRIPTION
Another follow-up from #233. Ensure that dirty tracking is fully enabled for migration tests. This doesn't seem to have broken any of those tests to date, but this will be needed to run them with Windows guests.

Most of the delta here is just the work needed to make the kernel VA routines generic over integers of different sizes. (It was maybe not worth it given that these settings will all go away in the fullness of time, but at least it was good practice.)