### PR TITLE
Cleanup VMM handle once Instance is dropped.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,4 @@ panic = "unwind"
 #crucible-client-types = { path = "../crucible/crucible-client-types" }
 
 #[patch."http://github.com/oxidecomputer/rfb"]
-# Double / here is intentional to defeat cargo's git canonicalization and allow us to
-# patch a crate using the same source.
-#rfb = { git = "http://github.com/oxidecomputer//rfb", rev = "" }
+#rfb = { path = "../rfb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,7 @@ panic = "abort"
 inherits = "dev"
 panic = "unwind"
 
-[patch."http://github.com/oxidecomputer/rfb"]
+#[patch."http://github.com/oxidecomputer/rfb"]
 # Double / here is intentional to defeat cargo's git canonicalization and allow us to
 # patch a crate using the same source.
-# Temp until https://github.com/oxidecomputer/rfb/pull/9 lands
-rfb = { git = "http://github.com/oxidecomputer//rfb", branch = "luqmana/vnc-stop" }
+#rfb = { git = "http://github.com/oxidecomputer//rfb", rev = "" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,9 @@ panic = "abort"
 [profile.phd]
 inherits = "dev"
 panic = "unwind"
+
+[patch."http://github.com/oxidecomputer/rfb"]
+# Double / here is intentional to defeat cargo's git canonicalization and allow us to
+# patch a crate using the same source.
+# Temp until https://github.com/oxidecomputer/rfb/pull/9 lands
+rfb = { git = "http://github.com/oxidecomputer//rfb", branch = "luqmana/vnc-stop" }

--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -47,7 +47,7 @@ slog = "2.7"
 propolis = { path = "../../lib/propolis", features = ["crucible-full", "oximeter"], default-features = false }
 propolis-client = { path = "../../lib/propolis-client", features = ["generated"] }
 propolis-server-config = { path = "../../crates/propolis-server-config" }
-rfb = { git = "https://github.com/oxidecomputer/rfb", rev = "a8a0034f83ad2695877b9fe7ce0216d33f442e44" }
+rfb = { git = "https://github.com/oxidecomputer/rfb", rev = "0cac8d9c25eb27acfa35df80f3b9d371de98ab3b" }
 uuid = "1.0.0"
 base64 = "0.13"
 

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -167,10 +167,15 @@ impl ServiceProviders {
     /// Directs the current set of per-instance service providers to stop in an
     /// orderly fashion, then drops them all.
     async fn stop(&self, log: &Logger) {
+        // Stop the VNC server
+        self.vnc_server.stop().await;
+
         if let Some(vm) = self.vm.lock().await.take_controller() {
             slog::info!(log, "Dropping instance";
                         "strong_refs" => Arc::strong_count(&vm),
-                        "weak_refs" => Arc::weak_count(&vm));
+                        "weak_refs" => Arc::weak_count(&vm),
+                        "instance_refs" => Arc::strong_count(vm.instance()),
+                    );
         }
         if let Some(serial_task) = self.serial_task.lock().await.take() {
             let _ = serial_task.close_ch.send(());

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -195,7 +195,7 @@ impl DropshotEndpointContext {
     /// Creates a new server context object.
     pub fn new(
         config: VmTomlConfig,
-        vnc_server: VncServer<PropolisVncServer>,
+        vnc_server: Arc<VncServer<PropolisVncServer>>,
         use_reservoir: bool,
         log: slog::Logger,
         metric_config: Option<MetricsEndpointConfig>,
@@ -211,7 +211,7 @@ impl DropshotEndpointContext {
                 serial_task: Mutex::new(None),
                 oximeter_server_task: Mutex::new(None),
                 oximeter_stats: Mutex::new(None),
-                vnc_server: Arc::new(vnc_server),
+                vnc_server,
             }),
             log,
         }

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -172,10 +172,10 @@ impl ServiceProviders {
 
         if let Some(vm) = self.vm.lock().await.take_controller() {
             slog::info!(log, "Dropping instance";
-                        "strong_refs" => Arc::strong_count(&vm),
-                        "weak_refs" => Arc::weak_count(&vm),
-                        "instance_refs" => Arc::strong_count(vm.instance()),
-                    );
+                "strong_refs" => Arc::strong_count(&vm),
+                "weak_refs" => Arc::weak_count(&vm),
+                "instance_refs" => Arc::strong_count(vm.instance()),
+            );
         }
         if let Some(serial_task) = self.serial_task.lock().await.take() {
             let _ = serial_task.close_ch.send(());

--- a/bin/propolis-server/src/lib/vnc.rs
+++ b/bin/propolis-server/src/lib/vnc.rs
@@ -189,7 +189,7 @@ impl Server for PropolisVncServer {
 pub fn setup_vnc(
     log: &Logger,
     addr: SocketAddr,
-) -> VncServer<PropolisVncServer> {
+) -> Arc<VncServer<PropolisVncServer>> {
     let initial_width = 1024;
     let initial_height = 768;
 

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -391,10 +391,7 @@ impl Instance {
                 }
                 State::Destroy => {
                     // Drop the instance
-                    let inst = guard.instance.take().unwrap();
-                    let machine = inst.destroy();
-                    let hdl = machine.destroy();
-                    hdl.destroy().unwrap();
+                    let _ = guard.instance.take().unwrap();
 
                     // Communicate that destruction is complete
                     slog::info!(&log, "Instance destroyed");

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -23,7 +23,7 @@ usdt = { version = "0.3.2", default-features = false }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 anyhow = "1"
-rfb = { git = "https://github.com/oxidecomputer/rfb", rev = "a8a0034f83ad2695877b9fe7ce0216d33f442e44" }
+rfb = { git = "https://github.com/oxidecomputer/rfb", rev = "0cac8d9c25eb27acfa35df80f3b9d371de98ab3b" }
 slog = "2.7"
 serde = { version = "1" }
 serde_arrays = "0.1"

--- a/lib/propolis/src/vmm/machine.rs
+++ b/lib/propolis/src/vmm/machine.rs
@@ -285,9 +285,9 @@ impl Builder {
 }
 impl Drop for Builder {
     fn drop(&mut self) {
-        if self.inner_hdl.is_some() {
+        if let Some(hdl) = &self.inner_hdl {
             // Do not allow the vmm device to persist
-            self.inner_hdl.as_mut().unwrap().destroy().unwrap();
+            hdl.destroy().unwrap();
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/oxidecomputer/propolis/issues/191.

Update the VNC server to cleanup on Stop (depends on https://github.com/oxidecomputer/rfb/pull/9) and release its Instance ref.

Update `Instance`'s drop impl to cleanup the VMM handle.