### PR TITLE
Automatically start VMs after a successful migration in

### DIFF
--- a/bin/propolis-server/src/lib/vm/state_driver.rs
+++ b/bin/propolis-server/src/lib/vm/state_driver.rs
@@ -509,7 +509,6 @@ mod tests {
         (vm_ctrl, vcpu_ctrl)
     }
 
-    /* TODO(#250)
     fn make_migration_target_mocks(
         migration_id: Uuid,
     ) -> (MockStateDriverVmController, MockVcpuTaskController) {
@@ -525,7 +524,6 @@ mod tests {
 
         (vm_ctrl, vcpu_ctrl)
     }
-    */
 
     fn add_reboot_expectations(
         vm_ctrl: &mut MockStateDriverVmController,
@@ -794,7 +792,6 @@ mod tests {
         );
     }
 
-    /* TODO(#250)
     #[tokio::test]
     async fn vm_starts_after_migration_in() {
         let migration_id = Uuid::new_v4();
@@ -852,7 +849,6 @@ mod tests {
         .await
         .unwrap();
     }
-    */
 
     /* TODO(#252)
     #[tokio::test]

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -355,7 +355,6 @@ impl TestVm {
             }
         }
 
-        self.run()?;
         Ok(())
     }
 


### PR DESCRIPTION
Start instances automatically upon successfully migrating into them. Fix one small race that could cause a client's requests to run a VM to fail even though it could observe that a migration in had successfully completed. (There are still some other sore spots in this state machine that aren't fixed in this PR; those are now tracked by #284.)

Fixes #250.