### PR TITLE
Add NMI injection endpoint

### DIFF
--- a/bin/propolis-cli/src/main.rs
+++ b/bin/propolis-cli/src/main.rs
@@ -109,6 +109,9 @@ enum Command {
 
     /// Monitor an instance's state in real time
     Monitor,
+
+    /// Inject an NMI into the instance
+    InjectNmi,
 }
 
 fn parse_state(state: &str) -> anyhow::Result<InstanceStateRequested> {
@@ -516,6 +519,13 @@ async fn monitor(addr: SocketAddr) -> anyhow::Result<()> {
     }
 }
 
+async fn inject_nmi(client: &Client) -> anyhow::Result<()> {
+    client
+        .instance_inject_nmi()
+        .await
+        .with_context(|| anyhow!("failed to inject NMI"))
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let opt = Opt::parse();
@@ -564,6 +574,7 @@ async fn main() -> anyhow::Result<()> {
             migrate_instance(client, dst_client, addr, dst_uuid).await?
         }
         Command::Monitor => monitor(addr).await?,
+        Command::InjectNmi => inject_nmi(&client).await?,
     }
 
     Ok(())

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -842,6 +842,20 @@ async fn instance_issue_crucible_snapshot_request(
     Ok(HttpResponseOk(()))
 }
 
+/// Issues an NMI to the instance.
+#[endpoint {
+    method = POST,
+    path = "/instance/nmi",
+}]
+async fn instance_issue_nmi(
+    rqctx: Arc<RequestContext<DropshotEndpointContext>>,
+) -> Result<HttpResponseOk<()>, HttpError> {
+    let vm = rqctx.context().vm().await?;
+    vm.inject_nmi();
+
+    Ok(HttpResponseOk(()))
+}
+
 /// Returns a Dropshot [`ApiDescription`] object to launch a server.
 pub fn api() -> ApiDescription<DropshotEndpointContext> {
     let mut api = ApiDescription::new();
@@ -856,6 +870,7 @@ pub fn api() -> ApiDescription<DropshotEndpointContext> {
     api.register(instance_migrate_start).unwrap();
     api.register(instance_migrate_status).unwrap();
     api.register(instance_issue_crucible_snapshot_request).unwrap();
+    api.register(instance_issue_nmi).unwrap();
 
     api
 }

--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -641,6 +641,20 @@ impl VmController {
         self.vm_objects.monitor_rx.borrow().state
     }
 
+    pub fn inject_nmi(&self) {
+        if let Some(instance) = &self.vm_objects.instance {
+            let instance = instance.lock();
+            match instance.machine().inject_nmi() {
+                Ok(_) => {
+                    info!(self.log, "Sending NMI to instance");
+                }
+                Err(e) => {
+                    error!(self.log, "Could not send NMI to instance: {}", e);
+                }
+            };
+        }
+    }
+
     pub fn state_watcher(
         &self,
     ) -> &tokio::sync::watch::Receiver<ApiMonitoredState> {

--- a/crates/bhyve-api/src/structs.rs
+++ b/crates/bhyve-api/src/structs.rs
@@ -266,6 +266,12 @@ pub struct vm_capability {
 
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
+pub struct vm_nmi {
+    pub cpuid: c_int,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
 pub struct vm_suspend {
     /// Acceptable values defined by `vm_suspend_how`
     pub how: u32,

--- a/lib/propolis-client/src/handmade/mod.rs
+++ b/lib/propolis-client/src/handmade/mod.rs
@@ -207,4 +207,10 @@ impl Client {
         );
         self.post(path, None).await
     }
+
+    /// Send an Non Maskable Interrupt (NMI) to the instance.
+    pub async fn instance_inject_nmi(&self) -> Result<(), Error> {
+        let path = format!("http://{}/instance/nmi", self.address);
+        self.post(path, None).await
+    }
 }

--- a/lib/propolis/src/vcpu.rs
+++ b/lib/propolis/src/vcpu.rs
@@ -214,6 +214,12 @@ impl Vcpu {
             }
         })
     }
