### PR TITLE
Defer Crucible activation to Crucible start

### DIFF
--- a/lib/propolis-client/Cargo.toml
+++ b/lib/propolis-client/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1.0", features = [ "net" ], optional = true }
 
 [dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "861a09c350fd0e127b6105c8099e31a0bc3b711a"
+rev = "5966aab7b1bb024d620d349230a58bcc558f9ffb"
 
 [features]
 default = []

--- a/lib/propolis-client/src/instance_spec/openapi_impls.rs
+++ b/lib/propolis-client/src/instance_spec/openapi_impls.rs
@@ -195,9 +195,19 @@ impl From<CrucibleVCR> for GenVCR {
             CrucibleVCR::Url { id, block_size, url } => {
                 GenVCR::Url { id, block_size, url }
             }
-            CrucibleVCR::Region { block_size, opts, gen } => {
-                GenVCR::Region { block_size, opts: opts.into(), gen }
-            }
+            CrucibleVCR::Region {
+                block_size,
+                blocks_per_extent,
+                extent_count,
+                opts,
+                gen,
+            } => GenVCR::Region {
+                block_size,
+                blocks_per_extent,
+                extent_count,
+                opts: opts.into(),
+                gen,
+            },
             CrucibleVCR::File { id, block_size, path } => {
                 GenVCR::File { id, block_size, path }
             }

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -40,12 +40,12 @@ rand = { version = "0.8", optional = true }
 
 [dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "861a09c350fd0e127b6105c8099e31a0bc3b711a"
+rev = "5966aab7b1bb024d620d349230a58bcc558f9ffb"
 optional = true
 
 [dependencies.crucible]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "861a09c350fd0e127b6105c8099e31a0bc3b711a"
+rev = "5966aab7b1bb024d620d349230a58bcc558f9ffb"
 optional = true
 
 [dependencies.oximeter]

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -1317,6 +1317,16 @@
                 "format": "uint64",
                 "minimum": 0
               },
+              "blocks_per_extent": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              },
+              "extent_count": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
               "gen": {
                 "type": "integer",
                 "format": "uint64",
@@ -1334,6 +1344,8 @@
             },
             "required": [
               "block_size",
+              "blocks_per_extent",
+              "extent_count",
               "gen",
               "opts",
               "type"

--- a/phd-tests/framework/Cargo.toml
+++ b/phd-tests/framework/Cargo.toml
@@ -38,4 +38,4 @@ base64 = "0.13.1"
 
 [dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "861a09c350fd0e127b6105c8099e31a0bc3b711a"
+rev = "5966aab7b1bb024d620d349230a58bcc558f9ffb"

--- a/phd-tests/framework/src/disk/crucible.rs
+++ b/phd-tests/framework/src/disk/crucible.rs
@@ -58,6 +58,12 @@ pub struct CrucibleDisk {
     /// The disk's block size.
     block_size: BlockSize,
 
+    /// The number of blocks in this disk's region's extents.
+    blocks_per_extent: u64,
+
+    /// The number of extents in each of the disk's regions.
+    extent_count: u32,
+
     /// The collection of downstairs process wrappers for this disk.
     downstairs_instances: Vec<Downstairs>,
 
@@ -121,7 +127,6 @@ impl CrucibleDisk {
                 "--data",
                 dir_arg.as_ref(),
                 "--encrypted",
-                "true",
                 "--uuid",
                 &disk_uuid.to_string(),
                 "--extent-size",
@@ -197,6 +202,8 @@ impl CrucibleDisk {
         Ok(Self {
             id: disk_uuid,
             block_size,
+            blocks_per_extent,
+            extent_count: extents_in_disk as u32,
             downstairs_instances,
             read_only_parent: read_only_parent
                 .map(|p| p.as_ref().to_path_buf()),
@@ -231,6 +238,8 @@ impl super::DiskConfig for CrucibleDisk {
                         block_size: self.block_size.bytes(),
                         sub_volumes: vec![VolumeConstructionRequest::Region {
                             block_size: self.block_size.bytes(),
+                            blocks_per_extent: self.blocks_per_extent,
+                            extent_count: self.extent_count,
                             opts: CrucibleOpts {
                                 id: Uuid::new_v4(),
                                 target: downstairs_addrs,


### PR DESCRIPTION
Move to the latest Crucible revision to pick up [e3a29afc](https://github.com/oxidecomputer/crucible/commit/e3a29afc7de634578888ab94cdfd125804ac16ba). With that change, `CrucibleBackend::_create` no longer needs to activate to get block sizes, so defer activation to the `start` callout instead.

Tested using manual runs of PHD's `crucible::migrate::load_test`, which fails consistently without this change and passes consistently with it.

Fixes #155.