### PR TITLE
Add Crucible support to PHD

### DIFF
--- a/phd-tests/framework/Cargo.toml
+++ b/phd-tests/framework/Cargo.toml
@@ -38,4 +38,4 @@ base64 = "0.13.1"
 
 [dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "00c1de9b165e8abff1eed6e26a5755465785fc07"
+rev = "861a09c350fd0e127b6105c8099e31a0bc3b711a"

--- a/phd-tests/framework/Cargo.toml
+++ b/phd-tests/framework/Cargo.toml
@@ -33,3 +33,7 @@ toml = "0.5.9"
 tracing = "0.1.35"
 uuid = "1.1.2"
 vte = "0.10.1"
+
+[dependencies.crucible-client-types]
+git = "https://github.com/oxidecomputer/crucible"
+rev = "00c1de9b165e8abff1eed6e26a5755465785fc07"

--- a/phd-tests/framework/Cargo.toml
+++ b/phd-tests/framework/Cargo.toml
@@ -33,6 +33,8 @@ toml = "0.5.9"
 tracing = "0.1.35"
 uuid = "1.1.2"
 vte = "0.10.1"
+rand = "0.8.5"
+base64 = "0.13.1"
 
 [dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"

--- a/phd-tests/framework/src/artifacts.rs
+++ b/phd-tests/framework/src/artifacts.rs
@@ -228,25 +228,18 @@ impl ArtifactStore {
         &self.local_root
     }
 
-    /// Given an artifact name, attempts to retrieve the guest OS artifact with
-    /// that name and returns the path to the artifact in the local store.
-    pub fn get_guest_image_path_by_name(
+    /// Given a guest OS artifact name, attempts to retrieve the corresponding
+    /// artifact and return a path to its contents and its guest OS kind.
+    pub fn get_guest_artifact_info_by_name(
         &self,
         artifact: &str,
-    ) -> Option<PathBuf> {
-        self.config
-            .guest_images
-            .get(artifact)
-            .map(|a| self.construct_full_path(&a.metadata.relative_local_path))
-    }
-
-    /// Given an artifact name, attempts to retrieve the guest OS artifact with
-    /// that name and returns the artifact's guest OS kind.
-    pub fn get_guest_os_kind_by_name(
-        &self,
-        artifact: &str,
-    ) -> Option<GuestOsKind> {
-        self.config.guest_images.get(artifact).map(|a| a.guest_os_kind)
+    ) -> Option<(PathBuf, GuestOsKind)> {
+        self.config.guest_images.get(artifact).map(|a| {
+            (
+                self.construct_full_path(&a.metadata.relative_local_path),
+                a.guest_os_kind,
+            )
+        })
     }
 
     /// Given an artifact name, attempts to retrieve the guest firmware artifact

--- a/phd-tests/framework/src/disk/crucible.rs
+++ b/phd-tests/framework/src/disk/crucible.rs
@@ -1,0 +1,275 @@
+//! Abstractions for Crucible-backed disks.
+
+use std::{
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    path::{Path, PathBuf},
+    process::Stdio,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use crucible_client_types::{CrucibleOpts, VolumeConstructionRequest};
+use tracing::{error, info};
+use uuid::Uuid;
+
+use crate::{guest_os::GuestOsKind, server_log_mode::ServerLogMode};
+
+use super::BlockSize;
+
+/// An RAII wrapper around a directory containing Crucible data files. Deletes
+/// the directory and its contents when dropped.
+#[derive(Debug)]
+struct DataDirectory {
+    path: PathBuf,
+}
+
+impl Drop for DataDirectory {
+    fn drop(&mut self) {
+        info!(?self.path, "Deleting Crucible downstairs data directory");
+        if let Err(e) = std::fs::remove_dir_all(&self.path) {
+            error!(?e, ?self.path, "Failed to delete Crucible downstairs data");
+        }
+    }
+}
+
+/// An RAII wrapper around a Crucible downstairs process. Stops the process and
+/// deletes the downstairs' data when dropped.
+#[allow(dead_code)]
+#[derive(Debug)]
+struct Downstairs {
+    process_handle: std::process::Child,
+    address: SocketAddr,
+    data_dir: DataDirectory,
+}
+
+impl Drop for Downstairs {
+    fn drop(&mut self) {
+        info!(?self, "Stopping Crucible downstairs process");
+        let _ = self.process_handle.kill();
+    }
+}
+
+/// An RAII wrapper around a Crucible disk.
+#[derive(Debug)]
+pub struct CrucibleDisk {
+    /// The UUID to insert into this disk's `VolumeConstructionRequest`s.
+    id: Uuid,
+
+    /// The disk's block size.
+    block_size: BlockSize,
+
+    /// The collection of downstairs process wrappers for this disk.
+    downstairs_instances: Vec<Downstairs>,
+
+    /// An optional path to a file to use as a read-only parent for this disk.
+    read_only_parent: Option<PathBuf>,
+
+    /// The kind of guest OS that can be found on this disk, if there is one.
+    guest_os: Option<GuestOsKind>,
+
+    /// The generation number to insert into this disk's
+    /// `VolumeConstructionRequest`s.
+    generation: AtomicU64,
+}
+
+impl CrucibleDisk {
+    /// Constructs a new Crucible disk that stores its files in the supplied
+    /// `data_dir`.
+    pub(crate) fn new(
+        disk_size_gib: u64,
+        block_size: BlockSize,
+        downstairs_binary_path: &impl AsRef<std::ffi::OsStr>,
+        downstairs_ports: &[u16],
+        data_dir: &impl AsRef<Path>,
+        read_only_parent: Option<&impl AsRef<Path>>,
+        guest_os: Option<GuestOsKind>,
+        log_mode: ServerLogMode,
+    ) -> anyhow::Result<Self> {
+        // To create a region, Crucible requires a block size, an extent size
+        // given as a number of blocks, and an extent count. Compute the latter
+        // two figures here. The extent size is semi-arbitrarily chosen to be 64
+        // MiB (to match Omicron's extent size at the time this module was
+        // authored); this can be parameterized later if needed.
+        const EXTENT_SIZE: u64 = 64 << 20;
+
+        assert!(EXTENT_SIZE > block_size.bytes());
+        assert!(EXTENT_SIZE % block_size.bytes() == 0);
+
+        let blocks_per_extent: u64 = EXTENT_SIZE / block_size.bytes();
+        let extents_in_disk = (disk_size_gib * (1 << 30)) / EXTENT_SIZE;
+
+        // Create the region directories for each region.
+        let mut data_dirs = vec![];
+        let disk_uuid = Uuid::new_v4();
+        for port in downstairs_ports {
+            let mut data_dir_path = data_dir.as_ref().to_path_buf();
+            data_dir_path.push(format!("{}_{}", disk_uuid, port));
+            std::fs::create_dir_all(&data_dir_path)?;
+            data_dirs.push(DataDirectory { path: data_dir_path });
+        }
+
+        for dir in &data_dirs {
+            let dir_arg = dir.path.to_string_lossy();
+            let crucible_args = [
+                "create",
+                "--block-size",
+                &block_size.bytes().to_string(),
+                "--data",
+                dir_arg.as_ref(),
+                "--encrypted",
+                "false",
+                "--uuid",
+                &disk_uuid.to_string(),
+                "--extent-size",
+                &blocks_per_extent.to_string(),
+                "--extent-count",
+                &extents_in_disk.to_string(),
+            ];
+
+            // This is a transient process, so just pipe stdout/stderr back into
+            // the framework and trace the outputs instead of setting up full
+            // log files.
+            let create_stdout = Stdio::piped();
+            let create_stderr = Stdio::piped();
+            let create_proc = run_crucible_downstairs(
+                &downstairs_binary_path,
+                &crucible_args,
+                create_stdout,
+                create_stderr,
+            )?;
+
+            let create_output = create_proc.wait_with_output()?;
+            info!(
+                stdout = std::str::from_utf8(&create_output.stdout)?,
+                stderr = std::str::from_utf8(&create_output.stderr)?,
+                status = ?create_output.status,
+                "Created Crucible region using crucible-downstairs"
+            );
+
+            if !create_output.status.success() {
+                anyhow::bail!(
+                    "Crucible region creation failed with exit code {:?}",
+                    create_output.status.code()
+                );
+            }
+        }
+
+        // Spawn the downstairs processes that will serve requests from guest
+        // VMs.
+        let mut downstairs_instances = vec![];
+        for (port, dir) in
+            downstairs_ports.into_iter().zip(data_dirs.into_iter())
+        {
+            let addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), *port);
+            let dir_arg = dir.path.to_string_lossy();
+            let crucible_args = [
+                "run",
+                "--address",
+                &addr.ip().to_string(),
+                "--port",
+                &addr.port().to_string(),
+                "--data",
+                dir_arg.as_ref(),
+            ];
+
+            let (stdout, stderr) = log_mode.get_handles(
+                data_dir,
+                &format!("crucible_{}_{}", disk_uuid, port),
+            )?;
+
+            info!(?crucible_args, "Launching Crucible downstairs server");
+            let downstairs = Downstairs {
+                process_handle: run_crucible_downstairs(
+                    &downstairs_binary_path,
+                    &crucible_args,
+                    stdout,
+                    stderr,
+                )?,
+                address: SocketAddr::V4(addr),
+                data_dir: dir,
+            };
+
+            downstairs_instances.push(downstairs);
+        }
+
+        Ok(Self {
+            id: disk_uuid,
+            block_size,
+            downstairs_instances,
+            read_only_parent: read_only_parent
+                .map(|p| p.as_ref().to_path_buf()),
+            guest_os,
+            generation: AtomicU64::new(0),
+        })
+    }
+
+    /// Sets the generation number to use in subsequent calls to create a
+    /// backend spec for this disk.
+    pub fn set_generation(&self, gen: u64) {
+        self.generation.store(gen, Ordering::Relaxed);
+    }
+}
+
+impl super::DiskConfig for CrucibleDisk {
+    fn backend_spec(&self) -> propolis_client::instance_spec::StorageBackend {
+        let gen = self.generation.load(Ordering::Relaxed);
+        let downstairs_addrs =
+            self.downstairs_instances.iter().map(|ds| ds.address).collect();
+
+        propolis_client::instance_spec::StorageBackend {
+            kind:
+                propolis_client::instance_spec::StorageBackendKind::Crucible {
+                    gen,
+                    req: VolumeConstructionRequest::Volume {
+                        id: self.id,
+                        block_size: self.block_size.bytes(),
+                        sub_volumes: vec![VolumeConstructionRequest::Region {
+                            block_size: self.block_size.bytes(),
+                            opts: CrucibleOpts {
+                                id: Uuid::new_v4(),
+                                target: downstairs_addrs,
+                                lossy: false,
+                                flush_timeout: None,
+                                key: None,
+                                cert_pem: None,
+                                key_pem: None,
+                                root_cert_pem: None,
+                                control: None,
+                                read_only: false,
+                            },
+                            gen,
+                        }],
+                        read_only_parent: self.read_only_parent.as_ref().map(
+                            |p| {
+                                Box::new(VolumeConstructionRequest::File {
+                                    id: Uuid::new_v4(),
+                                    block_size: self.block_size.bytes(),
+                                    path: p.to_string_lossy().to_string(),
+                                })
+                            },
+                        ),
+                    },
+                },
+            readonly: false,
+        }
+    }
+
+    fn guest_os(&self) -> Option<GuestOsKind> {
+        self.guest_os
+    }
+}
+
+fn run_crucible_downstairs(
+    binary_path: &impl AsRef<std::ffi::OsStr>,
+    args: &[&str],
+    stdout: impl Into<Stdio>,
+    stderr: impl Into<Stdio>,
+) -> anyhow::Result<std::process::Child> {
+    info!(?args, "Running crucible-downstairs");
+    let process_handle = std::process::Command::new(&binary_path)
+        .args(args)
+        .stdout(stdout)
+        .stderr(stderr)
+        .spawn()?;
+
+    Ok(process_handle)
+}

--- a/phd-tests/framework/src/disk/crucible.rs
+++ b/phd-tests/framework/src/disk/crucible.rs
@@ -83,7 +83,7 @@ impl CrucibleDisk {
         block_size: BlockSize,
         downstairs_binary_path: &impl AsRef<std::ffi::OsStr>,
         downstairs_ports: &[u16],
-        data_dir: &impl AsRef<Path>,
+        data_dir_root: &impl AsRef<Path>,
         read_only_parent: Option<&impl AsRef<Path>>,
         guest_os: Option<GuestOsKind>,
         log_mode: ServerLogMode,
@@ -105,7 +105,7 @@ impl CrucibleDisk {
         let mut data_dirs = vec![];
         let disk_uuid = Uuid::new_v4();
         for port in downstairs_ports {
-            let mut data_dir_path = data_dir.as_ref().to_path_buf();
+            let mut data_dir_path = data_dir_root.as_ref().to_path_buf();
             data_dir_path.push(format!("{}_{}", disk_uuid, port));
             std::fs::create_dir_all(&data_dir_path)?;
             data_dirs.push(DataDirectory { path: data_dir_path });
@@ -176,7 +176,7 @@ impl CrucibleDisk {
             ];
 
             let (stdout, stderr) = log_mode.get_handles(
-                data_dir,
+                data_dir_root,
                 &format!("crucible_{}_{}", disk_uuid, port),
             )?;
 

--- a/phd-tests/framework/src/disk/crucible.rs
+++ b/phd-tests/framework/src/disk/crucible.rs
@@ -198,7 +198,7 @@ impl CrucibleDisk {
             read_only_parent: read_only_parent
                 .map(|p| p.as_ref().to_path_buf()),
             guest_os,
-            generation: AtomicU64::new(0),
+            generation: AtomicU64::new(1),
         })
     }
 

--- a/phd-tests/framework/src/disk/crucible.rs
+++ b/phd-tests/framework/src/disk/crucible.rs
@@ -227,7 +227,6 @@ impl super::DiskConfig for CrucibleDisk {
         propolis_client::instance_spec::StorageBackend {
             kind:
                 propolis_client::instance_spec::StorageBackendKind::Crucible {
-                    gen,
                     req: VolumeConstructionRequest::Volume {
                         id: self.id,
                         block_size: self.block_size.bytes(),

--- a/phd-tests/framework/src/disk/mod.rs
+++ b/phd-tests/framework/src/disk/mod.rs
@@ -171,11 +171,16 @@ impl DiskFactory<'_> {
         .map(Arc::new)
     }
 
-    /// Creates a new Crucible-backed disk.
+    /// Creates a new Crucible-backed disk by creating three region files to
+    /// hold the disk's data and launching a Crucible downstairs process to
+    /// serve each one.
     ///
     /// # Parameters
     ///
     /// - source: The data source that supplies the disk's initial contents.
+    ///   If the source data is stored as a file on the local disk, the
+    ///   resulting disk's `VolumeConstructionRequest`s will specify that this
+    ///   file should be used as a read-only parent volume.
     /// - disk_size_gib: The disk's expected size in GiB.
     /// - block_size: The disk's block size.
     pub fn create_crucible_disk(

--- a/phd-tests/framework/src/disk/mod.rs
+++ b/phd-tests/framework/src/disk/mod.rs
@@ -41,7 +41,7 @@ trait DiskWrapper: std::fmt::Debug {
 ///
 /// New guest disks created by a [`DiskFactory`] are wrapped in an `Arc` so that
 /// test cases can decide whether to share them or move them into a new VM. See
-/// the documentation for [`DiskFactory::create_disk`] for more information.
+/// the documentation for [`DiskFactory`] for more information.
 #[derive(Debug)]
 pub struct GuestDisk {
     backend: Box<dyn DiskWrapper>,
@@ -70,15 +70,29 @@ pub enum DiskSource<'a> {
     Artifact(&'a str),
 }
 
-/// The possible kinds of backends a disk can have.
-#[derive(Clone, Copy, Debug)]
-pub enum DiskBackend {
-    /// Back this disk with a file on the local file system.
-    File,
-}
-
 /// A factory that provides tests with the means to create a disk they can
 /// attach to a guest VM.
+///
+/// The `create_foo` functions implemented by the factory create a [`GuestDisk`]
+/// whose initial contents are described by a supplied [`DiskSource`]. They
+/// return disks wrapped in an `Arc` that can be passed to `ConfigRequest`
+/// routines that add disks to a VM's configuration. This allows tests to manage
+/// disks in two ways:
+///
+/// 1. Tests that don't need a disk's resources to outlive a VM can simply move
+///    the disk reference into the VM config (which will move the reference to
+///    the VM). In this way the disk is destroyed when its test VM goes away.
+/// 2. Tests that want to preserve or reuse a disk after its VM stops can
+///    instead clone the reference into the VM and reuse the source reference
+///    later in the test. This can be used to, say, launch a VM, destroy it, and
+///    attach the same disk to another VM to verify that changes to it are
+///    persisted.
+///
+/// N.B. The `GuestDisk` objects the factory creates take no special care to
+///      ensure that they can be used safely by multiple VMs at the same time.
+///      If multiple VMs do use a single set of backend resources, the resulting
+///      behavior will depend on the chosen backend's semantics and the way the
+///      Propolis backend implementations interact with the disk.
 pub struct DiskFactory<'a> {
     /// The directory in which disk files should be stored.
     storage_dir: PathBuf,
@@ -101,50 +115,27 @@ impl<'a> DiskFactory<'a> {
 }
 
 impl DiskFactory<'_> {
-    /// Creates a new [`GuestDisk`] whose initial contents are described by
-    /// `source` and that uses the supplied kind of `backend`.
-    ///
-    /// The returned disk is wrapped in an `Arc` that can be passed to
-    /// `ConfigRequest` routines that add disks to a VM's configuration. This
-    /// enables disks to be managed in two ways:
-    ///
-    /// 1. Tests that don't need a disk's resources to outlive a VM can simply
-    ///    move the disk reference into the VM config (which will move the
-    ///    reference to the VM). In this way the disk is destroyed when its test
-    ///    VM goes away.
-    /// 2. Tests that want to preserve or reuse a disk after its VM stops can
-    ///    instead clone the reference into the VM and reuse the source
-    ///    reference later in the test. This can be used to, say, launch a VM,
-    ///    destroy it, and attach the same disk to another VM to verify that
-    ///    changes to it are persisted.
-    ///
-    /// N.B. The `GuestDisk` objects this function creates take no special care
-    ///      to ensure that they can be used safely by multiple VMs at the same
-    ///      time. If multiple VMs do use a single set of backend resources, the
-    ///      resulting behavior will depend on the chosen backend's semantics
-    ///      and the way the Propolis backend implementations interact with the
-    ///      disk.
-    pub fn create_disk(
+    fn get_guest_artifact_info(
+        &self,
+        artifact_name: &str,
+    ) -> Result<(PathBuf, GuestOsKind), DiskError> {
+        self.artifact_store
+            .get_guest_artifact_info_by_name(artifact_name)
+            .ok_or_else(|| {
+                DiskError::ArtifactNotFound(artifact_name.to_string())
+            })
+    }
+
+    /// Creates a new [`GuestDisk`] backed by a file whose initial contents are
+    /// specified by `source`.
+    pub fn create_file_backed_disk(
         &self,
         source: DiskSource,
-        _backend: DiskBackend,
     ) -> Result<Arc<GuestDisk>, DiskError> {
         let DiskSource::Artifact(artifact_name) = source;
-        let artifact_path = self
-            .artifact_store
-            .get_guest_image_path_by_name(artifact_name)
-            .ok_or_else(|| {
-                DiskError::ArtifactNotFound(artifact_name.to_string())
-            })?;
+        let (artifact_path, guest_os) =
+            self.get_guest_artifact_info(artifact_name)?;
 
-        let guest_os = self
-            .artifact_store
-            .get_guest_os_kind_by_name(artifact_name)
-            .ok_or_else(|| {
-                DiskError::ArtifactNotFound(artifact_name.to_string())
-            })?;
-
-        // disk backend
         let disk = FileBackedDisk::new_from_artifact(
             &artifact_path,
             &self.storage_dir,

--- a/phd-tests/framework/src/disk/mod.rs
+++ b/phd-tests/framework/src/disk/mod.rs
@@ -79,7 +79,7 @@ pub enum DiskSource<'a> {
 /// A factory that provides tests with the means to create a disk they can
 /// attach to a guest VM.
 ///
-/// The `create_foo` functions implemented by the factory create a [`GuestDisk`]
+/// The `create_foo` functions implemented by the factory create disk objects
 /// whose initial contents are described by a supplied [`DiskSource`]. They
 /// return disks wrapped in an `Arc` that can be passed to `ConfigRequest`
 /// routines that add disks to a VM's configuration. This allows tests to manage
@@ -94,9 +94,9 @@ pub enum DiskSource<'a> {
 ///    attach the same disk to another VM to verify that changes to it are
 ///    persisted.
 ///
-/// N.B. The `GuestDisk` objects the factory creates take no special care to
-///      ensure that they can be used safely by multiple VMs at the same time.
-///      If multiple VMs do use a single set of backend resources, the resulting
+/// N.B. The disk objects the factory creates take no special care to ensure
+///      that they can be used safely by multiple VMs at the same time. If
+///      multiple VMs do use a single set of backend resources, the resulting
 ///      behavior will depend on the chosen backend's semantics and the way the
 ///      Propolis backend implementations interact with the disk.
 pub struct DiskFactory<'a> {

--- a/phd-tests/framework/src/guest_os/alpine.rs
+++ b/phd-tests/framework/src/guest_os/alpine.rs
@@ -16,4 +16,8 @@ impl GuestOs for Alpine {
     fn get_shell_prompt(&self) -> &'static str {
         "localhost:~#"
     }
+
+    fn read_only_fs(&self) -> bool {
+        true
+    }
 }

--- a/phd-tests/framework/src/guest_os/debian11_nocloud.rs
+++ b/phd-tests/framework/src/guest_os/debian11_nocloud.rs
@@ -16,4 +16,8 @@ impl GuestOs for Debian11NoCloud {
     fn get_shell_prompt(&self) -> &'static str {
         "root@debian:~#"
     }
+
+    fn read_only_fs(&self) -> bool {
+        false
+    }
 }

--- a/phd-tests/framework/src/guest_os/mod.rs
+++ b/phd-tests/framework/src/guest_os/mod.rs
@@ -26,6 +26,9 @@ pub(super) trait GuestOs {
 
     /// Retrieves the default shell prompt for this OS.
     fn get_shell_prompt(&self) -> &'static str;
+
+    /// Indicates whether the guest has a read-only filesystem.
+    fn read_only_fs(&self) -> bool;
 }
 
 #[allow(dead_code)]

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -535,6 +535,11 @@ impl TestVm {
             VmState::New => Err(VmStateError::InstanceNotEnsured.into()),
         }
     }
+
+    /// Indicates whether this VM's guest OS has a read-only filesystem.
+    pub fn guest_os_has_read_only_fs(&self) -> bool {
+        self.guest_os.read_only_fs()
+    }
 }
 
 impl Drop for TestVm {

--- a/phd-tests/framework/src/test_vm/vm_config.rs
+++ b/phd-tests/framework/src/test_vm/vm_config.rs
@@ -48,7 +48,7 @@ impl From<DiskInterface> for StorageDeviceKind {
 struct DiskRequest {
     /// A reference to the resources needed to create this disk's backend. VMs
     /// created from this configuration also get a reference to these resources.
-    disk: Arc<disk::GuestDisk>,
+    disk: Arc<dyn disk::DiskConfig>,
 
     /// The PCI device number to assign to this disk. The disk's BDF will be
     /// 0/this value/0.
@@ -91,7 +91,7 @@ impl ConfigRequest {
 
     pub fn set_boot_disk(
         mut self,
-        disk: Arc<disk::GuestDisk>,
+        disk: Arc<dyn disk::DiskConfig>,
         pci_device_num: u8,
         interface: DiskInterface,
     ) -> Self {
@@ -190,7 +190,7 @@ impl ConfigRequest {
 #[derive(Clone, Debug)]
 pub struct VmConfig {
     instance_spec: InstanceSpec,
-    _disk_handles: Vec<Arc<disk::GuestDisk>>,
+    _disk_handles: Vec<Arc<dyn disk::DiskConfig>>,
     guest_os_kind: GuestOsKind,
     server_toml_path: PathBuf,
 }

--- a/phd-tests/runner/src/config.rs
+++ b/phd-tests/runner/src/config.rs
@@ -43,6 +43,10 @@ pub struct RunOptions {
     #[clap(long, value_parser)]
     pub propolis_server_cmd: PathBuf,
 
+    /// The command to use to launch Crucible downstairs servers.
+    #[clap(long, value_parser)]
+    pub crucible_downstairs_cmd: Option<PathBuf>,
+
     /// The directory into which to write temporary files (config TOMLs, log
     /// files, etc.) generated during test execution.
     #[clap(long, value_parser)]

--- a/phd-tests/runner/src/main.rs
+++ b/phd-tests/runner/src/main.rs
@@ -77,6 +77,9 @@ fn run_tests(run_opts: &RunOptions) -> ExecutionStats {
         disk_factory: phd_framework::disk::DiskFactory::new(
             &run_opts.tmp_directory,
             &artifact_store,
+            run_opts.crucible_downstairs_cmd.clone().as_ref(),
+            &port_allocator,
+            run_opts.server_logging_mode,
         ),
     };
     let fixtures = TestFixtures::new(&artifact_store, &ctx).unwrap();

--- a/phd-tests/testcase/src/lib.rs
+++ b/phd-tests/testcase/src/lib.rs
@@ -5,7 +5,7 @@ pub use phd_testcase_macros::*;
 use thiserror::Error;
 
 use phd_framework::{
-    disk::{DiskBackend, DiskFactory, DiskSource},
+    disk::{DiskFactory, DiskSource},
     test_vm::{factory::VmFactory, vm_config::ConfigRequest},
 };
 
@@ -44,10 +44,9 @@ impl TestContext<'_> {
     pub fn default_vm_config(&self) -> ConfigRequest {
         let boot_disk = self
             .disk_factory
-            .create_disk(
-                DiskSource::Artifact(&self.default_guest_image_artifact),
-                DiskBackend::File,
-            )
+            .create_file_backed_disk(DiskSource::Artifact(
+                &self.default_guest_image_artifact,
+            ))
             .unwrap();
         self.vm_factory.deviceless_vm_config().set_boot_disk(
             boot_disk,

--- a/phd-tests/tests/src/crucible/mod.rs
+++ b/phd-tests/tests/src/crucible/mod.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+
+use phd_testcase::{
+    phd_framework::disk::{
+        crucible::CrucibleDisk, BlockSize, DiskError, DiskSource,
+    },
+    phd_skip, TestContext,
+};
+
+mod smoke;
+
+/// Attempts to create a Crucible disk with the specified parameters. If the
+/// runner did not specify a Crucible downstairs path, produces the special
+/// "test skipped" error status for the caller to return.
+fn create_disk_or_skip(
+    ctx: &TestContext,
+    source: DiskSource,
+    disk_size_gib: u64,
+    block_size: BlockSize,
+) -> phd_testcase::Result<Arc<CrucibleDisk>> {
+    let disk = ctx.disk_factory.create_crucible_disk(
+        source,
+        disk_size_gib,
+        block_size,
+    );
+
+    if let Err(DiskError::NoCrucibleDownstairsPath) = disk {
+        phd_skip!("Crucible binary not specified, can't create crucible disk");
+    }
+
+    Ok(disk?)
+}
+
+/// Creates a boot disk of the supplied size using the default guest image
+/// artifact and a 512-byte block size. Returns the special "test skipped" error
+/// status if Crucible is not enabled for this test run (see
+/// [`create_disk_or_skip`]).
+fn create_default_boot_disk(
+    ctx: &TestContext,
+    disk_size_gib: u64,
+) -> phd_testcase::Result<Arc<CrucibleDisk>> {
+    create_disk_or_skip(
+        ctx,
+        DiskSource::Artifact(&ctx.default_guest_image_artifact),
+        disk_size_gib,
+        BlockSize::Bytes512,
+    )
+}

--- a/phd-tests/tests/src/crucible/smoke.rs
+++ b/phd-tests/tests/src/crucible/smoke.rs
@@ -1,4 +1,7 @@
+use std::time::Duration;
+
 use phd_testcase::{phd_framework::test_vm::vm_config::DiskInterface, *};
+use propolis_client::handmade::api::InstanceState;
 
 #[phd_testcase]
 fn boot_test(ctx: &TestContext) {
@@ -12,4 +15,47 @@ fn boot_test(ctx: &TestContext) {
     let mut vm = ctx.vm_factory.new_vm("crucible_boot_test", config)?;
     vm.launch()?;
     vm.wait_to_boot()?;
+}
+
+#[phd_testcase]
+fn shutdown_persistence_test(ctx: &TestContext) {
+    let disk = super::create_default_boot_disk(ctx, 10)?;
+    disk.set_generation(1);
+    let config = ctx.deviceless_vm_config().set_boot_disk(
+        disk.clone(),
+        4,
+        DiskInterface::Nvme,
+    );
+
+    let mut vm =
+        ctx.vm_factory.new_vm("crucible_shutdown_persistence_test", config)?;
+    vm.launch()?;
+    vm.wait_to_boot()?;
+
+    // Verify that the test file doesn't exist yet, then touch it, flush it, and
+    // shut down the VM.
+    let lsout = vm.run_shell_command("ls foo.bar 2> /dev/null")?;
+    assert_eq!(lsout, "");
+    vm.run_shell_command("touch ./foo.bar")?;
+    vm.run_shell_command("sync ./foo.bar")?;
+    vm.stop()?;
+    vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))?;
+
+    // Increment the disk's generation before attaching it to a new VM.
+    disk.set_generation(2);
+    let config = ctx.deviceless_vm_config().set_boot_disk(
+        disk.clone(),
+        4,
+        DiskInterface::Nvme,
+    );
+
+    // The touched file from the previous VM should be present in the new one.
+    let mut vm = ctx
+        .vm_factory
+        .new_vm("crucible_shutdown_persistence_test_2", config)?;
+
+    vm.launch()?;
+    vm.wait_to_boot()?;
+    let lsout = vm.run_shell_command("ls foo.bar 2> /dev/null")?;
+    assert_eq!(lsout, "foo.bar");
 }

--- a/phd-tests/tests/src/crucible/smoke.rs
+++ b/phd-tests/tests/src/crucible/smoke.rs
@@ -29,6 +29,13 @@ fn shutdown_persistence_test(ctx: &TestContext) {
 
     let mut vm =
         ctx.vm_factory.new_vm("crucible_shutdown_persistence_test", config)?;
+    if vm.guest_os_has_read_only_fs() {
+        phd_skip!(
+            "Can't run data persistence test on a guest with a read-only file
+             system"
+        );
+    }
+
     vm.launch()?;
     vm.wait_to_boot()?;
 

--- a/phd-tests/tests/src/crucible/smoke.rs
+++ b/phd-tests/tests/src/crucible/smoke.rs
@@ -1,0 +1,15 @@
+use phd_testcase::{phd_framework::test_vm::vm_config::DiskInterface, *};
+
+#[phd_testcase]
+fn boot_test(ctx: &TestContext) {
+    let disk = super::create_default_boot_disk(ctx, 10)?;
+    let config = ctx.deviceless_vm_config().set_boot_disk(
+        disk.clone(),
+        4,
+        DiskInterface::Nvme,
+    );
+
+    let mut vm = ctx.vm_factory.new_vm("crucible_boot_test", config)?;
+    vm.launch()?;
+    vm.wait_to_boot()?;
+}

--- a/phd-tests/tests/src/lib.rs
+++ b/phd-tests/tests/src/lib.rs
@@ -1,5 +1,6 @@
 pub use phd_testcase;
 
+mod crucible;
 mod migrate;
 mod server_state_machine;
 mod smoke;

--- a/phd-tests/tests/src/smoke.rs
+++ b/phd-tests/tests/src/smoke.rs
@@ -1,8 +1,5 @@
 use phd_testcase::{
-    phd_framework::{
-        disk::{DiskBackend, DiskSource},
-        test_vm::vm_config::DiskInterface,
-    },
+    phd_framework::{disk::DiskSource, test_vm::vm_config::DiskInterface},
     *,
 };
 
@@ -20,9 +17,8 @@ fn nproc_test(ctx: &TestContext) {
 
 #[phd_testcase]
 fn instance_spec_get_test(ctx: &TestContext) {
-    let disk = ctx.disk_factory.create_disk(
+    let disk = ctx.disk_factory.create_file_backed_disk(
         DiskSource::Artifact(&ctx.default_guest_image_artifact),
-        DiskBackend::File,
     )?;
 
     let config = ctx


### PR DESCRIPTION
Allow PHD to launch Crucible downstairs processes and use these to serve disks to guest VMs. Add a couple of basic Crucible tests.

To use the new tests, PHD needs to be given a `--crucible-downstairs-cmd` argument that points to the `crucible-downstairs` binary to use. Because I haven't yet worked out how best to manage this in Buildomat, the Crucible tests mark themselves as skipped if no such binary is specified.

Other small changes in this PR:

- When a test creates a disk, it used to get an opaque `Arc<GuestDisk>` that it could then pass back into the VM factory to attach the disk to a VM. This PR changes the model so that tests get a concrete disk type (`FileBackedDisk` or `CrucibleDisk`) instead. This is useful because Crucible tests need to access the concrete type to e.g. change the disk's generation number between uses (and is cleaner than the alternative of adding functions to `GuestDisk` that try to cast its interior disk pointer to a `CrucibleDisk` trait object).

Future work:

- This should be enough framework code to set up a Crucible live migration test once #155 is fixed.
- With this change we now have three crates in the repo that separately import `crucible-client-types`. It's important that Propolis, PHD, and the Crucible binary under test agree on what Crucible revision to use, or things will go sideways quickly. To try to make this easier, I'm tempted to convert this dependency (and propolis-lib's `crucible` dependency) to workspace-level dependencies, but I will do that in a separate PR since it has some blast radius outside the scope of PHD (e.g. increasing the MSRV to Rust 1.64).