### PR TITLE
rearrange serial task probes to work around early exit

### DIFF
--- a/bin/propolis-server/src/lib/serial/mod.rs
+++ b/bin/propolis-server/src/lib/serial/mod.rs
@@ -184,6 +184,9 @@ pub async fn instance_serial_task(
 
             // Read bytes from the UART to be transmitted out the WS
             nread = uart_read => {
+                // N.B. Putting this probe inside the match arms below causes
+                //      the `break` arm to be taken unexpectedly. See
+                //      propolis#292 for details.
                 probes::serial_uart_read!(|| { nread.unwrap_or(0) });
                 match nread {
                     Some(0) | None => {


### PR DESCRIPTION
There is something magical about the release-build codegen of `propolis_server::serial::instance_serial_task` that causes the task to exit early, evidently via the "UART read channel was closed/returned no data from a successful read" clause of its main `select!` statement. This doesn't happen in dev builds, and the code works as intended if I remove the `serial_uart_read` probe from the relevant match arm or if I add other statements (e.g. logging statements) to that arm.

In the fullness of time, we should dig into exactly what's happening here. Since this only happens in release builds and seems to require the presence of the `serial_uart_read` probe (and *only* that probe) in the relevant match arm, this smells to me like some kind of interesting code generation and/or USDT corner case. In the immediate term, though, this breaks the serial console for any users of propolis-server release builds, which includes Omicron. Work around the problem by moving the relevant probe out of the match arm.

Also add a couple of logging statements (on entry/exit from the serial task) that I found useful while investigating this problem.

Tested: 
- Local PHD run that specifically used a release `propolis-server`
- Deployed a binary with the fix to a local Omicron install and verified that the serial console works again

Fixes #292, though I will file another (lower-priority) issue to track further investigation of what happened here.