### PR TITLE
Point to specific rfb rev.

### DIFF
--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -47,7 +47,7 @@ slog = "2.7"
 propolis = { path = "../../lib/propolis", features = ["crucible-full", "oximeter"], default-features = false }
 propolis-client = { path = "../../lib/propolis-client", features = ["generated"] }
 propolis-server-config = { path = "../../crates/propolis-server-config" }
-rfb = { git = "https://github.com/oxidecomputer/rfb" }
+rfb = { git = "https://github.com/oxidecomputer/rfb", rev = "a8a0034f83ad2695877b9fe7ce0216d33f442e44" }
 uuid = "1.0.0"
 base64 = "0.13"
 

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -23,7 +23,7 @@ usdt = { version = "0.3.2", default-features = false }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 anyhow = "1"
-rfb = { git = "https://github.com/oxidecomputer/rfb" }
+rfb = { git = "https://github.com/oxidecomputer/rfb", rev = "a8a0034f83ad2695877b9fe7ce0216d33f442e44" }
 slog = "2.7"
 serde = { version = "1" }
 serde_arrays = "0.1"


### PR DESCRIPTION
Latest rfb branch requires https://github.com/oxidecomputer/propolis/pull/244 which hasn't landed. Update Cargo.toml to point to previous version that works with current propolis master.