### PR TITLE
"--mock" mode for propolis-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2869,6 +2869,7 @@ dependencies = [
  "bit_field",
  "bitvec",
  "bytes",
+ "cfg-if",
  "chrono",
  "clap 3.2.23",
  "const_format",

--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -43,7 +43,7 @@ serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
 slog.workspace = true
-propolis = { workspace = true, features = ["crucible-full", "oximeter"] }
+propolis.workspace = true
 propolis-client = { workspace = true, features = ["generated"] }
 propolis-server-config.workspace = true
 rfb.workspace = true
@@ -64,6 +64,7 @@ mockall.workspace = true
 version_check.workspace = true
 
 [features]
-default = ["dtrace-probes"]
+default = ["dtrace-probes", "propolis/crucible-full", "propolis/oximeter"]
 dtrace-probes = ["propolis/dtrace-probes", "dropshot/usdt-probes"]
 falcon = ["propolis/falcon"]
+mock-only = []

--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -67,4 +67,6 @@ version_check.workspace = true
 default = ["dtrace-probes", "propolis/crucible-full", "propolis/oximeter"]
 dtrace-probes = ["propolis/dtrace-probes", "dropshot/usdt-probes"]
 falcon = ["propolis/falcon"]
+# If selected, only build a mock server which does not actually spawn instances
+# (i.e. to test with a facsimile of the API on unsupported platforms)
 mock-only = []

--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -22,6 +22,7 @@ async-trait.workspace = true
 bit_field.workspace = true
 bitvec.workspace = true
 bytes.workspace = true
+cfg-if.workspace = true
 chrono = { workspace = true, features = [ "serde" ] }
 clap = { workspace = true, features = ["derive"] }
 const_format.workspace = true

--- a/bin/propolis-server/src/lib/lib.rs
+++ b/bin/propolis-server/src/lib/lib.rs
@@ -1,11 +1,21 @@
+// always present
 pub mod config;
-mod initializer;
-mod migrate;
 pub mod mock_server;
 mod serial;
-pub mod server;
+#[cfg_attr(feature = "mock-only", allow(unused))]
 mod spec;
+
+#[cfg(not(feature = "mock-only"))]
+mod initializer;
+#[cfg(not(feature = "mock-only"))]
+mod migrate;
+#[cfg(not(feature = "mock-only"))]
+pub mod server;
+#[cfg(not(feature = "mock-only"))]
 mod stats;
+#[cfg(not(feature = "mock-only"))]
 mod vcpu_tasks;
+#[cfg(not(feature = "mock-only"))]
 mod vm;
+#[cfg(not(feature = "mock-only"))]
 pub mod vnc;

--- a/bin/propolis-server/src/lib/lib.rs
+++ b/bin/propolis-server/src/lib/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 mod initializer;
 mod migrate;
+pub mod mock_server;
 mod serial;
 pub mod server;
 mod spec;

--- a/bin/propolis-server/src/lib/lib.rs
+++ b/bin/propolis-server/src/lib/lib.rs
@@ -1,21 +1,19 @@
 // always present
 pub mod config;
+#[cfg(any(test, feature = "mock-only"))]
 pub mod mock_server;
 mod serial;
 #[cfg_attr(feature = "mock-only", allow(unused))]
 mod spec;
 
-#[cfg(not(feature = "mock-only"))]
-mod initializer;
-#[cfg(not(feature = "mock-only"))]
-mod migrate;
-#[cfg(not(feature = "mock-only"))]
-pub mod server;
-#[cfg(not(feature = "mock-only"))]
-mod stats;
-#[cfg(not(feature = "mock-only"))]
-mod vcpu_tasks;
-#[cfg(not(feature = "mock-only"))]
-mod vm;
-#[cfg(not(feature = "mock-only"))]
-pub mod vnc;
+cfg_if::cfg_if! {
+    if #[cfg(not(feature = "mock-only"))] {
+        mod initializer;
+        mod migrate;
+        pub mod server;
+        mod stats;
+        mod vcpu_tasks;
+        mod vm;
+        pub mod vnc;
+    }
+}

