### PR TITLE
Store serial console history from instance boot.

### DIFF
--- a/bin/propolis-server/src/lib/serial/history_buffer.rs
+++ b/bin/propolis-server/src/lib/serial/history_buffer.rs
@@ -1,0 +1,213 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Maintains a buffer of an instance's serial console data, holding both the
+//! first mebibyte and the most recent mebibyte of console output.
+
+use std::collections::VecDeque;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Requested byte offset is no longer cached: {0}")]
+    ExpiredRange(usize),
+}
+
+const TTY_BUFFER_SIZE: usize = 1024 * 1024;
+const DEFAULT_MAX_LENGTH: isize = 16 * 1024;
+
+/// An abstraction for storing the contents of the instance's serial console
+/// output, intended for retrieval by the web console or other monitoring or
+/// troubleshooting tools.
+pub(crate) struct HistoryBuffer {
+    beginning: Vec<u8>,
+    rolling: VecDeque<u8>,
+    total_bytes: usize,
+}
+
+#[derive(Copy, Clone)]
+pub(crate) enum SerialHistoryOffset {
+    /// The byte index since instance start.
+    FromStart(usize),
+    /// The byte index *backwards* from the most recently buffered data.
+    MostRecent(usize),
+}
+
+impl Default for HistoryBuffer {
+    fn default() -> Self {
+        Self::new(TTY_BUFFER_SIZE)
+    }
+}
+
+impl HistoryBuffer {
+    pub fn new(buffer_size: usize) -> Self {
+        HistoryBuffer {
+            beginning: Vec::with_capacity(buffer_size),
+            rolling: VecDeque::with_capacity(buffer_size),
+            total_bytes: 0,
+        }
+    }
+
+    /// Feeds the buffer new bytes from the serial console.
+    pub fn consume(&mut self, data: &[u8]) {
+        let rolling_len = self.rolling.len();
+        let headroom = self.rolling.capacity() - rolling_len;
+        let read_size = data.len();
+        if read_size > headroom {
+            let to_capture = self.beginning.capacity() - self.beginning.len();
+            let drain = self
+                .rolling
+                .drain(0..rolling_len.min(read_size - headroom))
+                .take(to_capture);
+            self.beginning.extend(drain);
+        }
+        self.rolling.extend(data);
+        self.total_bytes += read_size;
+    }
+
+    /// Returns a tuple containing:
+    /// - an iterator of serial console bytes from the live buffer.
+    /// - the absolute byte index since instance start at which the iterator *begins*.
+    pub fn contents_iter(
+        &self,
+        byte_offset: SerialHistoryOffset,
+    ) -> Result<(Box<dyn Iterator<Item = u8> + '_>, usize), Error> {
+        let (from_start, from_end) =
+            self.offsets_from_start_and_end(byte_offset);
+
+        // determine whether we should pull from beginning or rolling (or if we're straddling both)
+        if self.total_bytes == self.rolling.len() + self.beginning.len() {
+            // still contiguous
+            Ok((
+                Box::new(
+                    self.beginning
+                        .iter()
+                        .chain(self.rolling.iter())
+                        .skip(from_start)
+                        .copied(),
+                ),
+                from_start,
+            ))
+        } else if from_start < self.beginning.len() {
+            // requesting from beginning buffer
+            Ok((
+                Box::new(self.beginning.iter().copied().skip(from_start)),
+                from_start,
+            ))
+        } else if from_end < self.rolling.len() {
+            // (apologies to Takenobu Mitsuyoshi)
+            let rolling_start = self.rolling.len() - from_end as usize;
+            Ok((
+                Box::new(self.rolling.iter().copied().skip(rolling_start)),
+                from_start,
+            ))
+        } else {
+            Err(Error::ExpiredRange(from_start))
+        }
+    }
+
+    /// Returns a tuple containing:
+    /// - a `Vec` of the requested range of serial console bytes from the live buffer.
+    /// - the absolute byte index since instance start at which the `Vec<u8>` *ends*.
+    /// given a `byte_offset` indicating the index from which the returned `Vec<u8>` should start,
+    /// and a `max_bytes` parameter, specifying a maximum length for the returned `Vec<u8>`, which
+    /// will be `DEFAULT_MAX_LENGTH` if left unspecified.
+    pub fn contents_vec(
+        &self,
+        byte_offset: SerialHistoryOffset,
+        max_bytes: Option<usize>,
+    ) -> Result<(Vec<u8>, usize), Error> {
+        let (iter, from_start) = self.contents_iter(byte_offset)?;
+        let data: Vec<u8> = iter
+            .take(max_bytes.unwrap_or(DEFAULT_MAX_LENGTH as usize))
+            .collect();
+        let end_offset = from_start + data.len();
+        Ok((data, end_offset))
+    }
+
+    fn offsets_from_start_and_end(
+        &self,
+        byte_offset: SerialHistoryOffset,
+    ) -> (usize, usize) {
+        match byte_offset {
+            SerialHistoryOffset::FromStart(offset) => {
+                if self.total_bytes > offset {
+                    (offset, self.total_bytes - offset)
+                } else {
+                    // if asking for a byte offset we haven't reached yet, just start from the end.
+                    (self.total_bytes, 0)
+                }
+            }
+            SerialHistoryOffset::MostRecent(offset) => {
+                if self.total_bytes > offset {
+                    (self.total_bytes - offset, offset)
+                } else {
+                    // if asking for the most recent N > total_bytes, just start from the beginning.
+                    (0, self.total_bytes)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use SerialHistoryOffset::*;
+
+    // for more legible assertions
+    fn sugar(
+        buf: &HistoryBuffer,
+        byte_offset: SerialHistoryOffset,
+        max_bytes: usize,
+    ) -> (String, usize) {
+        buf.contents_vec(byte_offset, Some(max_bytes))
+            .map(|x| (String::from_utf8(x.0).expect("invalid utf-8"), x.1))
+            .expect("serial range query failed")
+    }
+
+    #[test]
+    fn test_continuous_buffer_range_abstraction() {
+        let mut buf = HistoryBuffer::new(16);
+
+        assert_eq!(buf.contents_vec(FromStart(0), None).unwrap(), (vec![], 0));
+        assert_eq!(sugar(&buf, FromStart(0), 0), (String::new(), 0));
+        assert_eq!(sugar(&buf, FromStart(0), 11), (String::new(), 0));
+        assert_eq!(sugar(&buf, FromStart(11), 0), (String::new(), 0));
+        assert_eq!(sugar(&buf, FromStart(11), 11), (String::new(), 0));
+
+        let line = "This is an example of text.";
+        let line_bytes = line.as_bytes().to_vec();
+
+        buf.consume(&Vec::from(&line_bytes[..9]));
+        assert_eq!(sugar(&buf, FromStart(8), 5), ("a".to_string(), 9));
+        buf.consume(&Vec::from(&line_bytes[9..]));
+
+        assert_eq!(
+            buf.contents_vec(FromStart(0), None).unwrap(),
+            (line_bytes, line.len())
+        );
+        assert_eq!(
+            sugar(&buf, FromStart(0), line.len() + 10),
+            (line.to_string(), line.len())
+        );
+        assert_eq!(sugar(&buf, FromStart(8), 5), ("an ex".to_string(), 13));
+        assert_eq!(
+            sugar(&buf, FromStart(100), 10),
+            (String::new(), line.len())
+        );
+        assert_eq!(sugar(&buf, MostRecent(10), 4), ("e of".to_string(), 21));
+        assert_eq!(
+            sugar(&buf, MostRecent(10), 400),
+            ("e of text.".to_string(), line.len())
+        );
+        assert_eq!(sugar(&buf, MostRecent(100), 4), ("This".to_string(), 4));
+
+        buf.consume(&"\nNo thing beside remains.".as_bytes().to_vec());
+        assert_eq!(sugar(&buf, MostRecent(10), 4), ("e re".to_string(), 46));
+        assert_eq!(sugar(&buf, FromStart(8), 8), ("an examp".to_string(), 16));
+        assert_eq!(sugar(&buf, FromStart(8), 12), ("an examp".to_string(), 16));
+
+        assert!(buf.contents_vec(FromStart(16), None).is_err());
+    }
+}

--- a/lib/propolis-client/src/handmade/api.rs
+++ b/lib/propolis-client/src/handmade/api.rs
@@ -186,6 +186,49 @@ pub struct Instance {
     pub nics: Vec<NetworkInterface>,
 }
 
+/// Request a specific range of an Instance's serial console output history.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct InstanceSerialConsoleHistoryRequest {
+    /// Character index in the serial buffer from which to read, counting the bytes output since
+    /// instance start. If this is not provided, `most_recent` must be provided, and if this *is*
+    /// provided, `most_recent` must *not* be provided.
+    pub from_start: Option<u64>,
+    /// Character index in the serial buffer from which to read, counting *backward* from the most
+    /// recently buffered data retrieved from the instance. (See note on `from_start` about mutual
+    /// exclusivity)
+    pub most_recent: Option<u64>,
+    /// Maximum number of bytes of buffered serial console contents to return. If the requested
+    /// range runs to the end of the available buffer, the data returned will be shorter than
+    /// `max_bytes`.
+    pub max_bytes: Option<u64>,
+}
+
+/// Contents of an Instance's serial console buffer.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct InstanceSerialConsoleHistoryResponse {
+    /// The bytes starting from the requested offset up to either the end of the buffer or the
+    /// request's `max_bytes`. Provided as a u8 array rather than a string, as it may not be UTF-8.
+    pub data: Vec<u8>,
+    /// The absolute offset since boot (suitable for use as `byte_offset` in a subsequent request)
+    /// of the last byte returned in `data`.
+    pub last_byte_offset: u64,
+}
+
+/// Connect to an Instance's serial console via websocket, optionally sending
+/// bytes from the buffered history first.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct InstanceSerialConsoleStreamRequest {
+    /// Character index in the serial buffer from which to read, counting the bytes output since
+    /// instance start. If this is provided, `most_recent` must *not* be provided.
+    // TODO: if neither is specified, send enough serial buffer history to reconstruct
+    //  the current contents and cursor state of an interactive terminal
+    pub from_start: Option<u64>,
+    /// Character index in the serial buffer from which to read, counting *backward* from the most
+    /// recently buffered data retrieved from the instance. (See note on `from_start` about mutual
+    /// exclusivity)
+    pub most_recent: Option<u64>,
+}
+
 /// Describes how to connect to one or more storage agent services.
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
 pub struct StorageAgentDescription {

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -148,6 +148,30 @@
     "/instance/serial": {
       "get": {
         "operationId": "instance_serial",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "from_start",
+            "description": "Character index in the serial buffer from which to read, counting the bytes output since instance start. If this is provided, `most_recent` must *not* be provided.",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "query",
+            "name": "most_recent",
+            "description": "Character index in the serial buffer from which to read, counting *backward* from the most recently buffered data retrieved from the instance. (See note on `from_start` about mutual exclusivity)",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            }
+          }
+        ],
         "responses": {
           "default": {
             "description": "",
@@ -159,6 +183,64 @@
           }
         },
         "x-dropshot-websocket": {}
+      }
+    },
+    "/instance/serial/history": {
+      "get": {
+        "operationId": "instance_serial_history_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "from_start",
+            "description": "Character index in the serial buffer from which to read, counting the bytes output since instance start. If this is not provided, `most_recent` must be provided, and if this *is* provided, `most_recent` must *not* be provided.",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "query",
+            "name": "max_bytes",
+            "description": "Maximum number of bytes of buffered serial console contents to return. If the requested range runs to the end of the available buffer, the data returned will be shorter than `max_bytes`.",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            }
+          },
+          {
+            "in": "query",
+            "name": "most_recent",
+            "description": "Character index in the serial buffer from which to read, counting *backward* from the most recently buffered data retrieved from the instance. (See note on `from_start` about mutual exclusivity)",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstanceSerialConsoleHistoryResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
       }
     },
     "/instance/spec": {
@@ -750,6 +832,31 @@
           "memory",
           "name",
           "vcpus"
+        ]
+      },
+      "InstanceSerialConsoleHistoryResponse": {
+        "description": "Contents of an Instance's serial console buffer.",
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "The bytes starting from the requested offset up to either the end of the buffer or the request's `max_bytes`. Provided as a u8 array rather than a string, as it may not be UTF-8.",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            }
+          },
+          "last_byte_offset": {
+            "description": "The absolute offset since boot (suitable for use as `byte_offset` in a subsequent request) of the last byte returned in `data`.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "data",
+          "last_byte_offset"
         ]
       },
       "InstanceSpec": {


### PR DESCRIPTION
This change moves functionality from omicron's sled-agent into propolis-server to allow both querying serial console output history by byte range in GET requests, as well as allowing websocket clients to receive a backlog of stored data upon connecting, starting from any offset relative to either the first or the most recently outputted byte.

(This works with the existing implementation in omicron/sled-agent; the merge to remove its then-redundant copy should follow this one - https://github.com/oxidecomputer/omicron/pull/2022)

((~~[This failure in my unit test](https://github.com/oxidecomputer/propolis/actions/runs/3637686749/jobs/6139336587) seems to only happen on nightly - will try to figure out why tomorrow...~~ Fixed! Only was happening on nightlies new enough to be broken on Illumos per the rustix/nix `isatty` issue we ran into the other day. Seems to have originated from https://github.com/rust-lang/rust/commit/a1bf25e2bdbebad2f1f42118ba1d2c4a7ae4f7b0 changing how `VecDeque::drain` handles slices, if anyone's curious!))