### PR TITLE
Pause entities before halting them

### DIFF
--- a/lib/propolis/src/inventory.rs
+++ b/lib/propolis/src/inventory.rs
@@ -584,9 +584,9 @@ pub trait Entity: Send + Sync + 'static {
     fn reset(&self) {}
 
     /// Indicates that the entity's instance is stopping and will soon be
-    /// discarded. The entity should complete any in-flight requests and release
-    /// any references or resources it needs to release to ensure the instance
-    /// is fully destroyed.
+    /// discarded.
+    ///
+    /// N.B. The state driver ensures this is called only on paused entities.
     fn halt(&self) {}
 
     /// Return the Migrator object that will be used to export/import


### PR DESCRIPTION
Make the VM state driver pause entities before halting them if they weren't paused already.

Reactivate the unit test for this case. Add a second test that simulates a migration out (with a pause) followed by a halt and verifies that the pause command is only issued once.

Fixes #258. (Third time's the charm, right?)