### PR TITLE
server: Pause entities before halting them

### DIFF
--- a/bin/propolis-server/src/lib/vm.rs
+++ b/bin/propolis-server/src/lib/vm.rs
@@ -1132,6 +1132,12 @@ impl VmController {
         let next_external = Some(ApiInstanceState::Stopped);
         let next_lifecycle = Some(LifecycleStage::NoLongerActive);
         drop(inner);
+
+        // Force vCPUs and entities to quiesce before sending the halt message.
+        vcpu_tasks.pause_all();
+        self.pause_entities(log);
+        self.wait_for_entities_to_pause(log);
+
         vcpu_tasks.exit_all();
         self.halt_entities(log);
         (next_external, next_lifecycle)

--- a/lib/propolis/src/inventory.rs
+++ b/lib/propolis/src/inventory.rs
@@ -584,9 +584,9 @@ pub trait Entity: Send + Sync + 'static {
     fn reset(&self) {}
 
     /// Indicates that the entity's instance is stopping and will soon be
-    /// discarded. The entity should complete any in-flight requests and release
-    /// any references or resources it needs to release to ensure the instance
-    /// is fully destroyed.
+    /// discarded.
+    ///
+    /// N.B. The state driver ensures this is called only on paused entities.
     fn halt(&self) {}
 
     /// Return the Migrator object that will be used to export/import


### PR DESCRIPTION
Some entities assume they'll be explicitly paused before being halted. Standalone does this but server does not. Change server to match this behavior and document it more explicitly.

Tested with an ad hoc PHD test that creates a Crucible disk, starts a bunch of I/O, stops the VM, and then tries to reach its Propolis process. Without this fix, Propolis panics every 2-3 iterations; with the fix we can launch and stop 10 VMs with no Propolis crashes.

Fixes #258. Note that that bug discussed the possibility of adding a `PauseReason` enum that indicates to entities whether they're being paused for migration or paused because the VM is halting. I applied YAGNI and didn't implement that in this PR, but I can file an enhancement issue to track that work if we want (or we can just wait until we have an entity that we're sure will distinguish between reasons).
