### PR TITLE
Update crucible version

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -292,13 +292,12 @@ impl<'a> MachineInitializer<'a> {
                 })?;
             let StorageBackendInstance { be: backend, child, crucible } =
                 match &backend_spec.kind {
-                    StorageBackendKind::Crucible { gen, req } => {
+                    StorageBackendKind::Crucible { req } => {
                         info!(
                             self.log,
                             "Creating Crucible disk from request {:?}", req
                         );
                         let be = propolis::block::CrucibleBackend::create(
-                            *gen,
                             req.clone(),
                             backend_spec.readonly,
                             self.producer_registry.clone(),

--- a/bin/propolis-server/src/lib/spec.rs
+++ b/bin/propolis-server/src/lib/spec.rs
@@ -224,7 +224,6 @@ impl ServerSpecBuilder {
         let backend_name = disk.name.clone();
         let backend_spec = StorageBackend {
             kind: StorageBackendKind::Crucible {
-                gen: disk.gen,
                 req: disk.volume_construction_request.clone(),
             },
             readonly: disk.read_only,
@@ -472,7 +471,6 @@ mod test {
                 slot: Slot(0),
                 read_only: true,
                 device: "nvme".to_string(),
-                gen: 0,
                 volume_construction_request: VolumeConstructionRequest::File {
                     id: Uuid::new_v4(),
                     block_size: 512,
@@ -487,7 +485,6 @@ mod test {
                     slot: Slot(0),
                     read_only: true,
                     device: "virtio".to_string(),
-                    gen: 0,
                     volume_construction_request:
                         VolumeConstructionRequest::File {
                             id: Uuid::new_v4(),
@@ -527,7 +524,6 @@ mod test {
                     slot: Slot(0),
                     read_only: true,
                     device: "virtio-scsi".to_string(),
-                    gen: 0,
                     volume_construction_request:
                         VolumeConstructionRequest::File {
                             id: Uuid::new_v4(),

--- a/lib/propolis-client/Cargo.toml
+++ b/lib/propolis-client/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1.0", features = [ "net" ], optional = true }
 
 [dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "00c1de9b165e8abff1eed6e26a5755465785fc07"
+rev = "861a09c350fd0e127b6105c8099e31a0bc3b711a"
 
 [features]
 default = []

--- a/lib/propolis-client/src/handmade/api.rs
+++ b/lib/propolis-client/src/handmade/api.rs
@@ -239,7 +239,6 @@ pub struct DiskRequest {
     pub device: String,
 
     // Crucible related opts
-    pub gen: u64,
     pub volume_construction_request:
         crucible_client_types::VolumeConstructionRequest,
 }

--- a/lib/propolis-client/src/instance_spec/backends.rs
+++ b/lib/propolis-client/src/instance_spec/backends.rs
@@ -41,9 +41,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub enum StorageBackendKind {
-    /// A Crucible-backed device, containing a generation number and a
-    /// construction request.
-    Crucible { gen: u64, req: crucible_client_types::VolumeConstructionRequest },
+    /// A Crucible-backed device, containing a construction request.
+    Crucible { req: crucible_client_types::VolumeConstructionRequest },
 
     /// A device backed by a file on the host machine. The payload is a path to
     /// this file.

--- a/lib/propolis-client/src/lib.rs
+++ b/lib/propolis-client/src/lib.rs
@@ -47,7 +47,6 @@ mod _compat_impls {
                 slot,
                 read_only,
                 device,
-                gen,
                 volume_construction_request,
             } = self;
             generated::types::DiskRequest {
@@ -55,7 +54,6 @@ mod _compat_impls {
                 slot: slot.into(),
                 read_only,
                 device,
-                gen,
                 volume_construction_request: volume_construction_request.into(),
             }
         }

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -34,12 +34,12 @@ once_cell = "1.13"
 
 [dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "00c1de9b165e8abff1eed6e26a5755465785fc07"
+rev = "861a09c350fd0e127b6105c8099e31a0bc3b711a"
 optional = true
 
 [dependencies.crucible]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "00c1de9b165e8abff1eed6e26a5755465785fc07"
+rev = "861a09c350fd0e127b6105c8099e31a0bc3b711a"
 optional = true
 
 [dependencies.oximeter]

--- a/lib/propolis/src/block/crucible.rs
+++ b/lib/propolis/src/block/crucible.rs
@@ -25,28 +25,26 @@ pub struct CrucibleBackend {
 
 impl CrucibleBackend {
     pub fn create(
-        gen: u64,
         request: VolumeConstructionRequest,
         read_only: bool,
         producer_registry: Option<ProducerRegistry>,
     ) -> io::Result<Arc<Self>> {
         let rt = tokio::runtime::Handle::current();
         rt.block_on(async move {
-            CrucibleBackend::_create(gen, request, read_only, producer_registry)
+            CrucibleBackend::_create(request, read_only, producer_registry)
                 .await
         })
         .map_err(CrucibleError::into)
     }
 
     async fn _create(
-        gen: u64,
         request: VolumeConstructionRequest,
         read_only: bool,
         producer_registry: Option<ProducerRegistry>,
     ) -> Result<Arc<Self>, crucible::CrucibleError> {
         let volume = Volume::construct(request, producer_registry).await?;
 
-        volume.activate(gen).await?;
+        volume.activate().await?;
 
         // After active negotiation, set sizes
         let block_size = volume.get_block_size().await?;

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -343,11 +343,6 @@
           "device": {
             "type": "string"
           },
-          "gen": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
           "name": {
             "type": "string"
           },
@@ -363,7 +358,6 @@
         },
         "required": [
           "device",
-          "gen",
           "name",
           "read_only",
           "slot",


### PR DESCRIPTION
This is PR 2 of N to make sure that omicron doesn't get two separate
dependencies, one for progenitor with main and one for progenitor
without main.

For PR 1, see https://github.com/oxidecomputer/crucible/pull/552.

Without this fix, omicron ends up with two separate versions of
crucible, which causes build failures in omicron.

The update caused some breakage from
https://github.com/oxidecomputer/crucible/pull/516, which I've tried to
address (cc @leftwo to confirm that my changes look good).
