### PR TITLE
Wait until instance drop to publish InstanceState::Destroyed

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -65,7 +65,7 @@ pub fn build_instance(
     spec: &InstanceSpec,
     use_reservoir: bool,
     _log: slog::Logger,
-) -> Result<Arc<Instance>> {
+) -> Result<Instance> {
     let (lowmem, highmem) = get_spec_guest_ram_limits(spec);
     let create_opts = propolis::vmm::CreateOpts {
         force: true,
@@ -87,7 +87,7 @@ pub fn build_instance(
         builder = builder.add_mem_region(0x1_0000_0000, highmem, "highmem")?;
     }
 
-    Ok(Arc::new(Instance::create(builder.finalize()?)))
+    Ok(Instance::create(builder.finalize()?))
 }
 
 pub struct RegisteredChipset(Arc<I440Fx>, EntityID);

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -28,7 +28,7 @@ use tokio_tungstenite::tungstenite::protocol::{Role, WebSocketConfig};
 use tokio_tungstenite::WebSocketStream;
 
 use crate::spec::{ServerSpecBuilder, ServerSpecBuilderError};
-use crate::vm::{InstanceProvider, VmController};
+use crate::vm::VmController;
 use crate::vnc::PropolisVncServer;
 
 pub(crate) type CrucibleBackendMap =
@@ -436,11 +436,7 @@ async fn instance_ensure_common(
         // framebuffer, and PS2 controller.
         vnc_server
             .server
-            .initialize(
-                vnc_fb,
-                Arc::clone(ps2ctrl),
-                vm.clone() as Arc<dyn InstanceProvider>,
-            )
+            .initialize(vnc_fb, Arc::clone(ps2ctrl), vm.clone())
             .await;
 
         // Hook up the framebuffer notifier to update the Propolis VNC adapter

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -28,7 +28,7 @@ use tokio_tungstenite::tungstenite::protocol::{Role, WebSocketConfig};
 use tokio_tungstenite::WebSocketStream;
 
 use crate::spec::{ServerSpecBuilder, ServerSpecBuilderError};
-use crate::vm::VmController;
+use crate::vm::{InstanceProvider, VmController};
 use crate::vnc::PropolisVncServer;
 
 pub(crate) type CrucibleBackendMap =
@@ -120,19 +120,21 @@ impl VmControllerState {
     /// `VmControllerState::Destroyed`.
     pub fn take_controller(&mut self) -> Option<Arc<VmController>> {
         if let VmControllerState::Created(vm) = self {
+            let state = vm.state_watcher().borrow().state;
             let last_instance = api::Instance {
                 properties: vm.properties().clone(),
-                state: api::InstanceState::Destroyed,
+                state,
                 disks: vec![],
                 nics: vec![],
             };
-
             let last_instance_spec = vm.instance_spec().clone();
 
-            // The server is about to drop its reference to the controller, but
-            // the controller may continue changing state while it tears itself
-            // down. Grab a clone of the state watcher channel for subsequent
-            // calls to `instance_state_monitor` to use.
+            // Preserve the state watcher so that subsequent updates to the VM's
+            // state are visible to calls to query/monitor that state. Note that
+            // the VM's state will change at least once more after this point:
+            // the final transition to the "destroyed" state happens only when
+            // all references to the VM have been dropped, including the one
+            // this routine just exchanged and will return.
             let watcher = vm.state_watcher().clone();
             if let VmControllerState::Created(vm) = std::mem::replace(
                 self,
@@ -184,10 +186,9 @@ impl ServiceProviders {
         self.vnc_server.stop().await;
 
         if let Some(vm) = self.vm.lock().await.take_controller() {
-            slog::info!(log, "Dropping instance";
+            slog::info!(log, "Dropping server's VM controller reference";
                 "strong_refs" => Arc::strong_count(&vm),
                 "weak_refs" => Arc::weak_count(&vm),
-                "instance_refs" => Arc::strong_count(vm.instance()),
             );
         }
         if let Some(serial_task) = self.serial_task.lock().await.take() {
@@ -435,7 +436,11 @@ async fn instance_ensure_common(
         // framebuffer, and PS2 controller.
         vnc_server
             .server
-            .initialize(vnc_fb, Arc::clone(ps2ctrl), Arc::clone(vm.instance()))
+            .initialize(
+                vnc_fb,
+                Arc::clone(ps2ctrl),
+                vm.clone() as Arc<dyn InstanceProvider>,
+            )
             .await;
 
         // Hook up the framebuffer notifier to update the Propolis VNC adapter
@@ -544,8 +549,13 @@ async fn instance_get_common(
         VmControllerState::Destroyed {
             last_instance,
             last_instance_spec,
-            ..
-        } => Ok((last_instance.clone(), *last_instance_spec.clone())),
+            watcher,
+        } => {
+            let watcher = watcher.borrow();
+            let mut last_instance = last_instance.clone();
+            last_instance.state = watcher.state;
+            Ok((last_instance, *last_instance_spec.clone()))
+        }
     }
 }
 

--- a/bin/propolis-server/src/lib/vm.rs
+++ b/bin/propolis-server/src/lib/vm.rs
@@ -135,10 +135,6 @@ impl From<VmControllerError> for dropshot::HttpError {
     }
 }
 
-pub trait InstanceProvider: Send + Sync {
-    fn get(&self) -> &Instance;
-}
-
 /// A collection of objects that describe an instance and references to that
 /// instance and its components.
 pub(crate) struct VmObjects {
@@ -1457,12 +1453,6 @@ impl VmController {
             let pause_futures = devices.iter().map(|ent| ent.paused());
             futures::future::join_all(pause_futures).await;
         });
-    }
-}
-
-impl InstanceProvider for VmController {
-    fn get(&self) -> &Instance {
-        self.instance()
     }
 }
 

--- a/bin/propolis-server/src/lib/vm.rs
+++ b/bin/propolis-server/src/lib/vm.rs
@@ -135,11 +135,15 @@ impl From<VmControllerError> for dropshot::HttpError {
     }
 }
 
+pub trait InstanceProvider: Send + Sync {
+    fn get(&self) -> &Instance;
+}
+
 /// A collection of objects that describe an instance and references to that
 /// instance and its components.
 pub(crate) struct VmObjects {
     /// The underlying Propolis `Instance` this controller is managing.
-    instance: Arc<Instance>,
+    instance: Option<Instance>,
 
     /// The instance properties supplied when this controller was created.
     properties: InstanceProperties,
@@ -350,20 +354,6 @@ impl WorkerStateInner {
     }
 }
 
-impl Drop for WorkerStateInner {
-    fn drop(&mut self) {
-        // Send a final state monitor message indicating that the instance is
-        // destroyed. Normally, the existence of this structure implies the
-        // instance of at least one receiver, but at this point everything is
-        // being dropped, so this call to `send` is not safe to unwrap.
-        let gen = self.api_state.borrow().gen + 1;
-        let _ = self.api_state.send(ApiMonitoredState {
-            gen,
-            state: ApiInstanceState::Destroyed,
-        });
-    }
-}
-
 impl WorkerStateInner {
     fn new(watch: tokio::sync::watch::Sender<ApiMonitoredState>) -> Self {
         Self {
@@ -548,7 +538,7 @@ impl VmController {
         // The instance is fully set up; pass it to the new controller.
         let controller = Arc::new_cyclic(|this| Self {
             vm_objects: VmObjects {
-                instance,
+                instance: Some(instance),
                 properties,
                 spec: instance_spec,
                 com1,
@@ -587,8 +577,13 @@ impl VmController {
         &self.vm_objects.properties
     }
 
-    pub fn instance(&self) -> &Arc<Instance> {
-        &self.vm_objects.instance
+    pub fn instance(&self) -> &Instance {
+        // Unwrap safety: The instance is created when the controller is created
+        // and removed only when the controller is dropped.
+        self.vm_objects
+            .instance
+            .as_ref()
+            .expect("VM controller always has a valid instance")
     }
 
     pub fn instance_spec(&self) -> &InstanceSpec {
@@ -1118,7 +1113,7 @@ impl VmController {
         // then reset the vCPUs. The vCPU reset must come after the
         // bhyve reset.
         self.reset_entities(log);
-        self.vm_objects.instance.lock().machine().reinitialize().unwrap();
+        self.instance().lock().machine().reinitialize().unwrap();
         self.reset_vcpus(vcpu_tasks, log);
 
         // Resume entities so they're ready to do more work, then
@@ -1359,7 +1354,7 @@ impl VmController {
 
     fn reset_vcpus(&self, vcpu_tasks: &VcpuTasks, log: &Logger) {
         vcpu_tasks.new_generation();
-        for vcpu in self.vm_objects.instance.lock().machine().vcpus.iter() {
+        for vcpu in self.instance().lock().machine().vcpus.iter() {
             info!(log, "Resetting vCPU {}", vcpu.id);
             vcpu.activate().unwrap();
             vcpu.reboot_state().unwrap();
@@ -1429,7 +1424,7 @@ impl VmController {
             &propolis::inventory::Record,
         ) -> anyhow::Result<()>,
     {
-        self.vm_objects.instance.lock().inventory().for_each_node(
+        self.instance().lock().inventory().for_each_node(
             propolis::inventory::Order::Pre,
             |_eid, record| -> Result<(), anyhow::Error> {
                 let ent = record.entity();
@@ -1442,8 +1437,7 @@ impl VmController {
         info!(log, "Waiting for all entities to pause");
         self.runtime_hdl.block_on(async {
             let mut devices = vec![];
-            self.vm_objects
-                .instance
+            self.instance()
                 .lock()
                 .inventory()
                 .for_each_node(
@@ -1462,6 +1456,35 @@ impl VmController {
 
             let pause_futures = devices.iter().map(|ent| ent.paused());
             futures::future::join_all(pause_futures).await;
+        });
+    }
+}
+
+impl InstanceProvider for VmController {
+    fn get(&self) -> &Instance {
+        self.instance()
+    }
+}
+
+impl Drop for VmController {
+    fn drop(&mut self) {
+        info!(self.log, "Dropping VM controller");
+        let instance = self
+            .vm_objects
+            .instance
+            .take()
+            .expect("VM controller should have an instance at drop");
+        drop(instance);
+
+        // Send a final state monitor message indicating that the instance is
+        // destroyed. Normally, the existence of this structure implies the
+        // instance of at least one receiver, but at this point everything is
+        // being dropped, so this call to `send` is not safe to unwrap.
+        let api_state = &self.worker_state.inner.lock().unwrap().api_state;
+        let gen = api_state.borrow().gen + 1;
+        let _ = api_state.send(ApiMonitoredState {
+            gen,
+            state: ApiInstanceState::Destroyed,
         });
     }
 }

--- a/bin/propolis-server/src/lib/vnc.rs
+++ b/bin/propolis-server/src/lib/vnc.rs
@@ -2,7 +2,6 @@ use async_trait::async_trait;
 use propolis::common::GuestAddr;
 use propolis::hw::ps2::ctrl::PS2Ctrl;
 use propolis::hw::qemu::ramfb::{Config, FramebufferSpec};
-use propolis::Instance;
 use rfb::encodings::RawEncoding;
 use rfb::pixel_formats::fourcc;
 use rfb::rfb::{
@@ -14,6 +13,8 @@ use slog::{debug, error, info, o, trace, Logger};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+
+use crate::vm::InstanceProvider;
 
 const INITIAL_WIDTH: u16 = 1024;
 const INITIAL_HEIGHT: u16 = 768;
@@ -50,7 +51,7 @@ enum Framebuffer {
 struct PropolisVncServerInner {
     framebuffer: Framebuffer,
     ps2ctrl: Option<Arc<PS2Ctrl>>,
-    instance: Option<Arc<Instance>>,
+    instance: Option<Arc<dyn InstanceProvider>>,
 }
 
 #[derive(Clone)]
@@ -78,7 +79,7 @@ impl PropolisVncServer {
         &self,
         fb: RamFb,
         ps2ctrl: Arc<PS2Ctrl>,
-        instance: Arc<Instance>,
+        instance: Arc<dyn InstanceProvider>,
     ) {
         let mut inner = self.inner.lock().await;
         inner.framebuffer = Framebuffer::Initialized(fb);
@@ -152,7 +153,7 @@ impl Server for PropolisVncServer {
 
                 let read = tokio::task::block_in_place(|| {
                     let instance_guard =
-                        inner.instance.as_ref().unwrap().lock();
+                        inner.instance.as_ref().unwrap().get().lock();
                     let memctx =
                         instance_guard.machine().acc_mem.access().unwrap();
                     memctx.read_into(GuestAddr(fb.addr), &mut buf, len)

--- a/bin/propolis-server/src/lib/vnc.rs
+++ b/bin/propolis-server/src/lib/vnc.rs
@@ -79,12 +79,12 @@ impl PropolisVncServer {
         &self,
         fb: RamFb,
         ps2ctrl: Arc<PS2Ctrl>,
-        instance: Arc<VmController>,
+        vm: Arc<VmController>,
     ) {
         let mut inner = self.inner.lock().await;
         inner.framebuffer = Framebuffer::Initialized(fb);
         inner.ps2ctrl = Some(ps2ctrl);
-        inner.vm = Some(instance);
+        inner.vm = Some(vm);
     }
 
     pub async fn update(


### PR DESCRIPTION
Ensure that instance get and monitor operations don't return an instance state of "Destroyed" until the relevant instance has been dropped and its bhyve VM handles are closed. To do that:

- Rearrange the VM controller so that it is the sole owner of an `Instance` that users can borrow, instead of allowing users to get their own references directly to the instance
- Publish the "Destroyed" state transition during `VmController` drop (when the instance is really going away) instead of when the state worker exits
- Fix `VmControllerState::take_controller` so that state queries for a stopped instance return what the VM controller most recently published instead of always returning Destroyed

Tested by running ~15 PHD iterations locally and verifying that no VMM handles were leaked.

Fixes #270 (hopefully).