### PR TITLE
PHD: improve server termination logging; fix test VM name

### DIFF
--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -54,6 +54,8 @@ ls $runner
 ls $artifacts
 ls $propolis
 
+# Disable errexit so that we still upload logs on failure
+set +e
 (RUST_BACKTRACE=1 ptime -m pfexec $runner \
 	--emit-bunyan \
 	run \
@@ -62,8 +64,8 @@ ls $propolis
 	--tmp-directory $tmpdir \
 	--artifact-directory $tmpdir | \
 	tee /tmp/phd-runner.log)
-
 failcount=$?
+set -e
 
 tar -czvf /tmp/phd-tmp-files.tar.gz \
 	-C /tmp/propolis-phd /tmp/propolis-phd/*.log \

--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -47,7 +47,7 @@ slog = "2.7"
 propolis = { path = "../../lib/propolis", features = ["crucible-full", "oximeter"], default-features = false }
 propolis-client = { path = "../../lib/propolis-client", features = ["generated"] }
 propolis-server-config = { path = "../../crates/propolis-server-config" }
-rfb = { git = "https://github.com/oxidecomputer/rfb" }
+rfb = { git = "https://github.com/oxidecomputer/rfb", rev = "a8a0034f83ad2695877b9fe7ce0216d33f442e44" }
 uuid = "1.0.0"
 base64 = "0.13"
 

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -23,7 +23,7 @@ usdt = { version = "0.3.2", default-features = false }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 anyhow = "1"
-rfb = { git = "https://github.com/oxidecomputer/rfb" }
+rfb = { git = "https://github.com/oxidecomputer/rfb", rev = "a8a0034f83ad2695877b9fe7ce0216d33f442e44" }
 slog = "2.7"
 serde = { version = "1" }
 serde_arrays = "0.1"

--- a/phd-tests/framework/src/test_vm/server.rs
+++ b/phd-tests/framework/src/test_vm/server.rs
@@ -83,9 +83,24 @@ impl PropolisServer {
 
 impl Drop for PropolisServer {
     fn drop(&mut self) {
+        let pid = self.server.id().to_string();
+        info!(
+            pid,
+            %self.address,
+            "Killing Propolis server that was dropped"
+        );
+
         std::process::Command::new("pfexec")
-            .args(["kill", self.server.id().to_string().as_str()])
+            .args(["kill", &pid])
             .spawn()
-            .unwrap();
+            .expect("should be able to kill a phd-spawned propolis");
+
+        self.server
+            .wait()
+            .expect("should be able to wait on a phd-spawned propolis");
+
+        info!(pid,
+              %self.address,
+              "Successfully waited for demise of Propolis server that was dropped");
     }
 }

--- a/phd-tests/tests/src/server_state_machine.rs
+++ b/phd-tests/tests/src/server_state_machine.rs
@@ -40,7 +40,7 @@ fn instance_stop_causes_destroy_test(ctx: &TestContext) {
 #[phd_testcase]
 fn instance_reset_returns_to_running_test(ctx: &TestContext) {
     let mut vm = ctx.vm_factory.new_vm(
-        "instance_stop_returns_to_running_test",
+        "instance_reset_returns_to_running_test",
         ctx.default_vm_config(),
     )?;
 


### PR DESCRIPTION
Make the Propolis server wrapper's `Drop` impl log that the server is being terminated, and make it wait for the actual demise of the server process before continuing. (This may help either resolve or make actionable the failure we're currently seeing in CI in #244, where one of the tests' Propolis servers is logging `Error: Failed to start server: error creating server listener: Address already in use (os error 125)` on instantiation, and is good practice in any case.)

Also fix the naming of the VM generated in `instance_reset_returns_to_running_test`.
