### PR TITLE
Clean up clippy

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -565,7 +565,7 @@ impl<'a> MachineInitializer<'a> {
             self.log.clone(),
         )
         .map_err(|e| -> std::io::Error {
-            let io_err: std::io::Error = e.into();
+            let io_err: std::io::Error = e;
             std::io::Error::new(
                 io_err.kind(),
                 format!("register softnpu: {}", io_err),

--- a/bin/propolis-server/src/lib/spec.rs
+++ b/bin/propolis-server/src/lib/spec.rs
@@ -503,11 +503,7 @@ impl ServerSpecBuilder {
             ))
         })?;
 
-        let chunk_size: u32 = match device.get("chunk_size") {
-            Some(s) => s,
-            None => 65536,
-        };
-
+        let chunk_size: u32 = device.get("chunk_size").unwrap_or(65536);
         let pci_path: PciPath = device.get("pci-path").ok_or_else(|| {
             ServerSpecBuilderError::ConfigTomlError(format!(
                 "Failed to get PCI path for p9 device {}",

--- a/bin/propolis-server/src/lib/vm.rs
+++ b/bin/propolis-server/src/lib/vm.rs
@@ -472,6 +472,7 @@ impl ChipsetEventHandler for WorkerState {
 }
 
 impl VmController {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         instance_spec: InstanceSpec,
         properties: InstanceProperties,

--- a/bin/propolis-server/src/lib/vnc.rs
+++ b/bin/propolis-server/src/lib/vnc.rs
@@ -127,7 +127,7 @@ impl Server for PropolisVncServer {
     async fn get_framebuffer_update(&self) -> FramebufferUpdate {
         let inner = self.inner.lock().await;
 
-        let fb = match &inner.framebuffer {
+        match &inner.framebuffer {
             Framebuffer::Uninitialized(fb) => {
                 debug!(self.log, "framebuffer: uninitialized");
 
@@ -170,9 +170,7 @@ impl Server for PropolisVncServer {
                 );
                 FramebufferUpdate::new(vec![r])
             }
-        };
-
-        fb
+        }
     }
 
     async fn key_event(&self, ke: KeyEvent) {

--- a/bin/propolis-standalone/src/snapshot.rs
+++ b/bin/propolis-standalone/src/snapshot.rs
@@ -53,7 +53,7 @@ pub(crate) async fn save(
     let machine = guard.machine();
     let hdl = machine.hdl.clone();
     let memctx = machine.acc_mem.access().unwrap();
-    let migratectx = MigrateCtx { mem: &*memctx };
+    let migratectx = MigrateCtx { mem: &memctx };
     let inv = guard.inventory();
 
     info!(log, "Serializing global VM state");
@@ -286,7 +286,7 @@ pub(crate) async fn restore(
 
     // Finally, let's restore the device state
     let inv = guard.inventory();
-    let migratectx = MigrateCtx { mem: &*memctx };
+    let migratectx = MigrateCtx { mem: &memctx };
     let devices: Vec<(String, Vec<u8>)> =
         serde_json::from_slice(&device_states)
             .context("Failed to deserialize device state")?;

--- a/crates/dladm/src/lib.rs
+++ b/crates/dladm/src/lib.rs
@@ -66,7 +66,7 @@ impl Handle {
         // dladm show-linkprop -c -o value -p mtu <NIC_NAME>
         // 1500
         let output = Command::new("dladm")
-            .args(&["show-linkprop", "-c", "-o", "value", "-p", "mtu"])
+            .args(["show-linkprop", "-c", "-o", "value", "-p", "mtu"])
             .arg(name)
             .stderr(Stdio::null())
             .stdin(Stdio::null())
@@ -86,7 +86,7 @@ impl Handle {
         // dladm show-vnic -p -o macaddress <VNIC_NAME>
         // 2:8:20:2d:e9:24
         let output = Command::new("dladm")
-            .args(&["show-vnic", "-p", "-o", "macaddress"])
+            .args(["show-vnic", "-p", "-o", "macaddress"])
             .arg(name)
             .stderr(Stdio::null())
             .stdin(Stdio::null())

--- a/crates/propolis-server-config/src/lib.rs
+++ b/crates/propolis-server-config/src/lib.rs
@@ -65,7 +65,7 @@ impl Chipset {
 }
 
 /// A PCI-PCI bridge.
-#[derive(Default, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct PciBridge {
     /// The bus/device/function of this bridge as a device in the PCI topology.
     #[serde(rename = "pci-path")]

--- a/lib/propolis-client/src/handmade/api.rs
+++ b/lib/propolis-client/src/handmade/api.rs
@@ -142,7 +142,9 @@ pub enum InstanceStateRequested {
 }
 
 /// Current state of an Instance.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize, JsonSchema,
+)]
 pub enum InstanceState {
     Creating,
     Starting,
@@ -156,7 +158,7 @@ pub enum InstanceState {
     Destroyed,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, JsonSchema)]
 pub struct InstanceProperties {
     /// Unique identifier for this Instance.
     pub id: Uuid,

--- a/lib/propolis-client/src/instance_spec/builder.rs
+++ b/lib/propolis-client/src/instance_spec/builder.rs
@@ -197,7 +197,7 @@ impl SpecBuilder {
         );
         assert!(_old.is_none());
         if self.spec.devices.softnpu_ports.insert(key, port.clone()).is_some() {
-            Err(SpecBuilderError::SoftNpuPortInUse(port.name.clone()))
+            Err(SpecBuilderError::SoftNpuPortInUse(port.name))
         } else {
             Ok(self)
         }

--- a/lib/propolis-client/src/instance_spec/mod.rs
+++ b/lib/propolis-client/src/instance_spec/mod.rs
@@ -465,7 +465,7 @@ mod test {
             pci_path: PciPath::new(1, 2, 3).unwrap(),
         };
 
-        let mut b2 = b1.clone();
+        let mut b2 = b1;
         assert!(b1.can_migrate_from_element(&b2).is_ok());
 
         b2.downstream_bus += 1;

--- a/lib/propolis-client/src/lib.rs
+++ b/lib/propolis-client/src/lib.rs
@@ -38,16 +38,16 @@ pub use types as api;
 mod _compat_impls {
     use super::{generated, handmade};
 
-    impl Into<generated::types::DiskRequest> for handmade::api::DiskRequest {
-        fn into(self) -> generated::types::DiskRequest {
-            let Self {
+    impl From<handmade::api::DiskRequest> for generated::types::DiskRequest {
+        fn from(req: handmade::api::DiskRequest) -> Self {
+            let handmade::api::DiskRequest {
                 name,
                 slot,
                 read_only,
                 device,
                 volume_construction_request,
-            } = self;
-            generated::types::DiskRequest {
+            } = req;
+            Self {
                 name,
                 slot: slot.into(),
                 read_only,
@@ -57,9 +57,9 @@ mod _compat_impls {
         }
     }
 
-    impl Into<generated::types::Slot> for handmade::api::Slot {
-        fn into(self) -> generated::types::Slot {
-            generated::types::Slot(self.0)
+    impl From<handmade::api::Slot> for generated::types::Slot {
+        fn from(slot: handmade::api::Slot) -> Self {
+            Self(slot.0)
         }
     }
 }

--- a/lib/propolis/src/hw/virtio/p9fs.rs
+++ b/lib/propolis/src/hw/virtio/p9fs.rs
@@ -332,10 +332,7 @@ impl HostFSHandler {
         let metadata = match file.metadata() {
             Ok(m) => m,
             Err(e) => {
-                let ecode = match e.raw_os_error() {
-                    Some(ecode) => ecode,
-                    None => 0,
-                };
+                let ecode = e.raw_os_error().unwrap_or(0);
                 warn!(
                     self.log,
                     "read: metadata for {:?}: {:?}", &fid.pathbuf, e,
@@ -354,10 +351,7 @@ impl HostFSHandler {
 
         match file.seek(std::io::SeekFrom::Start(msg.offset)) {
             Err(e) => {
-                let ecode = match e.raw_os_error() {
-                    Some(ecode) => ecode,
-                    None => 0,
-                };
+                let ecode = e.raw_os_error().unwrap_or(0);
                 warn!(self.log, "read: seek: {:?}: {:?}", &fid.pathbuf, e,);
                 return write_error(ecode as u32, chain, mem);
             }
@@ -378,10 +372,7 @@ impl HostFSHandler {
 
         match file.read_exact(content.as_mut_slice()) {
             Err(e) => {
-                let ecode = match e.raw_os_error() {
-                    Some(ecode) => ecode,
-                    None => 0,
-                };
+                let ecode = e.raw_os_error().unwrap_or(0);
                 warn!(self.log, "read: exact: {:?}: {:?}", &fid.pathbuf, e,);
                 return write_error(ecode as u32, chain, mem);
             }
@@ -445,10 +436,7 @@ impl HostFSHandler {
         let metadata = match fs::metadata(&fid.pathbuf) {
             Ok(m) => m,
             Err(e) => {
-                let ecode = match e.raw_os_error() {
-                    Some(ecode) => ecode,
-                    None => 0,
-                };
+                let ecode = e.raw_os_error().unwrap_or(0);
                 return write_error(ecode as u32, chain, mem);
             }
         };
@@ -597,10 +585,7 @@ impl P9Handler for HostFSHandler {
         // grab inode number for qid uniqe file id
         let qpath = match fs::metadata(&self.source) {
             Err(e) => {
-                let ecode = match e.raw_os_error() {
-                    Some(ecode) => ecode,
-                    None => 0,
-                };
+                let ecode = e.raw_os_error().unwrap_or(0);
                 return write_error(ecode as u32, chain, mem);
             }
             Ok(m) => m.ino(),
@@ -669,10 +654,7 @@ impl P9Handler for HostFSHandler {
                     // check that new path is a thing
                     let (ino, qt) = match fs::metadata(&newpath) {
                         Err(e) => {
-                            let ecode = match e.raw_os_error() {
-                                Some(ecode) => ecode,
-                                None => 0,
-                            };
+                            let ecode = e.raw_os_error().unwrap_or(0);
                             warn!(
                                 self.log,
                                 "walk: no metadata: {:?}: {:?}", newpath, e
@@ -735,10 +717,7 @@ impl P9Handler for HostFSHandler {
                 // check that fid path is a thing
                 let (ino, qt) = match fs::metadata(&fid.pathbuf) {
                     Err(e) => {
-                        let ecode = match e.raw_os_error() {
-                            Some(ecode) => ecode,
-                            None => 0,
-                        };
+                        let ecode = e.raw_os_error().unwrap_or(0);
                         warn!(
                             self.log,
                             "open: no metadata: {:?}: {:?}", &fid.pathbuf, e
@@ -763,10 +742,7 @@ impl P9Handler for HostFSHandler {
                     {
                         Ok(f) => f,
                         Err(e) => {
-                            let ecode = match e.raw_os_error() {
-                                Some(ecode) => ecode,
-                                None => 0,
-                            };
+                            let ecode = e.raw_os_error().unwrap_or(0);
                             warn!(
                                 self.log,
                                 "open: {:?}: {:?}", &fid.pathbuf, e
@@ -817,10 +793,7 @@ impl P9Handler for HostFSHandler {
             Ok(r) => match r.collect::<Result<Vec<fs::DirEntry>, _>>() {
                 Ok(d) => d,
                 Err(e) => {
-                    let ecode = match e.raw_os_error() {
-                        Some(ecode) => ecode,
-                        None => 0,
-                    };
+                    let ecode = e.raw_os_error().unwrap_or(0);
                     warn!(
                         self.log,
                         "readdir: collect: {:?}: {:?}", &pathbuf, e
@@ -829,10 +802,7 @@ impl P9Handler for HostFSHandler {
                 }
             },
             Err(e) => {
-                let ecode = match e.raw_os_error() {
-                    Some(ecode) => ecode,
-                    None => 0,
-                };
+                let ecode = e.raw_os_error().unwrap_or(0);
                 warn!(self.log, "readdir: {:?}: {:?}", &pathbuf, e);
                 return write_error(ecode as u32, chain, mem);
             }
@@ -844,7 +814,7 @@ impl P9Handler for HostFSHandler {
         }
 
         // need to sort to ensure consistent offsets
-        dir.sort_by(|a, b| a.path().cmp(&b.path()));
+        dir.sort_by_key(|a| a.path());
 
         let mut space_left = msize as usize
             - size_of::<u32>()          // Rreaddir.size
@@ -859,10 +829,7 @@ impl P9Handler for HostFSHandler {
             let metadata = match de.metadata() {
                 Ok(m) => m,
                 Err(e) => {
-                    let ecode = match e.raw_os_error() {
-                        Some(ecode) => ecode,
-                        None => 0,
-                    };
+                    let ecode = e.raw_os_error().unwrap_or(0);
                     warn!(
                         self.log,
                         "readdir: metadata: {:?}: {:?}",

--- a/lib/propolis/src/vmm/machine.rs
+++ b/lib/propolis/src/vmm/machine.rs
@@ -146,7 +146,7 @@ impl Machine {
 
             bus_mmio,
             bus_pio,
-            kernel_devs: KernelVmmDevs::new(hdl.clone()),
+            kernel_devs: KernelVmmDevs::new(hdl),
 
             destroyed: AtomicBool::new(false),
         })

--- a/packaging/propolis-package/src/main.rs
+++ b/packaging/propolis-package/src/main.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<()> {
         omicron_zone_package::config::parse("packaging/package-manifest.toml")?;
 
     let output_dir = Path::new("out");
-    create_dir_all(&output_dir)?;
+    create_dir_all(output_dir)?;
 
     for package in cfg.packages.values() {
         package.create(output_dir).await?;

--- a/phd-tests/framework/src/artifacts.rs
+++ b/phd-tests/framework/src/artifacts.rs
@@ -317,7 +317,7 @@ impl ArtifactStore {
         }
 
         all_ok
-            .then(|| ())
+            .then_some(())
             .ok_or_else(|| ArtifactStoreError::ArtifactContentsInvalid().into())
     }
 }

--- a/phd-tests/framework/src/disk/crucible.rs
+++ b/phd-tests/framework/src/disk/crucible.rs
@@ -78,6 +78,7 @@ pub struct CrucibleDisk {
 impl CrucibleDisk {
     /// Constructs a new Crucible disk that stores its files in the supplied
     /// `data_dir`.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         disk_size_gib: u64,
         block_size: BlockSize,
@@ -160,9 +161,7 @@ impl CrucibleDisk {
         // Spawn the downstairs processes that will serve requests from guest
         // VMs.
         let mut downstairs_instances = vec![];
-        for (port, dir) in
-            downstairs_ports.into_iter().zip(data_dirs.into_iter())
-        {
+        for (port, dir) in downstairs_ports.iter().zip(data_dirs.into_iter()) {
             let addr = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), *port);
             let dir_arg = dir.path.to_string_lossy();
             let crucible_args = [
@@ -273,7 +272,7 @@ fn run_crucible_downstairs(
     stderr: impl Into<Stdio>,
 ) -> anyhow::Result<std::process::Child> {
     info!(?args, "Running crucible-downstairs");
-    let process_handle = std::process::Command::new(&binary_path)
+    let process_handle = std::process::Command::new(binary_path)
         .args(args)
         .stdout(stdout)
         .stderr(stderr)

--- a/phd-tests/framework/src/disk/file.rs
+++ b/phd-tests/framework/src/disk/file.rs
@@ -35,7 +35,7 @@ impl FileBackedDisk {
             "Copying source image to create temporary disk",
         );
 
-        std::fs::copy(&artifact_path, &disk_path)?;
+        std::fs::copy(artifact_path, &disk_path)?;
 
         // Make sure the disk is writable (the artifact may have been
         // read-only).

--- a/phd-tests/framework/src/disk/mod.rs
+++ b/phd-tests/framework/src/disk/mod.rs
@@ -192,7 +192,7 @@ impl DiskFactory<'_> {
         let binary_path = self
             .crucible_downstairs_binary
             .as_ref()
-            .ok_or_else(|| DiskError::NoCrucibleDownstairsPath)?;
+            .ok_or(DiskError::NoCrucibleDownstairsPath)?;
 
         let DiskSource::Artifact(artifact_name) = source;
         let (artifact_path, guest_os) =

--- a/phd-tests/framework/src/host_api/kvm.rs
+++ b/phd-tests/framework/src/host_api/kvm.rs
@@ -284,10 +284,11 @@ impl<T: SizedKernelGlobal> Drop for KernelValueGuard<T> {
         // this guard, so unless something has gone terribly wrong, it should be
         // possible to look up the same symbol and restore its old value.
         let va = find_symbol_va(&self.kvm_hdl, self.symbol)
-            .expect(format!("couldn't find symbol {}", self.symbol).as_str());
-        self.old_value.write_to_va(&self.kvm_hdl, va).expect(
-            format!("couldn't reset value of {}", self.symbol).as_str(),
-        );
+            .unwrap_or_else(|_| panic!("couldn't find symbol {}", self.symbol));
+
+        self.old_value.write_to_va(&self.kvm_hdl, va).unwrap_or_else(|_| {
+            panic!("couldn't reset value of {}", self.symbol)
+        });
     }
 }
 

--- a/phd-tests/framework/src/port_allocator.rs
+++ b/phd-tests/framework/src/port_allocator.rs
@@ -36,7 +36,7 @@ impl PortAllocator {
 
         let port = self.next.fetch_add(1, Ordering::Relaxed);
         if port >= self.range.end {
-            return Err(PortAllocatorError::NoMorePorts);
+            Err(PortAllocatorError::NoMorePorts)
         } else {
             Ok(port)
         }

--- a/phd-tests/framework/src/test_vm/vm_config.rs
+++ b/phd-tests/framework/src/test_vm/vm_config.rs
@@ -112,7 +112,7 @@ impl ConfigRequest {
             disk_request
                 .disk
                 .guest_os()
-                .ok_or_else(|| VmConfigError::BootDiskNotGuestImage)?
+                .ok_or(VmConfigError::BootDiskNotGuestImage)?
         } else {
             return Err(VmConfigError::NoBootDisk.into());
         };

--- a/phd-tests/tests/src/crucible/smoke.rs
+++ b/phd-tests/tests/src/crucible/smoke.rs
@@ -6,11 +6,8 @@ use propolis_client::handmade::api::InstanceState;
 #[phd_testcase]
 fn boot_test(ctx: &TestContext) {
     let disk = super::create_default_boot_disk(ctx, 10)?;
-    let config = ctx.deviceless_vm_config().set_boot_disk(
-        disk.clone(),
-        4,
-        DiskInterface::Nvme,
-    );
+    let config =
+        ctx.deviceless_vm_config().set_boot_disk(disk, 4, DiskInterface::Nvme);
 
     let mut vm = ctx.vm_factory.new_vm("crucible_boot_test", config)?;
     vm.launch()?;
@@ -50,11 +47,8 @@ fn shutdown_persistence_test(ctx: &TestContext) {
 
     // Increment the disk's generation before attaching it to a new VM.
     disk.set_generation(2);
-    let config = ctx.deviceless_vm_config().set_boot_disk(
-        disk.clone(),
-        4,
-        DiskInterface::Nvme,
-    );
+    let config =
+        ctx.deviceless_vm_config().set_boot_disk(disk, 4, DiskInterface::Nvme);
 
     // The touched file from the previous VM should be present in the new one.
     let mut vm = ctx


### PR DESCRIPTION
Today I learned that my Neovim rust-analyzer configuration has been busted for months without my consciously noticing. Celebrate fixing it (which gets clippy warnings to show up in my diagnostics pane) by clippy-cleaning the repo.