### PR TITLE
Add multiple-migration test case

### DIFF
--- a/phd-tests/tests/src/migrate.rs
+++ b/phd-tests/tests/src/migrate.rs
@@ -47,3 +47,26 @@ fn incompatible_vms(ctx: &TestContext) {
         assert!(target.migrate_from(&source, Duration::from_secs(60)).is_err());
     }
 }
+
+#[phd_testcase]
+fn multiple_migrations(ctx: &TestContext) {
+    let mut vm0 = ctx
+        .vm_factory
+        .new_vm("multiple_migrations_0", ctx.default_vm_config())?;
+    let mut vm1 = ctx
+        .vm_factory
+        .new_vm_from_cloned_config("multiple_migrations_1", &vm0)?;
+    let mut vm2 = ctx
+        .vm_factory
+        .new_vm_from_cloned_config("multiple_migrations_2", &vm1)?;
+
+    vm0.launch()?;
+    vm0.wait_to_boot()?;
+    vm1.migrate_from(&vm0, Duration::from_secs(60))?;
+    assert_eq!(vm1.run_shell_command("echo Hello world")?, "Hello world");
+    vm2.migrate_from(&vm1, Duration::from_secs(60))?;
+    assert_eq!(
+        vm2.run_shell_command("echo I have migrated!")?,
+        "I have migrated!"
+    );
+}


### PR DESCRIPTION
Enabling dirty tracking appears to be enough to get pages that are copied during migration to be marked dirty by a migration destination, such that they'll be copied again if that destination migrates someplace else. Write an integration test that demonstrates as much.

Closes #232.