+
+    /// Send a Non Maskable Interrupt (NMI) to the vcpu.
+    pub fn inject_nmi(&self) -> Result<()> {
+        let mut vm_nmi = bhyve_api::vm_nmi { cpuid: self.cpuid() };
+        unsafe { self.hdl.ioctl(bhyve_api::VM_INJECT_NMI, &mut vm_nmi) }
+    }
 }
 
 impl Entity for Vcpu {

--- a/lib/propolis/src/vmm/machine.rs
+++ b/lib/propolis/src/vmm/machine.rs
@@ -108,6 +108,12 @@ impl Machine {
             None
         }
     }
+
+    pub fn inject_nmi(&self) -> Result<()> {
+        // When the Machine is created, we're guaranteed at least one vcpu, so
+        // just send the NMI to the first one.
+        self.vcpus[0].inject_nmi()
+    }
 }
 impl Drop for Machine {
     fn drop(&mut self) {

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -145,6 +145,34 @@
         }
       }
     },
+    "/instance/nmi": {
+      "post": {
+        "summary": "Issues an NMI to the instance.",
+        "operationId": "instance_issue_nmi",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Null",
+                  "type": "string",
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/instance/serial": {
       "get": {
         "operationId": "instance_serial",


### PR DESCRIPTION
This change adds an endpoint to propolis-server (and corresponding client changes) to send an NMI to the server. The API to send an NMI is a POST to `/instance/nmi`. I picked the URI pretty arbitrarily and am open to feedback.

A preview of the CLI command and help message:
```
jordan@rodman:~/src/forks/propolis$ ./target/debug/propolis-cli -h
propolis-cli 0.1.0
A simple CLI tool to manipulate propolis-server

USAGE:
    propolis-cli [OPTIONS] --server <SERVER> <SUBCOMMAND>

OPTIONS:
    -d, --debug              Enable debugging
    -h, --help               Print help information
    -p, --port <PORT>        propolis-server port [default: 12400]
    -s, --server <SERVER>    propolis-server address
    -V, --version            Print version information

SUBCOMMANDS:
    get           Get the properties of a propolis instance
    help          Print this message or the help of the given subcommand(s)
    inject-nmi    Inject an NMI into the instance
    migrate       Migrate instance to new propolis-server
    monitor       Monitor an instance's state in real time
    new           Create a new propolis instance
    serial        Drop to a Serial console connected to the instance
    state         Transition the instance to a new state

```

**Testing**
Here is some example output from the serial console of different guests after running the `inject-nmi` command from the CLI:

helios:
```
panic[cpu0]/thread=fffffe0002005c20: NMI received                                                        
                                                                                                         
                                                                                                         
fffffffffbc13ed0 fffffffff78aa2a3 ()                                                                     
fffffffffbc13f00 unix:av_dispatch_nmivect+32 ()                                                          
fffffffffbc13f10 unix:nmiint+155 ()                                                                      
fffffe0002005ba0 unix:mach_cpu_idle+b ()                                                                 
fffffe0002005bd0 unix:cpu_idle+10f ()                                                                    
fffffe0002005be0 unix:cpu_idle_adaptive+19 ()                                                            
fffffe0002005c00 unix:idle+ae ()                                                                         
fffffe0002005c10 unix:thread_start+b ()                                                                  
                                                                                                         
skipping system dump - no dump device configured                                                         
rebooting...

```

alpine:
```
localhost:~# 
localhost:~# [   10.958704] Uhhuh. NMI received for unknown reason 20 on CPU 0.
[   10.958715] Do you have a strange power saving mode enabled?
[   10.958715] Dazed and confused, but trying to continue
```

Windows:
```
SAC><?xml><BP>
<INSTANCE CLASSNAME="BLUESCREEN">
<PROPERTY NAME="STOPCODE" TYPE="string"><VALUE>"0x80"</VALUE></PROPERTY><machine-info>
<name>WIN-HK2N6BN93I1</name>
<guid>00000000-0000-0000-0000-000000000000</guid>
<processor-architecture>AMD64</processor-architecture>
<os-version>10.0</os-version>
<os-build-number>17763</os-build-number>
<os-product>Windows Server 2019 Datacenter</os-product>
<os-service-pack>None</os-service-pack>
</machine-info>

</INSTANCE>
</BP>
!SAC>
Your PC ran into a problem and needs to restart.
If you call a support person, give them this info:
NMI_HARDWARE_FAILURE


0x00000000004F4454
0x0000000000000000
0x0000000000000000
0x0000000000000000

We're just collecting some error info, and then you can restart. 100% complete
```