### PR TITLE
Update to latest crucible rev

### DIFF
--- a/lib/propolis-client/Cargo.toml
+++ b/lib/propolis-client/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1.0", features = [ "net" ], optional = true }
 
 [dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "5966aab7b1bb024d620d349230a58bcc558f9ffb"
+rev = "0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec"
 
 [features]
 default = []

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -40,12 +40,12 @@ rand = { version = "0.8", optional = true }
 
 [dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "5966aab7b1bb024d620d349230a58bcc558f9ffb"
+rev = "0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec"
 optional = true
 
 [dependencies.crucible]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "5966aab7b1bb024d620d349230a58bcc558f9ffb"
+rev = "0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec"
 optional = true
 
 [dependencies.oximeter]

--- a/phd-tests/framework/Cargo.toml
+++ b/phd-tests/framework/Cargo.toml
@@ -38,4 +38,4 @@ base64 = "0.13.1"
 
 [dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "5966aab7b1bb024d620d349230a58bcc558f9ffb"
+rev = "0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec"


### PR DESCRIPTION
There are no major Crucible changes here; this is mostly to create a Propolis commit for Omicron to use so that Omicron's direct and transitive-via-Propolis dependencies on crucible-client-types resolve to the same Crucible commit.

Tested with a local PHD run incl. Crucible tests.