--- a/bin/propolis-server/src/lib/mock_server.rs
+++ b/bin/propolis-server/src/lib/mock_server.rs
@@ -1,0 +1,347 @@
+//! Implementation of a mock Propolis server
+
+use dropshot::endpoint;
+use dropshot::ApiDescription;
+use dropshot::HttpError;
+use dropshot::HttpResponseCreated;
+use dropshot::HttpResponseOk;
+use dropshot::HttpResponseUpdatedNoContent;
+use dropshot::Path;
+use dropshot::RequestContext;
+use dropshot::TypedBody;
+use futures::future::Fuse;
+use futures::{FutureExt, SinkExt, StreamExt};
+use hyper::upgrade::{self, Upgraded};
+use hyper::{header, Body, Response, StatusCode};
+use slog::{error, info, o, Logger};
+use std::borrow::Cow;
+use std::io::{Error, ErrorKind};
+use std::ops::Range;
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::sync::{oneshot, watch, Mutex};
+use tokio::task::JoinHandle;
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::protocol::{CloseFrame, WebSocketConfig};
+use tokio_tungstenite::tungstenite::{
+    self, handshake, protocol::Role, Message,
+};
+use tokio_tungstenite::WebSocketStream;
+use uuid::Uuid;
+
+use propolis::bhyve_api;
+use propolis::hw::pci;
+use propolis::hw::uart::LpcUart;
+use propolis::instance::Instance;
+use propolis_client::handmade::api;
+
+use crate::config::Config;
+use crate::initializer::{build_instance, MachineInitializer};
+use crate::migrate;
+use crate::serial::Serial;
+
+/// ed instance properties
+pub struct InstanceContext {
+    pub state: propolis::instance::State,
+    pub generation: u64,
+    pub properties: api::InstanceProperties,
+    state_watcher_rx: watch::Receiver<StateChange>,
+    state_watcher_tx: watch::Sender<StateChange>,
+}
+
+impl InstanceContext {
+    pub fn new(properties: api::InstanceProperties) -> Self {
+        let (state_watcher_tx, state_watcher_rx) =
+            watch::channel(StateChange {
+                gen: 0,
+                state: propolis::instance::State::Initialize,
+            });
+        Self {
+            state: propolis::instance::State::Initialize,
+            generation: 0,
+            properties,
+            state_watcher_rx,
+            state_watcher_tx,
+        }
+    }
+
+    /// Updates the state of the mock instance.
+    ///
+    /// Returns an error if the state transition is invalid.
+    pub fn set_target_state(
+        &mut self,
+        target: propolis::instance::ReqState,
+    ) -> Result<(), propolis::instance::TransitionError> {
+        use propolis::instance::ReqState;
+        use propolis::instance::State;
+        use propolis::instance::TransitionError;
+
+        if matches!(self.state, State::Halt | State::Destroy) {
+            // Cannot request any state once the target is halt/destroy
+            return Err(TransitionError::Terminal);
+        }
+        if self.state == State::Reset && target == ReqState::Run {
+            // Requesting a run when already on the road to reboot is an
+            // immediate success.
+            return Ok(());
+        }
+        match target {
+            ReqState::Run | ReqState::Reset => {
+                self.generation += 1;
+                self.state = State::Run;
+                let result = self.state_watcher_tx.send(StateChange {
+                    gen: self.generation,
+                    state: self.state,
+                });
+                assert!(
+                    result.is_ok(),
+                    "Failed to send simulated state change update"
+                );
+            }
+            ReqState::Halt => self.state = State::Halt,
+            ReqState::StartMigrate => {
+                unimplemented!("migration not yet implemented")
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Contextual information accessible from mock HTTP callbacks.
+pub struct Context {
+    instance: Mutex<Option<InstanceContext>>,
+    _config: Config,
+    log: Logger,
+}
+
+impl Context {
+    pub fn new(config: Config, log: Logger) -> Self {
+        Context { instance: Mutex::new(None), _config: config, log }
+    }
+}
+
+#[endpoint {
+    method = PUT,
+    path = "/instances/{instance_id}",
+}]
+async fn instance_ensure(
+    rqctx: Arc<RequestContext<Context>>,
+    path_params: Path<api::InstancePathParams>,
+    request: TypedBody<api::InstanceEnsureRequest>,
+) -> Result<HttpResponseCreated<api::InstanceEnsureResponse>, HttpError> {
+    let server_context = rqctx.context();
+    let request = request.into_inner();
+    let instance_id = path_params.into_inner().instance_id;
+    let (properties, nics, disks, cloud_init_bytes) = (
+        request.properties,
+        request.nics,
+        request.disks,
+        request.cloud_init_bytes,
+    );
+    if instance_id != properties.id {
+        return Err(HttpError::for_internal_error(
+            "UUID mismatch (path did not match struct)".to_string(),
+        ));
+    }
+
+    // Handle an already-initialized instance
+    let mut instance = server_context.instance.lock().await;
+    if let Some(instance) = &*instance {
+        if instance.properties.id != instance_id {
+            return Err(HttpError::for_internal_error(format!(
+                "Server already initialized with ID {}",
+                instance.properties.id
+            )));
+        }
+        if instance.properties != properties {
+            return Err(HttpError::for_internal_error(
+                "Cannot update running server".to_string(),
+            ));
+        }
+        return Ok(HttpResponseCreated(api::InstanceEnsureResponse {
+            migrate: None,
+        }));
+    }
+
+    // Perform some basic validation of the requested properties
+    for nic in &nics {
+        info!(server_context.log, "Creating NIC: {:#?}", nic);
+        slot_to_bdf(nic.slot, SlotType::NIC).map_err(|e| {
+            let err = Error::new(
+                ErrorKind::InvalidData,
+                format!("Cannot parse vnic PCI: {}", e),
+            );
+            HttpError::for_internal_error(format!(
+                "Cannot build instance: {}",
+                err
+            ))
+        })?;
+    }
+
+    for disk in &disks {
+        info!(server_context.log, "Creating Disk: {:#?}", disk);
+        slot_to_bdf(disk.slot, SlotType::Disk).map_err(|e| {
+            let err = Error::new(
+                ErrorKind::InvalidData,
+                format!("Cannot parse disk PCI: {}", e),
+            );
+            HttpError::for_internal_error(format!(
+                "Cannot build instance: {}",
+                err
+            ))
+        })?;
+        info!(server_context.log, "Disk {} created successfully", disk.name);
+    }
+
+    if let Some(cloud_init_bytes) = &cloud_init_bytes {
+        info!(server_context.log, "Creating cloud-init disk");
+        slot_to_bdf(api::Slot(0), SlotType::CloudInit).map_err(|e| {
+            let err = Error::new(ErrorKind::InvalidData, e.to_string());
+            HttpError::for_internal_error(format!(
+                "Cannot build instance: {}",
+                err
+            ))
+        })?;
+        base64::decode(&cloud_init_bytes).map_err(|e| {
+            let err = Error::new(ErrorKind::InvalidInput, e.to_string());
+            HttpError::for_internal_error(format!(
+                "Cannot build instance: {}",
+                err
+            ))
+        })?;
+        info!(server_context.log, "cloud-init disk created");
+    }
+
+    *instance = Some(InstanceContext::new(properties));
+    Ok(HttpResponseCreated(api::InstanceEnsureResponse { migrate: None }))
+}
+
+#[endpoint {
+    method = GET,
+    path = "/instances/{instance_id}/uuid",
+    unpublished = true,
+}]
+async fn instance_get_uuid(
+    rqctx: Arc<RequestContext<Context>>,
+    path_params: Path<api::InstanceNameParams>,
+) -> Result<HttpResponseOk<Uuid>, HttpError> {
+    let instance = rqctx.context().instance.lock().await;
+    let instance = instance.as_ref().ok_or_else(|| {
+        HttpError::for_internal_error(
+            "Server not initialized (no instance)".to_string(),
+        )
+    })?;
+    if path_params.into_inner().instance_id != instance.properties.name {
+        return Err(HttpError::for_internal_error(
+            "Instance name mismatch (path did not match struct)".to_string(),
+        ));
+    }
+    Ok(HttpResponseOk(instance.properties.id))
+}
+
+#[endpoint {
+    method = GET,
+    path = "/instances/{instance_id}",
+}]
+async fn instance_get(
+    rqctx: Arc<RequestContext<Context>>,
+    path_params: Path<api::InstancePathParams>,
+) -> Result<HttpResponseOk<api::InstanceGetResponse>, HttpError> {
+    let instance = rqctx.context().instance.lock().await;
+    let instance = instance.as_ref().ok_or_else(|| {
+        HttpError::for_internal_error(
+            "Server not initialized (no instance)".to_string(),
+        )
+    })?;
+    if path_params.into_inner().instance_id != instance.properties.id {
+        return Err(HttpError::for_internal_error(
+            "UUID mismatch (path did not match struct)".to_string(),
+        ));
+    }
+    let instance_info = api::Instance {
+        properties: instance.properties.clone(),
+        state: propolis_to_api_state(instance.state),
+        disks: vec![],
+        nics: vec![],
+    };
+    Ok(HttpResponseOk(api::InstanceGetResponse { instance: instance_info }))
+}
+
+#[endpoint {
+    method = GET,
+    path = "/instances/{instance_id}/state-monitor",
+}]
+async fn instance_state_monitor(
+    rqctx: Arc<RequestContext<Context>>,
+    path_params: Path<api::InstancePathParams>,
+    request: TypedBody<api::InstanceStateMonitorRequest>,
+) -> Result<HttpResponseOk<api::InstanceStateMonitorResponse>, HttpError> {
+    let (mut state_watcher, gen) = {
+        let instance = rqctx.context().instance.lock().await;
+        let instance = instance.as_ref().ok_or_else(|| {
+            HttpError::for_internal_error(
+                "Server not initialized (no instance)".to_string(),
+            )
+        })?;
+        let path_params = path_params.into_inner();
+        if path_params.instance_id != instance.properties.id {
+            return Err(HttpError::for_internal_error(
+                "UUID mismatch (path did not match struct)".to_string(),
+            ));
+        }
+        let gen = request.into_inner().gen;
+        let state_watcher = instance.state_watcher_rx.clone();
+        (state_watcher, gen)
+    };
+
+    loop {
+        let last = state_watcher.borrow().clone();
+        if gen <= last.gen {
+            let response = api::InstanceStateMonitorResponse {
+                gen: last.gen,
+                state: propolis_to_api_state(last.state),
+            };
+            return Ok(HttpResponseOk(response));
+        }
+        state_watcher.changed().await.unwrap();
+    }
+}
+
+#[endpoint {
+    method = PUT,
+    path = "/instances/{instance_id}/state",
+}]
+async fn instance_state_put(
+    rqctx: Arc<RequestContext<Context>>,
+    path_params: Path<api::InstancePathParams>,
+    request: TypedBody<api::InstanceStateRequested>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let mut instance = rqctx.context().instance.lock().await;
+    let instance = instance.as_mut().ok_or_else(|| {
+        HttpError::for_internal_error(
+            "Server not initialized (no instance)".to_string(),
+        )
+    })?;
+    if path_params.into_inner().instance_id != instance.properties.id {
+        return Err(HttpError::for_internal_error(
+            "UUID mismatch (path did not match struct)".to_string(),
+        ));
+    }
+    let requested_state = api_to_propolis_state(request.into_inner());
+    instance.set_target_state(requested_state).map_err(|err| {
+        HttpError::for_internal_error(format!("Failed to transition: {}", err))
+    })?;
+    Ok(HttpResponseUpdatedNoContent {})
+}
+
+/// Returns a Dropshot [`ApiDescription`] object to launch a mock Propolis
+/// server.
+pub fn api() -> ApiDescription<Context> {
+    let mut api = ApiDescription::new();
+    api.register(instance_ensure).unwrap();
+    api.register(instance_get_uuid).unwrap();
+    api.register(instance_get).unwrap();
+    api.register(instance_state_monitor).unwrap();
+    api.register(instance_state_put).unwrap();
+    api
+}

