### PR TITLE
NVMe: don't panic if guests tries a doorbell write for admin queues while controller is disabled

### DIFF
--- a/lib/propolis/src/hw/nvme/mod.rs
+++ b/lib/propolis/src/hw/nvme/mod.rs
@@ -760,7 +760,8 @@ impl PciNvme {
             }
 
             CtrlrReg::DoorBellAdminSQ => {
-                let val = wo.read_u32().try_into().unwrap();
+                // 32-bit register but ignore reserved top 16-bits
+                let val = wo.read_u32() as u16;
                 let state = self.state.lock().unwrap();
                 let admin_sq = state.get_admin_sq();
                 admin_sq.notify_tail(val)?;
@@ -769,7 +770,8 @@ impl PciNvme {
                 self.process_admin_queue(state, admin_sq)?;
             }
             CtrlrReg::DoorBellAdminCQ => {
-                let val = wo.read_u32().try_into().unwrap();
+                // 32-bit register but ignore reserved top 16-bits
+                let val = wo.read_u32() as u16;
                 let state = self.state.lock().unwrap();
                 let admin_cq = state.get_admin_cq();
                 admin_cq.notify_head(val)?;
@@ -794,7 +796,8 @@ impl PciNvme {
                 // But note that we only support CAP.DSTRD = 0
                 let off = wo.offset() - 0x1000;
 
-                let val: u16 = wo.read_u32().try_into().unwrap();
+                // 32-bit register but ignore reserved top 16-bits
+                let val = wo.read_u32() as u16;
                 let state = self.state.lock().unwrap();
 
                 if (off >> 2) & 0b1 == 0b1 {


### PR DESCRIPTION
Addresses panic in #308 (should leave issue open to further investigate if there's a bug on the propolis side).

As was mentioned on the bug, we shouldn't panic just because the guest did a register write at an unexpected time. Updated the code here to spit out a warning instead.

Also removed another possible source of unintended panics. The queue doorbell registers are defined in the spec as 32-bit but the top 16-bits are reserved and should be 0. But there's nothing stopping a bad/malicious guest from doing otherwise. I had previously used `try_into().unwrap()` to go from a `u32` to a `u16` here which would've caused a panic with that kind of bad input. Change here is to do a simple `as` cast which truncates to the lower 16-bits instead.