### PR TITLE
Pause before halting entities, this time with feeling

### DIFF
--- a/bin/propolis-server/src/lib/vcpu_tasks.rs
+++ b/bin/propolis-server/src/lib/vcpu_tasks.rs
@@ -36,7 +36,7 @@ pub trait VcpuEventHandler: Send + Sync {
 impl VcpuTasks {
     pub(crate) fn new(
         instance: propolis::instance::InstanceGuard,
-        event_handler: Arc<super::vm::WorkerState>,
+        event_handler: Arc<super::vm::SharedVmState>,
         log: slog::Logger,
     ) -> Result<Self, VcpuTaskError> {
         let generation = Arc::new(AtomicUsize::new(0));
@@ -94,7 +94,7 @@ impl VcpuTasks {
     fn vcpu_loop(
         vcpu: &Vcpu,
         task: propolis::tasks::TaskHdl,
-        event_handler: Arc<super::vm::WorkerState>,
+        event_handler: Arc<super::vm::SharedVmState>,
         generation: Arc<AtomicUsize>,
         log: slog::Logger,
     ) {

--- a/lib/propolis/src/inventory.rs
+++ b/lib/propolis/src/inventory.rs
@@ -584,9 +584,10 @@ pub trait Entity: Send + Sync + 'static {
     fn reset(&self) {}
 
     /// Indicates that the entity's instance is stopping and will soon be
-    /// discarded. The entity should complete any in-flight requests and release
-    /// any references or resources it needs to release to ensure the instance
-    /// is fully destroyed.
+    /// discarded. The entity should requests and release any references or
+    /// resources it needs to release to ensure the instance is fully destroyed.
+    ///
+    /// N.B. The state driver ensures this is called only on paused entities.
     fn halt(&self) {}
 
     /// Return the Migrator object that will be used to export/import


### PR DESCRIPTION
(**Reviewer note:** this PR is best read as two separate commits: one big refactor with no functional changes followed by the actual, much smaller, bug fix.)

When stopping a VM, pause all entities before calling `halt` and telling them to shut down. This fixes a panic that occurs when an instance's MSI accessor is told to shut down while devices are still doing work that can generate interrupts.

The first attempt to fix this (#276) ran aground in migration testing: a migration source pauses and then halts, and entities don't expect to be paused twice, so unconditionally pausing while halting a migration source causes panics. Fixing this in the existing code is messy because the VM controller's state worker has no good place to store long-lived context (like whether it has previously paused entities). To fix this, refactor to create a `StateWorkerContext` struct that the state worker thread exclusively owns instead of having the worker operate only on a shared `VmController` reference. This gives the worker a place to put all its stuff and lets context flow between state worker routines by having them take `&mut self`.

Tested by running Crucible PHD tests and checking for `MsiAccessor` panics. They're generally common without this fix but don't repro with the fix.

Fixes #258. N.B.: This PR does not implement the `PauseReason` enum described in that issue (for want of anyone who would currently do anything differently with that information). We can file a separate issue if/when we need/want to add that distinction.