### PR TITLE
server: Wait for Instance to be dropped before setting api state to Destroyed.

### DIFF
--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -47,7 +47,8 @@ slog = "2.7"
 propolis = { path = "../../lib/propolis", features = ["crucible-full", "oximeter"], default-features = false }
 propolis-client = { path = "../../lib/propolis-client", features = ["generated"] }
 propolis-server-config = { path = "../../crates/propolis-server-config" }
-rfb = { git = "https://github.com/oxidecomputer/rfb", rev = "0cac8d9c25eb27acfa35df80f3b9d371de98ab3b" }
+# TODO: Update once https://github.com/oxidecomputer/rfb/pull/10 lands
+rfb = { git = "https://github.com/oxidecomputer/rfb", branch = "luqmana/stop-for-real" }
 uuid = "1.0.0"
 base64 = "0.13"
 

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -167,8 +167,9 @@ impl ServiceProviders {
     /// Directs the current set of per-instance service providers to stop in an
     /// orderly fashion, then drops them all.
     async fn stop(&self, log: &Logger) {
-        // Stop the VNC server
-        self.vnc_server.stop().await;
+        if let Err(err) = self.vnc_server.stop().await {
+            slog::error!(log, "Failed to stop VNC server"; "err" => ?err);
+        }
 
         if let Some(vm) = self.vm.lock().await.take_controller() {
             slog::info!(log, "Dropping instance";

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -23,7 +23,8 @@ usdt = { version = "0.3.2", default-features = false }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 anyhow = "1"
-rfb = { git = "https://github.com/oxidecomputer/rfb", rev = "0cac8d9c25eb27acfa35df80f3b9d371de98ab3b" }
+# TODO: Update once https://github.com/oxidecomputer/rfb/pull/10 lands
+rfb = { git = "https://github.com/oxidecomputer/rfb", branch = "luqmana/stop-for-real" }
 slog = "2.7"
 serde = { version = "1" }
 serde_arrays = "0.1"


### PR DESCRIPTION
Previously, there was a bit of a race condition where the completion of the worker thread (and the subsequent dropping of WorkerStateInner) would set the API instance state to Destroyed, but the actual Instance itself might not've been destroyed yet.

Some PHD tests would thus sometimes leave left over VMM handles because the test framework immediately killed the propolis-server process when it saw the instance state get to Destroyed.

Also bail early if the VNC port is already used.