### PR TITLE
SoftNpu early return on empty guest virtio buffers, bump dlpi crate, fix duplicate crate import issue

### DIFF
--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -264,10 +264,9 @@ impl Instance {
             match state {
                 State::Run => {
                     if first_boot {
-                        ent.start().expect(&format!(
-                            "entity {} failed to start",
-                            record.name()
-                        ));
+                        ent.start().unwrap_or_else(|_| {
+                            panic!("entity {} failed to start", record.name())
+                        });
                     } else {
                         ent.resume();
                     }

--- a/crates/bhyve-api/header-check/Cargo.toml
+++ b/crates/bhyve-api/header-check/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Patrick Mooney <pmooney@oxide.computer>"]
 license = "MPL-2.0"
 build = "build.rs"
+publish = false
 
 [dependencies]
 bhyve_api = { path = ".." }

--- a/crates/viona-api/header-check/Cargo.toml
+++ b/crates/viona-api/header-check/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Patrick Mooney <pmooney@oxide.computer>"]
 license = "MPL-2.0"
 build = "build.rs"
+publish = false
 
 [dependencies]
 viona_api = { path = ".." }

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -65,10 +65,9 @@ branch = "main"
 optional = true
 package = "softnpu"
 
-#see: https://github.com/oxidecomputer/dlpi-sys/issues/1
 [dependencies.dlpi]
 git = "https://github.com/oxidecomputer/dlpi-sys"
-rev = "eb4dffeef88f86294d939aeb5521509ea3d59b69"
+branch = "main"
 optional = true
 
 [dev-dependencies]

--- a/lib/propolis/src/hw/virtio/softnpu.rs
+++ b/lib/propolis/src/hw/virtio/softnpu.rs
@@ -330,6 +330,8 @@ impl PciVirtioSoftNpuPort {
             if n != 10 {
                 if n > 0 {
                     push_used = true;
+                } else {
+                    break;
                 }
                 warn!(self.log, "failed to read virtio mystery bytes ({})", n);
                 //break;


### PR DESCRIPTION
### SoftNpu early return on empty buffers
Break out of the guest packet processing loop early when there are no bytes to read. This has a non-trivial impact on latency reduction.

### Bump dlpi
Bump the dlpi dependency. The latest version is less chatty with logging and the bug previously referenced is no longer an issue since we are not using the async API exported by the dlpi create.

### Fix import issue
Set `publish = false` on the header check libraries. When importing propolis libraries, because both `viona-api` and `bhyve-api` have a sub-crate called `header-check`, cargo starts screaming. This is working around this [issue](https://github.com/rust-lang/cargo/issues/10752) with this [fix](https://github.com/rust-lang/cargo/pull/10767)

### Other
The changes in propolis-standalone are in response to clippy complaints.