### PR TITLE
Allow enabling dirty page tracking per-VM during creation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,13 @@ pfexec mdb -kw -e "vmm_allow_state_writes ::write -l 1 1"
 pfexec mdb -kw -e "gpt_track_dirty ::write -l 1 1"
 ```
 
+**Note:** Setting `gpt_track_dirty` is unnecessary on builds including
+[14251](https://www.illumos.org/issues/14251)
+([4ac713d](https://github.com/illumos/illumos-gate/commit/4ac713da4ff2c45287699af975f8c98142bbd9d3)).
+
 Propolis works best (and its CI tests run) on AMD hosts, but it can also be used
-to run VMs on Intel hosts. Live migration is only supported on AMD hosts.
+to run VMs on Intel hosts. Live migration is primarily supported on AMD hosts
+but may work on Intel hosts as well.
 
 ## Building
 

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -67,7 +67,11 @@ pub fn build_instance(
     _log: slog::Logger,
 ) -> Result<Arc<Instance>> {
     let (lowmem, highmem) = get_spec_guest_ram_limits(spec);
-    let create_opts = propolis::vmm::CreateOpts { force: true, use_reservoir };
+    let create_opts = propolis::vmm::CreateOpts {
+        force: true,
+        use_reservoir,
+        track_dirty: true,
+    };
     let mut builder = Builder::new(name, create_opts)?
         .max_cpus(spec.devices.board.cpus)?
         .add_mem_region(0, lowmem, "lowmem")?

--- a/crates/bhyve-api/src/lib.rs
+++ b/crates/bhyve-api/src/lib.rs
@@ -16,7 +16,7 @@ pub const VMM_CTL_PATH: &str = "/dev/vmmctl";
 /// This is the VMM interface version against which bhyve_api expects to operate
 /// against.  All constants and structs defined by the crate are done so in
 /// terms of that specific version.
-pub const VMM_CURRENT_INTERFACE_VERSION: u32 = 4;
+pub const VMM_CURRENT_INTERFACE_VERSION: u32 = 8;
 
 use std::io::Result;
 

--- a/crates/bhyve-api/src/structs.rs
+++ b/crates/bhyve-api/src/structs.rs
@@ -412,6 +412,9 @@ impl vm_create_req {
 // attempting to create transient allocations.
 pub const VCF_RESERVOIR_MEM: u64 = 1;
 
+/// Enable dirty page tracking for the guest.
+pub const VCF_TRACK_DIRTY: u64 = 1 << 1;
+
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct vm_destroy_req {

--- a/lib/propolis/src/vmm/hdl.rs
+++ b/lib/propolis/src/vmm/hdl.rs
@@ -34,6 +34,7 @@ use crate::vmm::mem::Prot;
 pub struct CreateOpts {
     pub force: bool,
     pub use_reservoir: bool,
+    pub track_dirty: bool,
 }
 
 /// Creates a new virtual machine with the provided `name`.
@@ -63,6 +64,9 @@ fn create_vm_impl(name: &str, opts: CreateOpts) -> Result<VmmHdl> {
     let mut req = bhyve_api::vm_create_req::new(name);
     if opts.use_reservoir {
         req.flags |= bhyve_api::VCF_RESERVOIR_MEM;
+    }
+    if opts.track_dirty {
+        req.flags |= bhyve_api::VCF_TRACK_DIRTY;
     }
     let res = unsafe { libc::ioctl(ctlfd, bhyve_api::VMM_CREATE_VM, &req) };
     if res != 0 {

--- a/phd-tests/framework/src/host_api/kvm.rs
+++ b/phd-tests/framework/src/host_api/kvm.rs
@@ -301,7 +301,7 @@ pub fn set_vmm_globals() -> Result<Vec<Box<dyn std::any::Any>>> {
     guards.push(Box::new(allow_state_writes));
 
     // Enable global dirty tracking bit on systems where it exists.
-    // TODO: Remove once CI has updated to include https://code.illumos.org/c/illumos-gate/+/2502
+    // TODO(#255): Remove once CI has updated to include https://code.illumos.org/c/illumos-gate/+/2502
     if let Ok(gpt_track_dirty) = KernelValueGuard::new("gpt_track_dirty", 1u8) {
         guards.push(Box::new(gpt_track_dirty));
     }

--- a/phd-tests/framework/src/host_api/kvm.rs
+++ b/phd-tests/framework/src/host_api/kvm.rs
@@ -294,9 +294,17 @@ impl<T: SizedKernelGlobal> Drop for KernelValueGuard<T> {
 /// Sets all of the kernel globals needed to run PHD tests. Returns a vector of
 /// RAII guards that reset these values to their pre-test values when dropped.
 pub fn set_vmm_globals() -> Result<Vec<Box<dyn std::any::Any>>> {
+    let mut guards: Vec<Box<dyn std::any::Any>> = vec![];
+
     let allow_state_writes =
-        Box::new(KernelValueGuard::new("vmm_allow_state_writes", 1u32)?);
-    let gpt_track_dirty =
-        Box::new(KernelValueGuard::new("gpt_track_dirty", 1u8)?);
-    Ok(vec![allow_state_writes, gpt_track_dirty])
+        KernelValueGuard::new("vmm_allow_state_writes", 1u32)?;
+    guards.push(Box::new(allow_state_writes));
+
+    // Enable global dirty tracking bit on systems where it exists.
+    // TODO: Remove once CI has updated to include https://code.illumos.org/c/illumos-gate/+/2502
+    if let Ok(gpt_track_dirty) = KernelValueGuard::new("gpt_track_dirty", 1u8) {
+        guards.push(Box::new(gpt_track_dirty));
+    }
+
+    Ok(guards)
 }


### PR DESCRIPTION
With https://code.illumos.org/c/illumos-gate/+/2502 it is now possible to enable the dirty page tracking feature per-VM instead of via a kernel global.