### PR TITLE
Instance spec API fixes

### DIFF
--- a/crates/propolis-types/src/lib.rs
+++ b/crates/propolis-types/src/lib.rs
@@ -15,8 +15,7 @@ use serde::{Deserialize, Serialize};
 const PCI_DEVICES_PER_BUS: u8 = 32;
 const PCI_FUNCTIONS_PER_DEVICE: u8 = 8;
 
-/// A PCI bus/device/function tuple. Supports conversion from a string formatted
-/// as "B.D.F", e.g. "0.7.0".
+/// A PCI bus/device/function tuple.
 #[derive(
     Clone,
     Copy,

--- a/lib/propolis-client/src/instance_spec/backends.rs
+++ b/lib/propolis-client/src/instance_spec/backends.rs
@@ -40,7 +40,7 @@ use serde::{Deserialize, Serialize};
 /// services that provide the functions storage devices need to implement their
 /// contracts.
 #[derive(Clone, Deserialize, Serialize, Debug, JsonSchema)]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum StorageBackendKind {
     /// A Crucible-backed device, containing a construction request.
     Crucible { req: crucible_client_types::VolumeConstructionRequest },
@@ -69,7 +69,7 @@ pub struct StorageBackend {
 /// that provides the functions needed for guest network adapters to implement
 /// their contracts.
 #[derive(Clone, Deserialize, Serialize, Debug, JsonSchema)]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum NetworkBackendKind {
     /// A virtio-net (viona) backend associated with the supplied named vNIC on
     /// the host.

--- a/lib/propolis-client/src/instance_spec/devices.rs
+++ b/lib/propolis-client/src/instance_spec/devices.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 #[derive(
     Clone, Copy, Deserialize, Serialize, Debug, PartialEq, Eq, JsonSchema,
 )]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum Chipset {
     /// An Intel 440FX-compatible chipset.
     I440Fx {
@@ -117,7 +117,7 @@ impl MigrationElement for Board {
 #[derive(
     Clone, Copy, Deserialize, Serialize, Debug, PartialEq, Eq, JsonSchema,
 )]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum StorageDeviceKind {
     Virtio,
     Nvme,
@@ -209,7 +209,7 @@ impl MigrationElement for NetworkDevice {
 #[derive(
     Clone, Copy, Deserialize, Serialize, Debug, PartialEq, Eq, JsonSchema,
 )]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum SerialPortNumber {
     Com1,
     Com2,

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -1155,7 +1155,7 @@
         ]
       },
       "PciPath": {
-        "description": "A PCI bus/device/function tuple. Supports conversion from a string formatted as \"B.D.F\", e.g. \"0.7.0\".",
+        "description": "A PCI bus/device/function tuple.",
         "type": "object",
         "properties": {
           "bus": {

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -460,7 +460,7 @@
             "description": "An Intel 440FX-compatible chipset.",
             "type": "object",
             "properties": {
-              "I440Fx": {
+              "i440_fx": {
                 "type": "object",
                 "properties": {
                   "enable_pcie": {
@@ -475,7 +475,7 @@
               }
             },
             "required": [
-              "I440Fx"
+              "i440_fx"
             ],
             "additionalProperties": false
           }
@@ -1036,7 +1036,7 @@
             "description": "A virtio-net (viona) backend associated with the supplied named vNIC on the host.",
             "type": "object",
             "properties": {
-              "Virtio": {
+              "virtio": {
                 "type": "object",
                 "properties": {
                   "vnic_name": {
@@ -1050,7 +1050,7 @@
               }
             },
             "required": [
-              "Virtio"
+              "virtio"
             ],
             "additionalProperties": false
           },
@@ -1058,7 +1058,7 @@
             "description": "A DLPI backend associated with the supplied named vNIC on the host.",
             "type": "object",
             "properties": {
-              "Dlpi": {
+              "dlpi": {
                 "type": "object",
                 "properties": {
                   "vnic_name": {
@@ -1072,7 +1072,7 @@
               }
             },
             "required": [
-              "Dlpi"
+              "dlpi"
             ],
             "additionalProperties": false
           }
@@ -1227,10 +1227,10 @@
         "description": "A serial port identifier, which determines what I/O ports a guest can use to access a port.",
         "type": "string",
         "enum": [
-          "Com1",
-          "Com2",
-          "Com3",
-          "Com4"
+          "com1",
+          "com2",
+          "com3",
+          "com4"
         ]
       },
       "Slot": {
@@ -1269,7 +1269,7 @@
             "description": "A Crucible-backed device, containing a construction request.",
             "type": "object",
             "properties": {
-              "Crucible": {
+              "crucible": {
                 "type": "object",
                 "properties": {
                   "req": {
@@ -1283,7 +1283,7 @@
               }
             },
             "required": [
-              "Crucible"
+              "crucible"
             ],
             "additionalProperties": false
           },
@@ -1291,7 +1291,7 @@
             "description": "A device backed by a file on the host machine. The payload is a path to this file.",
             "type": "object",
             "properties": {
-              "File": {
+              "file": {
                 "type": "object",
                 "properties": {
                   "path": {
@@ -1305,7 +1305,7 @@
               }
             },
             "required": [
-              "File"
+              "file"
             ],
             "additionalProperties": false
           },
@@ -1313,7 +1313,7 @@
             "description": "A device backed by an in-memory buffer in the VMM process. The initial contents of the disk are a base64-encoded string.",
             "type": "object",
             "properties": {
-              "InMemory": {
+              "in_memory": {
                 "type": "object",
                 "properties": {
                   "base64": {
@@ -1327,7 +1327,7 @@
               }
             },
             "required": [
-              "InMemory"
+              "in_memory"
             ],
             "additionalProperties": false
           }
@@ -1369,8 +1369,8 @@
         "description": "A kind of storage device: the sort of virtual device interface the VMM exposes to guest software.",
         "type": "string",
         "enum": [
-          "Virtio",
-          "Nvme"
+          "virtio",
+          "nvme"
         ]
       },
       "VolumeConstructionRequest": {


### PR DESCRIPTION
Fix a few small issues with instance spec-based server APIs:

- Fix #289 (the From impl that converted handmade `PciPath`s to generated paths was self-referential and recursed infinitely). Add a unit test that catches this.
- Remove the custom serializer/deserializer for `PciPath`s, since it causes generated-client users not to be able to send requests to the handmade-type-using server. See the commit message for ff01a5e for details.
- Use snake_case for instance spec types to satisfy our [OpenAPI linting rules](https://github.com/oxidecomputer/openapi-lint#naming). There are additional rules violations beyond the ones fixed in this PR, but this PR's changes suffice to allow instance spec types to be used in other APIs (e.g. sled agent's) without causing linting failures. I'll address the other issues in a subsequent PR.

Tested with cargo test, PHD, some ad hoc use of propolis-server with a config TOML, and a local Omicron installation.