### PR TITLE
Crucible deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,30 +19,30 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
 dependencies = [
+ "crypto-common",
  "generic-array",
 ]
 
 [[package]]
 name = "aes"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "opaque-debug",
 ]
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589c637f0e68c877bbd59a4599bbe849cac8e5f3e4b5a3ebae8f528cd218dcdc"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
 dependencies = [
  "aead",
  "aes",
@@ -239,12 +239,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
-name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -381,11 +375,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
- "generic-array",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -583,13 +578,13 @@ dependencies = [
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec#0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec"
+source = "git+https://github.com/oxidecomputer/crucible?branch=main#f43b9c5b7e6bcb4b0266037b50a2ac51971ad173"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
  "async-recursion 1.0.0",
  "async-trait",
- "base64 0.20.0",
+ "base64 0.21.0",
  "bitvec",
  "bytes",
  "chrono",
@@ -627,9 +622,9 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec#0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec"
+source = "git+https://github.com/oxidecomputer/crucible?branch=main#f43b9c5b7e6bcb4b0266037b50a2ac51971ad173"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.21.0",
  "schemars",
  "serde",
  "serde_json",
@@ -639,7 +634,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec#0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec"
+source = "git+https://github.com/oxidecomputer/crucible?branch=main#f43b9c5b7e6bcb4b0266037b50a2ac51971ad173"
 dependencies = [
  "anyhow",
  "rusqlite",
@@ -657,7 +652,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec#0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec"
+source = "git+https://github.com/oxidecomputer/crucible?branch=main#f43b9c5b7e6bcb4b0266037b50a2ac51971ad173"
 dependencies = [
  "anyhow",
  "bincode",
@@ -675,6 +670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -690,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
 ]
@@ -1534,6 +1530,15 @@ dependencies = [
  "number_prefix",
  "portable-atomic",
  "unicode-width",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2479,9 +2484,9 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polyval"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4224,11 +4229,11 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
 dependencies = [
- "generic-array",
+ "crypto-common",
  "subtle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,8 @@ chrono = "0.4.19"
 clap = "3.2"
 const_format = "0.2"
 crossbeam-channel = "0.5"
+crucible = { git = "https://github.com/oxidecomputer/crucible", branch = "main" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", branch = "main" }
 ctest2 = "0.4.3"
 ctrlc = "3.2"
 dladm = { path = "crates/dladm" }
@@ -126,11 +128,3 @@ uuid = "1.0.0"
 version_check = "0.9"
 viona_api = { path = "crates/viona-api" }
 vte = "0.10.1"
-
-[workspace.dependencies.crucible-client-types]
-git = "https://github.com/oxidecomputer/crucible"
-rev = "0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec"
-
-[workspace.dependencies.crucible]
-git = "https://github.com/oxidecomputer/crucible"
-rev = "0e2bea7741c6bdc34e8e08addb941ee31e4ac9ec"

--- a/bin/propolis-cli/src/main.rs
+++ b/bin/propolis-cli/src/main.rs
@@ -556,7 +556,7 @@ async fn main() -> anyhow::Result<()> {
             let cloud_init_bytes = if let Some(cloud_init) = cloud_init {
                 Some(base64::Engine::encode(
                     &base64::engine::general_purpose::STANDARD,
-                    std::fs::read(&cloud_init)?,
+                    std::fs::read(cloud_init)?,
                 ))
             } else {
                 None

--- a/bin/propolis-server/src/lib/serial/history_buffer.rs
+++ b/bin/propolis-server/src/lib/serial/history_buffer.rs
@@ -96,7 +96,7 @@ impl HistoryBuffer {
             ))
         } else if from_end < self.rolling.len() {
             // (apologies to Takenobu Mitsuyoshi)
-            let rolling_start = self.rolling.len() - from_end as usize;
+            let rolling_start = self.rolling.len() - from_end;
             Ok((
                 Box::new(self.rolling.iter().copied().skip(rolling_start)),
                 from_start,
@@ -203,7 +203,7 @@ mod tests {
         );
         assert_eq!(sugar(&buf, MostRecent(100), 4), ("This".to_string(), 4));
 
-        buf.consume(&"\nNo thing beside remains.".as_bytes().to_vec());
+        buf.consume("\nNo thing beside remains.".as_bytes());
         assert_eq!(sugar(&buf, MostRecent(10), 4), ("e re".to_string(), 46));
         assert_eq!(sugar(&buf, FromStart(8), 8), ("an examp".to_string(), 16));
         assert_eq!(sugar(&buf, FromStart(8), 12), ("an examp".to_string(), 16));

--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -524,7 +524,7 @@ impl VmController {
             oximeter_registry,
         );
 
-        init.initialize_rom(&bootrom)?;
+        init.initialize_rom(bootrom)?;
         init.initialize_kernel_devs()?;
         let chipset = init.initialize_chipset(
             &(worker_state.clone() as Arc<dyn ChipsetEventHandler>),

--- a/lib/propolis/src/block/crucible.rs
+++ b/lib/propolis/src/block/crucible.rs
@@ -83,7 +83,7 @@ impl block::Backend for CrucibleBackend {
     fn info(&self) -> DeviceInfo {
         DeviceInfo {
             block_size: self.block_size as u32,
-            total_size: self.sectors as u64,
+            total_size: self.sectors,
             writable: !self.read_only,
         }
     }

--- a/lib/propolis/src/hw/pci/bar.rs
+++ b/lib/propolis/src/hw/pci/bar.rs
@@ -28,7 +28,7 @@ impl BarDefine {
         match self {
             BarDefine::Pio(sz) => *sz as u64,
             BarDefine::Mmio(sz) => *sz as u64,
-            BarDefine::Mmio64(sz) => *sz as u64,
+            BarDefine::Mmio64(sz) => *sz,
         }
     }
 }
@@ -135,7 +135,7 @@ impl Bars {
             EntryKind::Mmio64(size) => {
                 let old = ent.value;
                 let mask = !(size - 1) as u32;
-                let low = val as u32 & mask;
+                let low = val & mask;
                 ent.value = (old & (0xffffffff << 32)) | low as u64;
                 (BarDefine::Mmio64(size), old, ent.value)
             }

--- a/lib/propolis/src/hw/pci/device.rs
+++ b/lib/propolis/src/hw/pci/device.rs
@@ -884,7 +884,7 @@ impl MsixCfg {
                         MsixCapReg::MsgCtrl => {
                             let state = self.state.lock().unwrap();
                             // low 10 bits hold `count - 1`
-                            let mut val = self.count as u16 - 1;
+                            let mut val = self.count - 1;
                             if state.enabled {
                                 val |= MSIX_MSGCTRL_ENABLE;
                             }

--- a/lib/propolis/src/mmio.rs
+++ b/lib/propolis/src/mmio.rs
@@ -45,7 +45,7 @@ impl MmioBus {
             _ => panic!(),
         };
         let handled = self.do_mmio(addr, |a, o, func| {
-            let mut wo = WriteOp::from_buf(o as usize, data);
+            let mut wo = WriteOp::from_buf(o, data);
             func(a, RWOp::Write(&mut wo))
         });
 
@@ -67,7 +67,7 @@ impl MmioBus {
             _ => panic!(),
         };
         let handled = self.do_mmio(addr, |a, o, func| {
-            let mut ro = ReadOp::from_buf(o as usize, &mut data);
+            let mut ro = ReadOp::from_buf(o, &mut data);
             func(a, RWOp::Read(&mut ro))
         });
 


### PR DESCRIPTION
With Cargo.lock committed now, we can switch the Crucible dependencies to track `main` .