### PR TITLE
Make Entity::start fallible

### DIFF
--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -264,7 +264,10 @@ impl Instance {
             match state {
                 State::Run => {
                     if first_boot {
-                        ent.start();
+                        ent.start().expect(&format!(
+                            "entity {} failed to start",
+                            record.name()
+                        ));
                     } else {
                         ent.resume();
                     }

--- a/lib/propolis/src/block/crucible.rs
+++ b/lib/propolis/src/block/crucible.rs
@@ -136,8 +136,9 @@ impl Entity for CrucibleBackend {
     // TODO(#155): Move Crucible activation here. Also, this entity probably
     // needs its own pause/resume routines akin to those in the other block
     // backends.
-    fn start(&self) {
+    fn start(&self) -> anyhow::Result<()> {
         self.scheduler.start();
+        Ok(())
     }
     fn pause(&self) {
         self.scheduler.pause();

--- a/lib/propolis/src/block/file.rs
+++ b/lib/propolis/src/block/file.rs
@@ -134,8 +134,9 @@ impl Entity for FileBackend {
     fn type_name(&self) -> &'static str {
         "block-file"
     }
-    fn start(&self) {
+    fn start(&self) -> anyhow::Result<()> {
         self.driver.start();
+        Ok(())
     }
     fn pause(&self) {
         self.driver.pause();

--- a/lib/propolis/src/block/in_memory.rs
+++ b/lib/propolis/src/block/in_memory.rs
@@ -133,8 +133,9 @@ impl Entity for InMemoryBackend {
     fn type_name(&self) -> &'static str {
         "block-in-memory"
     }
-    fn start(&self) {
+    fn start(&self) -> anyhow::Result<()> {
         self.driver.start();
+        Ok(())
     }
     fn pause(&self) {
         self.driver.pause();

--- a/lib/propolis/src/hw/chipset/i440fx.rs
+++ b/lib/propolis/src/hw/chipset/i440fx.rs
@@ -939,8 +939,9 @@ impl Entity for Piix3PM {
         // If the machine was reset
         self.ensure_pmtmr_located();
     }
-    fn start(&self) {
+    fn start(&self) -> anyhow::Result<()> {
         self.ensure_pmtmr_located();
+        Ok(())
     }
     fn migrate(&self) -> Migrator {
         Migrator::Custom(self)

--- a/lib/propolis/src/hw/virtio/softnpu.rs
+++ b/lib/propolis/src/hw/virtio/softnpu.rs
@@ -261,10 +261,10 @@ impl Entity for SoftNpu {
         "softnpu"
     }
 
-    fn start(&self) {
+    fn start(&self) -> anyhow::Result<()> {
         let mut booted = self.booted.lock().unwrap();
         if *booted {
-            return;
+            return Ok(());
         }
         self.run_management_handler_thread();
         for i in 0..self.pci_port.data_handles.len() {
@@ -278,7 +278,8 @@ impl Entity for SoftNpu {
                 self.log.clone(),
             );
         }
-        *booted = true
+        *booted = true;
+        Ok(())
     }
 
     fn migrate(&'_ self) -> Migrator<'_> {

--- a/lib/propolis/src/hw/virtio/viona.rs
+++ b/lib/propolis/src/hw/virtio/viona.rs
@@ -286,10 +286,11 @@ impl Entity for PciVirtioViona {
     fn reset(&self) {
         self.virtio_state.reset(self);
     }
-    fn start(&self) {
+    fn start(&self) -> anyhow::Result<()> {
         // This entity initializes into a paused state. Starting it is
         // equivalent to resuming it.
         self.resume();
+        Ok(())
     }
     fn pause(&self) {
         self.poller_stop(false);

--- a/lib/propolis/src/inventory.rs
+++ b/lib/propolis/src/inventory.rs
@@ -548,14 +548,16 @@ pub trait Entity: Send + Sync + 'static {
         Box::pin(future::ready(()))
     }
 
-    /// Called when first servicing the guest after initializing an instance.
-    /// After this returns, the callee entity should be ready to do work on the
-    /// guest's behalf.
+    /// Called when an instance is about to begin running, just before any
+    /// vCPU threads are started. After this returns, the callee entity should
+    /// be ready to do work on the guest's behalf.
     ///
     /// Note that this is only called the first time an instance begins running.
     /// If it reboots, the entity will observe a paused -> reset -> resumed
     /// transition instead.
-    fn start(&self) {}
+    fn start(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
 
     /// Directs this entity to pause. A paused entity must stop producing work
     /// for other entities, but must accept (and hold onto) new work from other


### PR DESCRIPTION
This is a prerequisite to moving Crucible activation, which can fail, to the Crucible backend's `start` callout.