--- a/bin/propolis-server/src/lib/mock_server.rs
+++ b/bin/propolis-server/src/lib/mock_server.rs
@@ -25,14 +25,6 @@ use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use tokio_tungstenite::tungstenite::{protocol::Role, Message};
 use tokio_tungstenite::WebSocketStream;
 
-#[derive(Debug, Eq, PartialEq, Error)]
-pub enum Error {
-    #[error("Failed to send simulated state change update through channel")]
-    TransitionSendFail,
-    #[error("Cannot request any new mock instance state once it is stopped/destroyed/failed")]
-    TerminalState,
-}
-
 use propolis::chardev;
 use propolis::chardev::{SinkNotifier, SourceNotifier};
 use propolis_client::handmade::api;
@@ -41,6 +33,14 @@ use crate::config::Config;
 use crate::serial::history_buffer::SerialHistoryOffset;
 use crate::serial::{Serial, SerialTask};
 use crate::spec::{slot_to_pci_path, SlotType};
+
+#[derive(Debug, Eq, PartialEq, Error)]
+pub enum Error {
+    #[error("Failed to send simulated state change update through channel")]
+    TransitionSendFail,
+    #[error("Cannot request any new mock instance state once it is stopped/destroyed/failed")]
+    TerminalState,
+}
 
 /// simulated instance properties
 pub struct InstanceContext {

--- a/bin/propolis-server/src/lib/mock_server.rs
+++ b/bin/propolis-server/src/lib/mock_server.rs
@@ -1,65 +1,96 @@
 //! Implementation of a mock Propolis server
 
+use base64::Engine;
 use dropshot::endpoint;
 use dropshot::ApiDescription;
 use dropshot::HttpError;
 use dropshot::HttpResponseCreated;
 use dropshot::HttpResponseOk;
 use dropshot::HttpResponseUpdatedNoContent;
-use dropshot::Path;
 use dropshot::RequestContext;
 use dropshot::TypedBody;
-use futures::future::Fuse;
-use futures::{FutureExt, SinkExt, StreamExt};
-use hyper::upgrade::{self, Upgraded};
-use hyper::{header, Body, Response, StatusCode};
-use slog::{error, info, o, Logger};
-use std::borrow::Cow;
-use std::io::{Error, ErrorKind};
-use std::ops::Range;
+use dropshot::WebsocketConnection;
+use dropshot::{channel, Query};
+use futures::SinkExt;
+use slog::{error, info, Logger};
+use std::collections::VecDeque;
+use std::convert::TryFrom;
+use std::hash::{Hash, Hasher};
+use std::io::{Error as IoError, ErrorKind};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use thiserror::Error;
-use tokio::sync::{oneshot, watch, Mutex};
-use tokio::task::JoinHandle;
-use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
-use tokio_tungstenite::tungstenite::protocol::{CloseFrame, WebSocketConfig};
-use tokio_tungstenite::tungstenite::{
-    self, handshake, protocol::Role, Message,
-};
+use tokio::sync::{mpsc, oneshot, watch, Mutex};
+use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
+use tokio_tungstenite::tungstenite::{protocol::Role, Message};
 use tokio_tungstenite::WebSocketStream;
-use uuid::Uuid;
 
-use propolis::bhyve_api;
-use propolis::hw::pci;
-use propolis::hw::uart::LpcUart;
-use propolis::instance::Instance;
+#[derive(Debug, Eq, PartialEq, Error)]
+pub enum Error {
+    #[error("Failed to send simulated state change update through channel")]
+    TransitionSendFail,
+    #[error("Cannot request any new mock instance state once it is stopped/destroyed/failed")]
+    TerminalState,
+}
+
+use propolis::chardev;
+use propolis::chardev::{SinkNotifier, SourceNotifier};
 use propolis_client::handmade::api;
 
 use crate::config::Config;
-use crate::initializer::{build_instance, MachineInitializer};
-use crate::migrate;
-use crate::serial::Serial;
+use crate::serial::history_buffer::SerialHistoryOffset;
+use crate::serial::{Serial, SerialTask};
+use crate::spec::{slot_to_pci_path, SlotType};
 
-/// ed instance properties
+/// simulated instance properties
 pub struct InstanceContext {
-    pub state: propolis::instance::State,
+    pub state: api::InstanceState,
     pub generation: u64,
     pub properties: api::InstanceProperties,
-    state_watcher_rx: watch::Receiver<StateChange>,
-    state_watcher_tx: watch::Sender<StateChange>,
+    serial: Arc<Serial<MockUart>>,
+    serial_task: SerialTask,
+    state_watcher_rx: watch::Receiver<api::InstanceStateMonitorResponse>,
+    state_watcher_tx: watch::Sender<api::InstanceStateMonitorResponse>,
 }
 
 impl InstanceContext {
-    pub fn new(properties: api::InstanceProperties) -> Self {
+    pub fn new(properties: api::InstanceProperties, log: &Logger) -> Self {
         let (state_watcher_tx, state_watcher_rx) =
-            watch::channel(StateChange {
+            watch::channel(api::InstanceStateMonitorResponse {
                 gen: 0,
-                state: propolis::instance::State::Initialize,
+                state: api::InstanceState::Creating,
             });
+        let mock_uart = Arc::new(MockUart::new(&properties.name));
+        let sink_size = NonZeroUsize::new(64).unwrap();
+        let source_size = NonZeroUsize::new(1024).unwrap();
+        let serial = Arc::new(Serial::new(mock_uart, sink_size, source_size));
+        let serial_clone = serial.clone();
+
+        let (websocks_ch, websocks_recv) = mpsc::channel(1);
+        let (close_ch, close_recv) = oneshot::channel();
+
+        let log = log.new(slog::o!("component" => "serial task"));
+        let task = tokio::spawn(async move {
+            if let Err(e) = super::serial::instance_serial_task(
+                websocks_recv,
+                close_recv,
+                serial_clone,
+                log.clone(),
+            )
+            .await
+            {
+                error!(log, "Spawning serial task failed: {}", e);
+            }
+        });
+
+        let serial_task = SerialTask { task, close_ch, websocks_ch };
+
         Self {
-            state: propolis::instance::State::Initialize,
+            state: api::InstanceState::Creating,
             generation: 0,
             properties,
+            serial,
+            serial_task,
             state_watcher_rx,
             state_watcher_tx,
         }
@@ -70,40 +101,43 @@ impl InstanceContext {
     /// Returns an error if the state transition is invalid.
     pub fn set_target_state(
         &mut self,
-        target: propolis::instance::ReqState,
-    ) -> Result<(), propolis::instance::TransitionError> {
-        use propolis::instance::ReqState;
-        use propolis::instance::State;
-        use propolis::instance::TransitionError;
-
-        if matches!(self.state, State::Halt | State::Destroy) {
-            // Cannot request any state once the target is halt/destroy
-            return Err(TransitionError::Terminal);
-        }
-        if self.state == State::Reset && target == ReqState::Run {
-            // Requesting a run when already on the road to reboot is an
-            // immediate success.
-            return Ok(());
-        }
-        match target {
-            ReqState::Run | ReqState::Reset => {
-                self.generation += 1;
-                self.state = State::Run;
-                let result = self.state_watcher_tx.send(StateChange {
-                    gen: self.generation,
-                    state: self.state,
-                });
-                assert!(
-                    result.is_ok(),
-                    "Failed to send simulated state change update"
-                );
+        target: api::InstanceStateRequested,
+    ) -> Result<(), Error> {
+        match self.state {
+            api::InstanceState::Stopped
+            | api::InstanceState::Destroyed
+            | api::InstanceState::Failed => {
+                // Cannot request any state once the target is halt/destroy
+                Err(Error::TerminalState)
             }
-            ReqState::Halt => self.state = State::Halt,
-            ReqState::StartMigrate => {
-                unimplemented!("migration not yet implemented")
+            api::InstanceState::Rebooting
+                if matches!(target, api::InstanceStateRequested::Run) =>
+            {
+                // Requesting a run when already on the road to reboot is an
+                // immediate success.
+                Ok(())
             }
+            _ => match target {
+                api::InstanceStateRequested::Run
+                | api::InstanceStateRequested::Reboot => {
+                    self.generation += 1;
+                    self.state = api::InstanceState::Running;
+                    self.state_watcher_tx
+                        .send(api::InstanceStateMonitorResponse {
+                            gen: self.generation,
+                            state: self.state.clone(),
+                        })
+                        .map_err(|_| Error::TransitionSendFail)
+                }
+                api::InstanceStateRequested::Stop => {
+                    self.state = api::InstanceState::Stopped;
+                    Ok(())
+                }
+                api::InstanceStateRequested::MigrateStart => {
+                    unimplemented!("migration not yet implemented")
+                }
+            },
         }
-        Ok(())
     }
 }
 
@@ -122,37 +156,24 @@ impl Context {
 
 #[endpoint {
     method = PUT,
-    path = "/instances/{instance_id}",
+    path = "/instance",
 }]
 async fn instance_ensure(
-    rqctx: Arc<RequestContext<Context>>,
-    path_params: Path<api::InstancePathParams>,
+    rqctx: RequestContext<Arc<Context>>,
     request: TypedBody<api::InstanceEnsureRequest>,
 ) -> Result<HttpResponseCreated<api::InstanceEnsureResponse>, HttpError> {
     let server_context = rqctx.context();
     let request = request.into_inner();
-    let instance_id = path_params.into_inner().instance_id;
     let (properties, nics, disks, cloud_init_bytes) = (
         request.properties,
         request.nics,
         request.disks,
         request.cloud_init_bytes,
     );
-    if instance_id != properties.id {
-        return Err(HttpError::for_internal_error(
-            "UUID mismatch (path did not match struct)".to_string(),
-        ));
-    }
 
     // Handle an already-initialized instance
     let mut instance = server_context.instance.lock().await;
     if let Some(instance) = &*instance {
-        if instance.properties.id != instance_id {
-            return Err(HttpError::for_internal_error(format!(
-                "Server already initialized with ID {}",
-                instance.properties.id
-            )));
-        }
         if instance.properties != properties {
             return Err(HttpError::for_internal_error(
                 "Cannot update running server".to_string(),
@@ -166,8 +187,8 @@ async fn instance_ensure(
     // Perform some basic validation of the requested properties
     for nic in &nics {
         info!(server_context.log, "Creating NIC: {:#?}", nic);
-        slot_to_bdf(nic.slot, SlotType::NIC).map_err(|e| {
-            let err = Error::new(
+        slot_to_pci_path(nic.slot, SlotType::Nic).map_err(|e| {
+            let err = IoError::new(
                 ErrorKind::InvalidData,
                 format!("Cannot parse vnic PCI: {}", e),
             );
@@ -180,8 +201,8 @@ async fn instance_ensure(
 
     for disk in &disks {
         info!(server_context.log, "Creating Disk: {:#?}", disk);
-        slot_to_bdf(disk.slot, SlotType::Disk).map_err(|e| {
-            let err = Error::new(
+        slot_to_pci_path(disk.slot, SlotType::Disk).map_err(|e| {
+            let err = IoError::new(
                 ErrorKind::InvalidData,
                 format!("Cannot parse disk PCI: {}", e),
             );
@@ -195,57 +216,35 @@ async fn instance_ensure(
 
     if let Some(cloud_init_bytes) = &cloud_init_bytes {
         info!(server_context.log, "Creating cloud-init disk");
-        slot_to_bdf(api::Slot(0), SlotType::CloudInit).map_err(|e| {
-            let err = Error::new(ErrorKind::InvalidData, e.to_string());
+        slot_to_pci_path(api::Slot(0), SlotType::CloudInit).map_err(|e| {
+            let err = IoError::new(ErrorKind::InvalidData, e.to_string());
             HttpError::for_internal_error(format!(
                 "Cannot build instance: {}",
                 err
             ))
         })?;
-        base64::decode(&cloud_init_bytes).map_err(|e| {
-            let err = Error::new(ErrorKind::InvalidInput, e.to_string());
-            HttpError::for_internal_error(format!(
-                "Cannot build instance: {}",
-                err
-            ))
-        })?;
+        base64::engine::general_purpose::STANDARD
+            .decode(&cloud_init_bytes)
+            .map_err(|e| {
+                let err = IoError::new(ErrorKind::InvalidInput, e.to_string());
+                HttpError::for_internal_error(format!(
+                    "Cannot build instance: {}",
+                    err
+                ))
+            })?;
         info!(server_context.log, "cloud-init disk created");
     }
 
-    *instance = Some(InstanceContext::new(properties));
+    *instance = Some(InstanceContext::new(properties, &server_context.log));
     Ok(HttpResponseCreated(api::InstanceEnsureResponse { migrate: None }))
 }
 
 #[endpoint {
     method = GET,
-    path = "/instances/{instance_id}/uuid",
-    unpublished = true,
-}]
-async fn instance_get_uuid(
-    rqctx: Arc<RequestContext<Context>>,
-    path_params: Path<api::InstanceNameParams>,
-) -> Result<HttpResponseOk<Uuid>, HttpError> {
-    let instance = rqctx.context().instance.lock().await;
-    let instance = instance.as_ref().ok_or_else(|| {
-        HttpError::for_internal_error(
-            "Server not initialized (no instance)".to_string(),
-        )
-    })?;
-    if path_params.into_inner().instance_id != instance.properties.name {
-        return Err(HttpError::for_internal_error(
-            "Instance name mismatch (path did not match struct)".to_string(),
-        ));
-    }
-    Ok(HttpResponseOk(instance.properties.id))
-}
-
-#[endpoint {
-    method = GET,
-    path = "/instances/{instance_id}",
+    path = "/instance",
 }]
 async fn instance_get(
-    rqctx: Arc<RequestContext<Context>>,
-    path_params: Path<api::InstancePathParams>,
+    rqctx: RequestContext<Arc<Context>>,
 ) -> Result<HttpResponseOk<api::InstanceGetResponse>, HttpError> {
     let instance = rqctx.context().instance.lock().await;
     let instance = instance.as_ref().ok_or_else(|| {
@@ -253,14 +252,9 @@ async fn instance_get(
             "Server not initialized (no instance)".to_string(),
         )
     })?;
-    if path_params.into_inner().instance_id != instance.properties.id {
-        return Err(HttpError::for_internal_error(
-            "UUID mismatch (path did not match struct)".to_string(),
-        ));
-    }
     let instance_info = api::Instance {
         properties: instance.properties.clone(),
-        state: propolis_to_api_state(instance.state),
+        state: instance.state.clone(),
         disks: vec![],
         nics: vec![],
     };
@@ -269,11 +263,10 @@ async fn instance_get(
 
 #[endpoint {
     method = GET,
-    path = "/instances/{instance_id}/state-monitor",
+    path = "/instance/state-monitor",
 }]
 async fn instance_state_monitor(
-    rqctx: Arc<RequestContext<Context>>,
-    path_params: Path<api::InstancePathParams>,
+    rqctx: RequestContext<Arc<Context>>,
     request: TypedBody<api::InstanceStateMonitorRequest>,
 ) -> Result<HttpResponseOk<api::InstanceStateMonitorResponse>, HttpError> {
     let (mut state_watcher, gen) = {
@@ -283,12 +276,6 @@ async fn instance_state_monitor(
                 "Server not initialized (no instance)".to_string(),
             )
         })?;
-        let path_params = path_params.into_inner();
-        if path_params.instance_id != instance.properties.id {
-            return Err(HttpError::for_internal_error(
-                "UUID mismatch (path did not match struct)".to_string(),
-            ));
-        }
         let gen = request.into_inner().gen;
         let state_watcher = instance.state_watcher_rx.clone();
         (state_watcher, gen)
@@ -299,7 +286,7 @@ async fn instance_state_monitor(
         if gen <= last.gen {
             let response = api::InstanceStateMonitorResponse {
                 gen: last.gen,
-                state: propolis_to_api_state(last.state),
+                state: last.state,
             };
             return Ok(HttpResponseOk(response));
         }
@@ -309,11 +296,10 @@ async fn instance_state_monitor(
 
 #[endpoint {
     method = PUT,
-    path = "/instances/{instance_id}/state",
+    path = "/instance/state",
 }]
 async fn instance_state_put(
-    rqctx: Arc<RequestContext<Context>>,
-    path_params: Path<api::InstancePathParams>,
+    rqctx: RequestContext<Arc<Context>>,
     request: TypedBody<api::InstanceStateRequested>,
 ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
     let mut instance = rqctx.context().instance.lock().await;
@@ -322,26 +308,193 @@ async fn instance_state_put(
             "Server not initialized (no instance)".to_string(),
         )
     })?;
-    if path_params.into_inner().instance_id != instance.properties.id {
-        return Err(HttpError::for_internal_error(
-            "UUID mismatch (path did not match struct)".to_string(),
-        ));
-    }
-    let requested_state = api_to_propolis_state(request.into_inner());
+    let requested_state = request.into_inner();
     instance.set_target_state(requested_state).map_err(|err| {
         HttpError::for_internal_error(format!("Failed to transition: {}", err))
     })?;
     Ok(HttpResponseUpdatedNoContent {})
 }
 
+// TODO: mock the "Serial" struct itself instead?
+#[channel {
+    protocol = WEBSOCKETS,
+    path = "/instance/serial",
+}]
+async fn instance_serial(
+    rqctx: RequestContext<Arc<Context>>,
+    query: Query<api::InstanceSerialConsoleStreamRequest>,
+    websock: WebsocketConnection,
+) -> dropshot::WebsocketChannelResult {
+    let config =
+        WebSocketConfig { max_send_queue: Some(4096), ..Default::default() };
+    let mut ws_stream = WebSocketStream::from_raw_socket(
+        websock.into_inner(),
+        Role::Server,
+        Some(config),
+    )
+    .await;
+
+    let instance_mtx = rqctx.context().instance.lock().await;
+    if instance_mtx.as_ref().unwrap().state != api::InstanceState::Running {
+        ws_stream.send(Message::Close(None)).await?;
+        return Err("Instance isn't running!".into());
+    }
+
+    let serial = instance_mtx.as_ref().unwrap().serial.clone();
+
+    let byte_offset = SerialHistoryOffset::try_from(&query.into_inner()).ok();
+    if let Some(mut byte_offset) = byte_offset {
+        loop {
+            let (data, offset) = serial.history_vec(byte_offset, None).await?;
+            if data.is_empty() {
+                break;
+            }
+            ws_stream.send(Message::Binary(data)).await?;
+            byte_offset = SerialHistoryOffset::FromStart(offset);
+        }
+    }
+
+    instance_mtx
+        .as_ref()
+        .unwrap()
+        .serial_task
+        .websocks_ch
+        .send(ws_stream)
+        .await
+        .map_err(|e| format!("Serial socket hand-off failed: {}", e).into())
+}
+
+#[endpoint {
+    method = GET,
+    path = "/instance/serial/history",
+}]
+async fn instance_serial_history_get(
+    rqctx: RequestContext<Arc<Context>>,
+    query: Query<api::InstanceSerialConsoleHistoryRequest>,
+) -> Result<HttpResponseOk<api::InstanceSerialConsoleHistoryResponse>, HttpError>
+{
+    let query_params = query.into_inner();
+    let byte_offset = SerialHistoryOffset::try_from(&query_params)?;
+    let max_bytes = query_params.max_bytes.map(|x| x as usize);
+
+    let ctx = rqctx.context();
+    let (data, end) = ctx
+        .instance
+        .lock()
+        .await
+        .as_ref()
+        .ok_or(HttpError::for_internal_error(
+            "No mock instance instantiated".to_string(),
+        ))?
+        .serial
+        .history_vec(byte_offset, max_bytes)
+        .await
+        .map_err(|e| HttpError::for_bad_request(None, e.to_string()))?;
+
+    Ok(HttpResponseOk(api::InstanceSerialConsoleHistoryResponse {
+        data,
+        last_byte_offset: end as u64,
+    }))
+}
+
+// (ahem) mock *thou* art.
+struct MockUart {
+    buf: std::sync::Mutex<VecDeque<u8>>,
+}
+
+impl MockUart {
+    fn new(name: &str) -> Self {
+        let mut buf = VecDeque::with_capacity(1024);
+        #[rustfmt::skip]
+        let gerunds = [
+            "Loading", "Reloading", "Advancing", "Reticulating", "Defeating",
+            "Spoiling", "Cooking", "Destroying", "Resenting", "Introducing",
+            "Reiterating", "Blasting", "Tolling", "Delivering", "Engendering",
+            "Establishing",
+        ];
+        #[rustfmt::skip]
+        let nouns = [
+            "canon", "browsers", "meta", "splines", "villains",
+            "plot", "books", "evidence", "decisions", "chaos",
+            "points", "processors", "bells", "value", "gender",
+            "shots",
+        ];
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        name.hash(&mut hasher);
+        let mut entropy = hasher.finish();
+        buf.extend(
+            format!(
+                "This is simulated serial console output for {}.\r\n",
+                name
+            )
+            .as_bytes(),
+        );
+        while entropy != 0 {
+            let gerund = gerunds[entropy as usize % gerunds.len()];
+            entropy /= gerunds.len() as u64;
+            let noun = nouns[entropy as usize % nouns.len()];
+            entropy /= nouns.len() as u64;
+            buf.extend(
+                format!(
+                    "{} {}... {}[\x1b[92m 0K \x1b[m]\r\n",
+                    gerund,
+                    noun,
+                    " ".repeat(40 - gerund.len() - noun.len())
+                )
+                .as_bytes(),
+            );
+        }
+        buf.extend(
+            format!(
+                "\x1b[2J\x1b[HOS/478 ({name}) (ttyl)\r\n\r\n{name} login: ",
+                name = name
+            )
+            .as_bytes(),
+        );
+        Self { buf: std::sync::Mutex::new(buf) }
+    }
+}
+
+impl chardev::Sink for MockUart {
+    fn write(&self, data: u8) -> bool {
+        self.buf.lock().unwrap().push_back(data);
+        true
+    }
+
+    fn set_notifier(&self, _f: Option<SinkNotifier>) {
+        //todo!()
+    }
+}
+
+impl chardev::Source for MockUart {
+    fn read(&self) -> Option<u8> {
+        self.buf.lock().unwrap().pop_front()
+    }
+
+    fn discard(&self, count: usize) -> usize {
+        let mut buf = self.buf.lock().unwrap();
+        let end = buf.len().min(count);
+        buf.drain(0..end).count()
+    }
+
+    fn set_autodiscard(&self, _active: bool) {
+        //todo!()
+    }
+
+    fn set_notifier(&self, _f: Option<SourceNotifier>) {
+        //todo!()
+    }
+}
+
 /// Returns a Dropshot [`ApiDescription`] object to launch a mock Propolis
 /// server.
-pub fn api() -> ApiDescription<Context> {
+pub fn api() -> ApiDescription<Arc<Context>> {
     let mut api = ApiDescription::new();
     api.register(instance_ensure).unwrap();
-    api.register(instance_get_uuid).unwrap();
     api.register(instance_get).unwrap();
     api.register(instance_state_monitor).unwrap();
     api.register(instance_state_put).unwrap();
+    api.register(instance_serial).unwrap();
+    api.register(instance_serial_history_get).unwrap();
     api
 }

--- a/bin/propolis-server/src/lib/serial/mod.rs
+++ b/bin/propolis-server/src/lib/serial/mod.rs
@@ -11,7 +11,6 @@ use futures::stream::SplitSink;
 use futures::{FutureExt, SinkExt, StreamExt};
 use hyper::upgrade::Upgraded;
 use propolis::chardev::{pollers, Sink, Source};
-use propolis::hw::uart::LpcUart;
 use slog::{info, Logger};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot, RwLock as AsyncRwLock};
@@ -57,10 +56,10 @@ pub struct SerialTask {
     pub websocks_ch: mpsc::Sender<WebSocketStream<Upgraded>>,
 }
 
-pub async fn instance_serial_task(
+pub async fn instance_serial_task<Device: Sink + Source>(
     mut websocks_recv: mpsc::Receiver<WebSocketStream<Upgraded>>,
     mut close_recv: oneshot::Receiver<()>,
-    serial: Arc<Serial<LpcUart>>,
+    serial: Arc<Serial<Device>>,
     log: Logger,
 ) -> Result<(), SerialTaskError> {
     info!(log, "Entered serial task");

--- a/bin/propolis-server/src/lib/spec.rs
+++ b/bin/propolis-server/src/lib/spec.rs
@@ -52,7 +52,7 @@ pub enum SlotType {
 
 /// Translates a device type and PCI slot (as presented in an instance creation
 /// request) into a concrete PCI path. See the documentation for [`SlotType`].
-fn slot_to_pci_path(
+pub(crate) fn slot_to_pci_path(
     slot: api::Slot,
     ty: SlotType,
 ) -> Result<PciPath, ServerSpecBuilderError> {

--- a/bin/propolis-server/src/main.rs
+++ b/bin/propolis-server/src/main.rs
@@ -14,9 +14,11 @@ use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
 
+#[cfg(feature = "mock-only")]
+use propolis_server::mock_server;
 use propolis_server::server::MetricsEndpointConfig;
 use propolis_server::vnc::setup_vnc;
-use propolis_server::{config, mock_server, server};
+use propolis_server::{config, server};
 
 #[derive(Debug, Parser)]
 #[clap(about, version)]
@@ -42,11 +44,6 @@ enum Args {
             action
         )]
         vnc_addr: SocketAddr,
-
-        /// If true, run a mock server which does not actually spawn instances
-        /// (i.e. to test with a facsimile of the API on unsupported platforms)
-        #[structopt(short, long)]
-        mock: bool,
     },
 }
 
@@ -73,7 +70,7 @@ async fn main() -> anyhow::Result<()> {
     match args {
         Args::OpenApi => run_openapi()
             .map_err(|e| anyhow!("Cannot generate OpenAPI spec: {}", e)),
-        Args::Run { cfg, propolis_addr, metric_addr, vnc_addr, mock } => {
+        Args::Run { cfg, propolis_addr, metric_addr, vnc_addr } => {
             let config = config::parse(&cfg)?;
 
             // Dropshot configuration.
@@ -99,47 +96,32 @@ async fn main() -> anyhow::Result<()> {
                 imc
             });
 
-            if mock {
-                let context =
-                    mock_server::Context::new(config, log.new(slog::o!()));
-                info!(log, "Starting mock server...");
-                let server = HttpServerStarter::new(
-                    &config_dropshot,
-                    mock_server::api(),
-                    Arc::new(context),
-                    &log,
-                )
-                .map_err(|error| {
-                    anyhow!("Failed to start mock server: {}", error)
-                })?
-                .start();
-                server.await.map_err(|e| {
-                    anyhow!("Mock server exited with an error: {}", e)
-                })
-            } else {
-                let context = server::DropshotEndpointContext::new(
-                    config,
-                    vnc_server,
-                    use_reservoir,
-                    log.new(slog::o!()),
-                    metric_config,
-                );
+            #[cfg(feature = "mock-only")]
+            let context =
+                mock_server::Context::new(config, log.new(slog::o!()));
+            #[cfg(not(feature = "mock-only"))]
+            let context = server::DropshotEndpointContext::new(
+                config,
+                vnc_server,
+                use_reservoir,
+                log.new(slog::o!()),
+                metric_config,
+            );
 
-                info!(log, "Starting server...");
+            info!(log, "Starting server...");
 
-                let server = HttpServerStarter::new(
-                    &config_dropshot,
-                    server::api(),
-                    Arc::new(context),
-                    &log,
-                )
-                .map_err(|error| anyhow!("Failed to start server: {}", error))?
-                .start();
+            let server = HttpServerStarter::new(
+                &config_dropshot,
+                server::api(),
+                Arc::new(context),
+                &log,
+            )
+            .map_err(|error| anyhow!("Failed to start server: {}", error))?
+            .start();
 
-                let server_res = join!(server, vnc_server_hdl.start()).0;
-                server_res
-                    .map_err(|e| anyhow!("Server exited with an error: {}", e))
-            }
+            let server_res = join!(server, vnc_server_hdl.start()).0;
+            server_res
+                .map_err(|e| anyhow!("Server exited with an error: {}", e))
         }
     }
 }

--- a/bin/propolis-server/src/main.rs
+++ b/bin/propolis-server/src/main.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use propolis_server::server::MetricsEndpointConfig;
 use propolis_server::vnc::setup_vnc;
-use propolis_server::{config, server};
+use propolis_server::{config, server, mock_server};
 
 #[derive(Debug, Parser)]
 #[clap(about, version)]
@@ -42,6 +42,10 @@ enum Args {
             action
         )]
         vnc_addr: SocketAddr,
+
+        /// If true, run a mock server which does not actually spawn instances
+        #[structopt(short, long)]
+        mock: bool,
     },
 }
 
@@ -68,7 +72,7 @@ async fn main() -> anyhow::Result<()> {
     match args {
         Args::OpenApi => run_openapi()
             .map_err(|e| anyhow!("Cannot generate OpenAPI spec: {}", e)),
-        Args::Run { cfg, propolis_addr, metric_addr, vnc_addr } => {
+        Args::Run { cfg, propolis_addr, metric_addr, vnc_addr, mock } => {
             let config = config::parse(&cfg)?;
 
             // Dropshot configuration.
@@ -94,28 +98,47 @@ async fn main() -> anyhow::Result<()> {
                 imc
             });
 
-            let context = server::DropshotEndpointContext::new(
-                config,
-                vnc_server,
-                use_reservoir,
-                log.new(slog::o!()),
-                metric_config,
-            );
+            if mock {
+                let context =
+                    mock_server::MockContext::new(config, log.new(slog::o!()));
+                info!(log, "Starting mock server...");
+                let server = HttpServerStarter::new(
+                    &config_dropshot,
+                    mock_server::api(),
+                    context,
+                    &log,
+                )
+                .map_err(|error| {
+                    anyhow!("Failed to start mock server: {}", error)
+                })?
+                .start();
+                server.await.map_err(|e| {
+                    anyhow!("Mock server exited with an error: {}", e)
+                })
+            } else {
+                let context = server::DropshotEndpointContext::new(
+                    config,
+                    vnc_server,
+                    use_reservoir,
+                    log.new(slog::o!()),
+                    metric_config,
+                );
 
-            info!(log, "Starting server...");
+                info!(log, "Starting server...");
 
-            let server = HttpServerStarter::new(
-                &config_dropshot,
-                server::api(),
-                Arc::new(context),
-                &log,
-            )
-            .map_err(|error| anyhow!("Failed to start server: {}", error))?
-            .start();
+                let server = HttpServerStarter::new(
+                    &config_dropshot,
+                    server::api(),
+                    Arc::new(context),
+                    &log,
+                )
+                .map_err(|error| anyhow!("Failed to start server: {}", error))?
+                .start();
 
-            let server_res = join!(server, vnc_server_hdl.start()).0;
-            server_res
-                .map_err(|e| anyhow!("Server exited with an error: {}", e))
+                let server_res = join!(server, vnc_server_hdl.start()).0;
+                server_res
+                    .map_err(|e| anyhow!("Server exited with an error: {}", e))
+            }
         }
     }
 }


### PR DESCRIPTION
this builds on @bnaecker's [mock-server](https://github.com/oxidecomputer/propolis/tree/mock-server) branch from back in april, bringing it up to date with the changes to the API since then (e.g. no more UUID path params), and adding the serial console websocket (and serial console history-retrieving) API endpoints, backed with similar output as was used in the previous sled-agent-sim implementation.