### PR TITLE
Replace migration transport layer with websockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
 [[package]]
 name = "api_identity"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3606be36c0a35c0bb111fbf813f503497601ba2f"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#bab91f6b5cba896ff391995d4b770b0ccc18e5c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "async-recursion"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -316,6 +316,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce55916af2c6b989e02b810ed4d9fb1bf219f809b683039c33eb92bbb4f2973b"
+dependencies = [
+ "cargo-lock",
+ "git2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,9 +339,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
  "serde",
 ]
@@ -346,10 +356,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-lock"
+version = "8.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031718ddb8f78aa5def78a09e90defe30151d1f6c672f937af4dd916429ed996"
+dependencies = [
+ "semver 1.0.16",
+ "serde",
+ "toml 0.5.11",
+ "url",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -402,12 +427,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.32"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags",
- "clap_derive 4.0.21",
+ "clap_derive 4.1.0",
  "clap_lex 0.3.0",
  "is-terminal",
  "once_cell",
@@ -430,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -514,15 +539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_panic"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58baae561b85ca19b3122a9ddd35c8ec40c3bcd14fe89921824eae73f7baffbf"
-dependencies = [
- "konst_kernel",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,11 +594,11 @@ dependencies = [
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=fb671895e8adb3cab5e801bbbe8728997178aba4#fb671895e8adb3cab5e801bbbe8728997178aba4"
+source = "git+https://github.com/oxidecomputer/crucible?rev=894d44988c56713105bbbd07900d628781ab4dda#894d44988c56713105bbbd07900d628781ab4dda"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
- "async-recursion 1.0.0",
+ "async-recursion 1.0.2",
  "async-trait",
  "base64 0.21.0",
  "bytes",
@@ -611,7 +627,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "toml",
+ "toml 0.7.2",
  "tracing",
  "usdt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid",
@@ -621,7 +637,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=fb671895e8adb3cab5e801bbbe8728997178aba4#fb671895e8adb3cab5e801bbbe8728997178aba4"
+source = "git+https://github.com/oxidecomputer/crucible?rev=894d44988c56713105bbbd07900d628781ab4dda#894d44988c56713105bbbd07900d628781ab4dda"
 dependencies = [
  "base64 0.21.0",
  "schemars",
@@ -633,7 +649,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=fb671895e8adb3cab5e801bbbe8728997178aba4#fb671895e8adb3cab5e801bbbe8728997178aba4"
+source = "git+https://github.com/oxidecomputer/crucible?rev=894d44988c56713105bbbd07900d628781ab4dda#894d44988c56713105bbbd07900d628781ab4dda"
 dependencies = [
  "anyhow",
  "rusqlite",
@@ -643,7 +659,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio-rustls",
- "toml",
+ "toml 0.7.2",
  "twox-hash",
  "uuid",
 ]
@@ -651,7 +667,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=fb671895e8adb3cab5e801bbbe8728997178aba4#fb671895e8adb3cab5e801bbbe8728997178aba4"
+source = "git+https://github.com/oxidecomputer/crucible?rev=894d44988c56713105bbbd07900d628781ab4dda#894d44988c56713105bbbd07900d628781ab4dda"
 dependencies = [
  "anyhow",
  "bincode",
@@ -883,8 +899,8 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dropshot"
-version = "0.8.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#120e168525018dca4c9c3bed47d398c55fdd4d6b"
+version = "0.9.1-dev"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#bfcbec77e7c6b49aa940065eb5b1a5e5b34f4d5e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -916,7 +932,7 @@ dependencies = [
  "slog-term",
  "tokio",
  "tokio-rustls",
- "toml",
+ "toml 0.7.2",
  "usdt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid",
  "version_check",
@@ -924,8 +940,8 @@ dependencies = [
 
 [[package]]
 name = "dropshot_endpoint"
-version = "0.8.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#120e168525018dca4c9c3bed47d398c55fdd4d6b"
+version = "0.9.1-dev"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#bfcbec77e7c6b49aa940065eb5b1a5e5b34f4d5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1138,9 +1154,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1153,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1163,15 +1179,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1180,15 +1196,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1197,21 +1213,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1283,6 +1299,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
+name = "git2"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1620,6 +1649,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,12 +1665,6 @@ checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "konst_kernel"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7771682454392dfe62a909aba2c6efc6674e2ad0b678fbc33b154e2e1bd59b89"
 
 [[package]]
 name = "lazy_static"
@@ -1652,6 +1684,18 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/dlpi-sys?branch=main#1d587ea98cf2d36f1b1624b0b960559c76d475d2"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.14.2+1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,6 +1711,18 @@ version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
 dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1837,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "nexus-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3606be36c0a35c0bb111fbf813f503497601ba2f"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#bab91f6b5cba896ff391995d4b770b0ccc18e5c2"
 dependencies = [
  "chrono",
  "omicron-common",
@@ -1859,6 +1915,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "static_assertions",
+]
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2014,7 +2079,7 @@ dependencies = [
 [[package]]
 name = "omicron-common"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3606be36c0a35c0bb111fbf813f503497601ba2f"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#bab91f6b5cba896ff391995d4b770b0ccc18e5c2"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -2032,6 +2097,7 @@ dependencies = [
  "reqwest",
  "ring",
  "schemars",
+ "semver 1.0.16",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2041,7 +2107,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-postgres",
- "toml",
+ "toml 0.5.11",
  "uuid",
 ]
 
@@ -2060,7 +2126,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -2146,7 +2212,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "oximeter"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3606be36c0a35c0bb111fbf813f503497601ba2f"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#bab91f6b5cba896ff391995d4b770b0ccc18e5c2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2161,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "oximeter-macro-impl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3606be36c0a35c0bb111fbf813f503497601ba2f"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#bab91f6b5cba896ff391995d4b770b0ccc18e5c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2171,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "oximeter-producer"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#3606be36c0a35c0bb111fbf813f503497601ba2f"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#bab91f6b5cba896ff391995d4b770b0ccc18e5c2"
 dependencies = [
  "chrono",
  "dropshot",
@@ -2394,7 +2460,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-tungstenite",
- "toml",
+ "toml 0.5.11",
  "tracing",
  "uuid",
  "vte",
@@ -2580,7 +2646,7 @@ checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
 dependencies = [
  "once_cell",
  "thiserror",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -2609,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -2619,22 +2685,25 @@ dependencies = [
 [[package]]
 name = "progenitor"
 version = "0.2.1-dev"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#a5fea0b0611585eb1c4b8bee651089f8b8547d89"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#680150559a55f6ff7fc8d783c9a72461a233c3b5"
 dependencies = [
  "anyhow",
- "clap 4.0.32",
+ "built",
+ "clap 4.1.4",
  "openapiv3",
  "progenitor-client",
  "progenitor-impl",
  "progenitor-macro",
+ "project-root",
  "serde",
  "serde_json",
+ "serde_yaml",
 ]
 
 [[package]]
 name = "progenitor-client"
 version = "0.2.1-dev"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#a5fea0b0611585eb1c4b8bee651089f8b8547d89"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#680150559a55f6ff7fc8d783c9a72461a233c3b5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2648,7 +2717,7 @@ dependencies = [
 [[package]]
 name = "progenitor-impl"
 version = "0.2.1-dev"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#a5fea0b0611585eb1c4b8bee651089f8b8547d89"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#680150559a55f6ff7fc8d783c9a72461a233c3b5"
 dependencies = [
  "getopts",
  "heck",
@@ -2670,7 +2739,7 @@ dependencies = [
 [[package]]
 name = "progenitor-macro"
 version = "0.2.1-dev"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#a5fea0b0611585eb1c4b8bee651089f8b8547d89"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#680150559a55f6ff7fc8d783c9a72461a233c3b5"
 dependencies = [
  "openapiv3",
  "proc-macro2",
@@ -2680,8 +2749,15 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tokenstream",
+ "serde_yaml",
  "syn",
 ]
+
+[[package]]
+name = "project-root"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "propolis"
@@ -2817,7 +2893,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
- "toml",
+ "toml 0.5.11",
  "usdt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid",
  "version_check",
@@ -2830,7 +2906,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "thiserror",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -2851,7 +2927,7 @@ dependencies = [
  "slog-async",
  "slog-term",
  "tokio",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -2974,11 +3050,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3010,6 +3086,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -3047,12 +3124,9 @@ dependencies = [
 
 [[package]]
 name = "ringbuffer"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034f2f6835eab90a8942169db360776272fe3fce9eb13b9bdefaceea67cabd68"
-dependencies = [
- "const_panic",
-]
+checksum = "1973f95452ec56a4b2c683f5eabc15617e38f4faf2776ed4a0011d5070ecb37e"
 
 [[package]]
 name = "ron"
@@ -3103,7 +3177,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror",
- "toml",
+ "toml 0.5.11",
  "toolchain_find",
 ]
 
@@ -3123,9 +3197,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -3260,6 +3334,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "semver-parser"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3310,9 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
 dependencies = [
  "itoa",
  "ryu",
@@ -3328,6 +3411,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3388,6 +3480,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb06d4b6cdaef0e0c51fa881acb721bed3c924cfaa71d9c94a3b771dfdf6567"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3590,7 +3695,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/softnpu?branch=main#a6a8a4538be3733683e26b35060604175d48fb0b"
 dependencies = [
  "anyhow",
- "clap 4.0.32",
+ "clap 4.1.4",
  "devinfo 0.1.0 (git+https://github.com/oxidecomputer/devinfo-sys?branch=main)",
  "dlpi",
  "indicatif",
@@ -3606,7 +3711,7 @@ dependencies = [
  "slog-envlogger",
  "slog-term",
  "tokio",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -3877,9 +3982,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3979,11 +4084,45 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6a7712b49e1775fb9a7b998de6635b299237f48b404dde71704f2e0e7f37e5"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
 ]
 
 [[package]]
@@ -4142,7 +4281,7 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 [[package]]
 name = "typify"
 version = "0.0.11-dev"
-source = "git+https://github.com/oxidecomputer/typify#0f173877fa12c7e53c351fd1084e7cab0c6a7be1"
+source = "git+https://github.com/oxidecomputer/typify#e4e7b449ea934da76565202a30d983a7d2d85054"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -4151,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "typify-impl"
 version = "0.0.11-dev"
-source = "git+https://github.com/oxidecomputer/typify#0f173877fa12c7e53c351fd1084e7cab0c6a7be1"
+source = "git+https://github.com/oxidecomputer/typify#e4e7b449ea934da76565202a30d983a7d2d85054"
 dependencies = [
  "heck",
  "log",
@@ -4169,7 +4308,7 @@ dependencies = [
 [[package]]
 name = "typify-macro"
 version = "0.0.11-dev"
-source = "git+https://github.com/oxidecomputer/typify#0f173877fa12c7e53c351fd1084e7cab0c6a7be1"
+source = "git+https://github.com/oxidecomputer/typify#e4e7b449ea934da76565202a30d983a7d2d85054"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4235,6 +4374,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
 
 [[package]]
 name = "untrusted"
@@ -4385,9 +4530,9 @@ checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
 name = "uuid"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
  "serde",
@@ -4534,6 +4679,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,8 +129,8 @@ vte = "0.10.1"
 
 [workspace.dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "fb671895e8adb3cab5e801bbbe8728997178aba4"
+rev = "894d44988c56713105bbbd07900d628781ab4dda"
 
 [workspace.dependencies.crucible]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "fb671895e8adb3cab5e801bbbe8728997178aba4"
+rev = "894d44988c56713105bbbd07900d628781ab4dda"

--- a/bin/propolis-server/src/lib/migrate/codec.rs
+++ b/bin/propolis-server/src/lib/migrate/codec.rs
@@ -1,10 +1,9 @@
 //! Copyright 2021 Oxide Computer Company
 //!
-//! Support for framing messages in the propolis/bhyve live
-//! migration protocol.  Frames are defined by a 5-byte header
-//! consisting of a 32-bit length (unsigned little endian)
-//! followed by a tag byte indicating the frame type, and then
-//! the frame data.  The length field includes the header.
+//! Support for encoding messages in the propolis/bhyve live
+//! migration protocol. Messages are serialized to binary and
+//! wrapped in Binary websocket frames with a trailing byte
+//! indicating the message type.
 //!
 //! As defined in RFD0071, most messages are either serialized
 //! structures or blobs, while the structures involved in the
@@ -20,12 +19,12 @@
 //! for that.
 
 use super::MigrateError;
-use bytes::{Buf, BufMut, BytesMut};
+use bytes::{Buf, BufMut, Bytes};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use slog::error;
 use std::convert::TryFrom;
 use thiserror::Error;
-use tokio_util::codec;
+use tokio_tungstenite::tungstenite;
 
 /// Migration protocol errors.
 #[derive(Debug, Error)]
@@ -35,8 +34,8 @@ pub enum ProtocolError {
     InvalidMessageType(u8),
 
     /// The message received on the wire wasn't the expected length
-    #[error("unexpected message length")]
-    UnexpectedMessageLen,
+    #[error("unexpected message length {1} for type {0:?}")]
+    UnexpectedMessageLen(u8, usize),
 
     /// Encountered an I/O error on the transport
     #[error("I/O error: {0}")]
@@ -49,6 +48,18 @@ pub enum ProtocolError {
     /// Received non-UTF8 string
     #[error("non-UTF8 string: {0}")]
     Utf8(#[from] std::str::Utf8Error),
+
+    /// Nothing, not even a tag byte
+    #[error("received empty message with no discriminant")]
+    EmptyMessage,
+
+    /// An error occurred in the underlying websocket transport
+    #[error("error occurred in websocket layer: {0}")]
+    WebsocketError(tokio_tungstenite::tungstenite::Error),
+
+    /// All our codec's messages should be tungstenite::Message::Binary
+    #[error("received empty message with no discriminant")]
+    UnexpectedWebsocketMessage(tungstenite::Message),
 }
 
 /// Message represents the different frame types for messages
@@ -77,7 +88,7 @@ pub(crate) enum Message {
 /// identifying frame types.  They are an implementation detail of
 /// the wire format, and not used elsewhere.  However, they must be
 /// kept in bijection with Message, above.
-#[derive(PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[derive(Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 enum MessageType {
     Okay,
@@ -113,440 +124,238 @@ impl From<&Message> for MessageType {
     }
 }
 
-/// `LiveMigrationEncoder` implements the `Encoder` & `Decoder`
-/// traits for transforming a stream of bytes to/from migration
-/// protocol messages.
-pub(crate) struct LiveMigrationFramer {
-    log: slog::Logger,
-}
-
-impl LiveMigrationFramer {
-    /// Creates a new LiveMigrationFramer, which represents the
-    /// right to encode and decode messages.
-    pub fn new(log: slog::Logger) -> LiveMigrationFramer {
-        LiveMigrationFramer { log }
-    }
-    /// Writes the header at the start of the frame.  Also reserves enough space
-    /// in the destination buffer for the complete message.
-    fn put_header(&mut self, tag: MessageType, len: usize, dst: &mut BytesMut) {
-        let len = len + 5;
-        if dst.remaining_mut() < len {
-            dst.reserve(len - dst.remaining_mut());
-        }
-        dst.put_u32_le(len as u32);
-        dst.put_u8(tag.into());
-    }
-
-    // Writes a (`start`, `end`) pair into the buffer.
-    fn put_start_end(&mut self, start: u64, end: u64, dst: &mut BytesMut) {
-        dst.put_u64_le(start);
-        dst.put_u64_le(end);
-    }
-
-    // Writes a vector of bytes representing a bitmap into the buffer.
-    fn put_bitmap(&mut self, bitmap: &[u8], dst: &mut BytesMut) {
-        dst.put(bitmap);
-    }
-
-    // Retrieves a (`start`, `end`) pair from the buffer.  Ensures
-    // valid length, and returns the length minus the size of the
-    // pair.
-    fn get_start_end(
-        &mut self,
-        len: usize,
-        src: &mut BytesMut,
-    ) -> Result<(usize, u64, u64), ProtocolError> {
-        if len < 16 {
-            error!(self.log, "short message reading start end: {len}");
-            return Err(ProtocolError::UnexpectedMessageLen);
-        }
-        let start = src.get_u64_le();
-        let end = src.get_u64_le();
-        Ok((len - 16, start, end))
-    }
-
-    // Retrieves a bitmap from the buffer.  Validates that enough
-    // bytes are in the buffer to satisfy the request.
-    fn get_bitmap(
-        &mut self,
-        len: usize,
-        src: &mut BytesMut,
-    ) -> Result<Vec<u8>, ProtocolError> {
-        let remaining = src.remaining();
-        if remaining < len {
-            error!(self.log, "short message reading bitmap (remaining: {remaining} len: {len}");
-            return Err(ProtocolError::UnexpectedMessageLen);
-        }
-        let v = src[..len].to_vec();
-        src.advance(len);
-        Ok(v.to_vec())
-    }
-}
-
-impl codec::Encoder<Message> for LiveMigrationFramer {
+impl std::convert::TryInto<tungstenite::Message> for Message {
     type Error = ProtocolError;
-
-    // Encodes each message according to its type.
-    fn encode(
-        &mut self,
-        m: Message,
-        dst: &mut BytesMut,
-    ) -> Result<(), Self::Error> {
-        let tag = (&m).into();
-        match m {
-            Message::Okay => {
-                self.put_header(tag, 0, dst);
-            }
+    fn try_into(self) -> Result<tungstenite::Message, ProtocolError> {
+        let mut dst = Vec::new();
+        let tag = MessageType::from(&self) as u8;
+        match self {
+            Message::Okay | Message::MemDone => {}
             Message::Error(e) => {
                 let serialized = ron::ser::to_string(&e)?;
-                let bytes = serialized.into_bytes();
-                self.put_header(tag, bytes.len(), dst);
-                dst.put(&bytes[..]);
+                dst.extend(serialized.as_bytes());
             }
-            Message::Serialized(s) => {
-                let bytes = s.into_bytes();
-                self.put_header(tag, bytes.len(), dst);
-                dst.put(&bytes[..]);
+            Message::Serialized(s) => dst.put_slice(s.as_bytes()),
+            Message::Blob(bytes) | Message::Page(bytes) => {
+                dst.put_slice(&bytes);
             }
-            Message::Blob(bytes) => {
-                self.put_header(tag, bytes.len(), dst);
-                dst.put(&bytes[..]);
+            Message::MemQuery(start, end) | Message::MemEnd(start, end) => {
+                dst.put_u64_le(start);
+                dst.put_u64_le(end);
             }
-            Message::Page(page) => {
-                self.put_header(tag, page.len(), dst);
-                dst.put(&page[..]);
+            Message::MemOffer(start, end, bitmap)
+            | Message::MemFetch(start, end, bitmap)
+            | Message::MemXfer(start, end, bitmap) => {
+                dst.put_u64_le(start);
+                dst.put_u64_le(end);
+                dst.put_slice(&bitmap);
             }
-            Message::MemQuery(start, end) => {
-                self.put_header(tag, 8 + 8, dst);
-                self.put_start_end(start, end, dst);
-            }
-            Message::MemOffer(start, end, bitmap) => {
-                self.put_header(tag, 8 + 8 + bitmap.len(), dst);
-                self.put_start_end(start, end, dst);
-                self.put_bitmap(&bitmap, dst);
-            }
-            Message::MemEnd(start, end) => {
-                self.put_header(tag, 8 + 8, dst);
-                self.put_start_end(start, end, dst);
-            }
-            Message::MemFetch(start, end, bitmap) => {
-                self.put_header(tag, 8 + 8 + bitmap.len(), dst);
-                self.put_start_end(start, end, dst);
-                self.put_bitmap(&bitmap, dst);
-            }
-            Message::MemXfer(start, end, bitmap) => {
-                self.put_header(tag, 8 + 8 + bitmap.len(), dst);
-                self.put_start_end(start, end, dst);
-                self.put_bitmap(&bitmap, dst);
-            }
-            Message::MemDone => {
-                self.put_header(tag, 0, dst);
-            }
-        };
-        Ok(())
+        }
+        // tag at the end so we can pop it later (& so u64's align nicely)
+        dst.push(tag);
+        Ok(tungstenite::Message::Binary(dst))
     }
 }
 
-impl codec::Decoder for LiveMigrationFramer {
-    type Item = Message;
+// Retrieves a (`start`, `end`) pair from the buffer, ensuring valid length.
+fn get_start_end(
+    tag: MessageType,
+    src: &mut Bytes,
+) -> Result<(u64, u64), ProtocolError> {
+    if src.len() < 16 {
+        return Err(ProtocolError::UnexpectedMessageLen(tag as u8, src.len()));
+    }
+    let start = src.get_u64_le();
+    let end = src.get_u64_le();
+    Ok((start, end))
+}
+
+impl std::convert::TryInto<Message> for tungstenite::Message {
     type Error = ProtocolError;
-
-    // Decodes each message according to the header length and type
-    // indicated by the tag byte.
-    fn decode(
-        &mut self,
-        src: &mut BytesMut,
-    ) -> Result<Option<Self::Item>, Self::Error> {
-        // Each message is prepended with a 5 octet header.  The
-        // first four of those contain a 32-bit little-endian frame
-        // size and the fifth is a tag field.  Check whether the
-        // underlying transport has produced at least 5 bytes for
-        // that header.
-        if src.remaining() < 5 {
-            return Ok(None);
+    fn try_into(self) -> Result<Message, ProtocolError> {
+        match self {
+            tungstenite::Message::Binary(mut v) => {
+                // If the tag byte is absent or invalid, don't bother looking at the message.
+                let tag_byte = v.pop().ok_or(ProtocolError::EmptyMessage)?;
+                let tag = MessageType::try_from(tag_byte)
+                    .map_err(|_| ProtocolError::InvalidMessageType(tag_byte))?;
+                let mut src = Bytes::from(v);
+                // At this point, we have a valid message of a known type, and
+                // the remaining bytes are the message contents.
+                // Attempt decode and return the received message.
+                let m = match tag {
+                    MessageType::Okay => {
+                        if src.len() != 0 {
+                            return Err(ProtocolError::UnexpectedMessageLen(
+                                tag as u8,
+                                src.len(),
+                            ));
+                        }
+                        Message::Okay
+                    }
+                    MessageType::Error => {
+                        let e = ron::de::from_str(std::str::from_utf8(&src)?)?;
+                        Message::Error(e)
+                    }
+                    MessageType::Serialized => {
+                        let s = std::str::from_utf8(&src)?.to_string();
+                        Message::Serialized(s)
+                    }
+                    MessageType::Blob => Message::Blob(src.to_vec()),
+                    MessageType::Page => {
+                        if src.len() != 4096 {
+                            return Err(ProtocolError::UnexpectedMessageLen(
+                                tag as u8,
+                                src.len(),
+                            ));
+                        }
+                        Message::Page(src.to_vec())
+                    }
+                    MessageType::MemQuery => {
+                        let (start, end) = get_start_end(tag, &mut src)?;
+                        Message::MemQuery(start, end)
+                    }
+                    MessageType::MemOffer => {
+                        let (start, end) = get_start_end(tag, &mut src)?;
+                        let bitmap = src.to_vec();
+                        Message::MemOffer(start, end, bitmap)
+                    }
+                    MessageType::MemEnd => {
+                        let (start, end) = get_start_end(tag, &mut src)?;
+                        Message::MemEnd(start, end)
+                    }
+                    MessageType::MemFetch => {
+                        let (start, end) = get_start_end(tag, &mut src)?;
+                        let bitmap = src.to_vec();
+                        Message::MemFetch(start, end, bitmap)
+                    }
+                    MessageType::MemXfer => {
+                        let (start, end) = get_start_end(tag, &mut src)?;
+                        let bitmap = src.to_vec();
+                        Message::MemXfer(start, end, bitmap)
+                    }
+                    MessageType::MemDone => {
+                        if src.len() != 0 {
+                            return Err(ProtocolError::UnexpectedMessageLen(
+                                tag as u8,
+                                src.len(),
+                            ));
+                        }
+                        Message::MemDone
+                    }
+                };
+                Ok(m)
+            }
+            x => Err(ProtocolError::UnexpectedWebsocketMessage(x)),
         }
-        // Extract the frame header.  If the tag byte is invalid,
-        // don't bother looking at the frame size.
-        let tag = MessageType::try_from(src[4])
-            .map_err(|_| ProtocolError::InvalidMessageType(src[4]))?;
-        let len = u32::from_le_bytes([src[0], src[1], src[2], src[3]]) as usize;
-        if len < 5 {
-            error!(self.log, "decode: length too short for header {len}");
-            return Err(ProtocolError::UnexpectedMessageLen);
-        }
-        // The frame header looks valid; ensure we have read the entire
-        // message.
-        if src.remaining() < len {
-            src.reserve(len - src.remaining());
-            return Ok(None);
-        }
-        // At this point, we have a valid message of the specified length.
-        // Advance past the frame header, attempt decode and return the
-        // received message.
-        src.advance(5);
-        let len = len - 5;
-        let m = match tag {
-            MessageType::Okay => {
-                assert_eq!(len, 0);
-                Message::Okay
-            }
-            MessageType::Error => {
-                let e = ron::de::from_str(std::str::from_utf8(&src[..len])?)?;
-                src.advance(len);
-                Message::Error(e)
-            }
-            MessageType::Serialized => {
-                let s = std::str::from_utf8(&src[..len])?.to_string();
-                src.advance(len);
-                Message::Serialized(s)
-            }
-            MessageType::Blob => {
-                let v = src[..len].to_vec();
-                src.advance(len);
-                Message::Blob(v)
-            }
-            MessageType::Page => {
-                if len != 4096 {
-                    error!(
-                        self.log,
-                        "decode: invalid length for `Page` message (len)"
-                    );
-                    return Err(ProtocolError::UnexpectedMessageLen);
-                }
-                let p = src[..len].to_vec();
-                src.advance(len);
-                Message::Page(p)
-            }
-            MessageType::MemQuery => {
-                let (_, start, end) = self.get_start_end(len, src)?;
-                Message::MemQuery(start, end)
-            }
-            MessageType::MemOffer => {
-                let (len, start, end) = self.get_start_end(len, src)?;
-                let bitmap = self.get_bitmap(len, src)?;
-                Message::MemOffer(start, end, bitmap)
-            }
-            MessageType::MemEnd => {
-                let (_, start, end) = self.get_start_end(len, src)?;
-                Message::MemEnd(start, end)
-            }
-            MessageType::MemFetch => {
-                let (len, start, end) = self.get_start_end(len, src)?;
-                let bitmap = self.get_bitmap(len, src)?;
-                Message::MemFetch(start, end, bitmap)
-            }
-            MessageType::MemXfer => {
-                let (len, start, end) = self.get_start_end(len, src)?;
-                let bitmap = self.get_bitmap(len, src)?;
-                Message::MemXfer(start, end, bitmap)
-            }
-            MessageType::MemDone => {
-                assert_eq!(len, 0);
-                Message::MemDone
-            }
-        };
-        Ok(Some(m))
-    }
-}
-
-#[cfg(test)]
-fn test_framer() -> LiveMigrationFramer {
-    let log = slog::Logger::root(slog::Discard, slog::o!());
-    LiveMigrationFramer::new(log)
-}
-
-#[cfg(test)]
-mod live_migration_encoder_tests {
-    use super::*;
-
-    #[test]
-    fn put_header() {
-        let mut bytes = BytesMut::new();
-        let mut encoder = test_framer();
-        encoder.put_header(MessageType::Okay, 0, &mut bytes);
-        assert_eq!(&bytes[..], &[5, 0, 0, 0, 0]);
-    }
-
-    #[test]
-    fn put_header_nonzero_tag() {
-        let mut bytes = BytesMut::new();
-        let mut encoder = test_framer();
-        encoder.put_header(MessageType::Error, 0, &mut bytes);
-        assert_eq!(&bytes[..], &[5, 0, 0, 0, 1]);
-    }
-
-    #[test]
-    fn put_start_end() {
-        let mut bytes = BytesMut::new();
-        let mut encoder = test_framer();
-        encoder.put_start_end(1, 2, &mut bytes);
-        assert_eq!(
-            &bytes[..],
-            &[1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0]
-        );
-    }
-
-    #[test]
-    fn put_empty_bitmap() {
-        let mut bytes = BytesMut::new();
-        let mut encoder = test_framer();
-        let v = Vec::new();
-        encoder.put_bitmap(&v, &mut bytes);
-        assert!(&bytes[..].is_empty());
-    }
-
-    #[test]
-    fn put_bitmap() {
-        let mut bytes = BytesMut::new();
-        let mut encoder = test_framer();
-        let v = vec![0b1100_0000];
-        encoder.put_bitmap(&v, &mut bytes);
-        assert_eq!(&bytes[..], &[0b1100_0000]);
     }
 }
 
 #[cfg(test)]
 mod encoder_tests {
     use super::*;
-    use tokio_util::codec::Encoder;
+    use std::convert::TryInto;
+    use tokio_tungstenite::tungstenite;
+
+    fn encode(m: Message) -> Vec<u8> {
+        if let tungstenite::Message::Binary(bytes) = m.try_into().unwrap() {
+            return bytes;
+        } else {
+            panic!();
+        }
+    }
 
     #[test]
     fn encode_okay() {
-        let mut bytes = BytesMut::new();
-        let mut encoder = test_framer();
-        let okay = Message::Okay;
-        encoder.encode(okay, &mut bytes).ok();
-        assert_eq!(&bytes[..], &[5, 0, 0, 0, MessageType::Okay as u8]);
+        let bytes = encode(Message::Okay);
+        assert_eq!(&bytes[..], &[MessageType::Okay as u8]);
     }
 
     #[test]
     fn encode_error() {
-        let mut bytes = BytesMut::new();
         let error = MigrateError::Initiate;
-        let mut encoder = test_framer();
-        encoder.encode(Message::Error(error), &mut bytes).ok();
-        assert_eq!(&bytes[..5], &[13, 0, 0, 0, MessageType::Error as u8]);
-        assert_eq!(&bytes[5..], br#"Initiate"#);
+        let mut bytes = encode(Message::Error(error));
+        assert_eq!(bytes.pop(), Some(MessageType::Error as u8));
+        assert_eq!(&bytes[..], br#"Initiate"#);
     }
 
     #[test]
     fn encode_serialized() {
-        let mut bytes = BytesMut::new();
         let obj = String::from("this is an object");
-        let mut encoder = test_framer();
-        encoder.encode(Message::Serialized(obj), &mut bytes).ok();
-        assert_eq!(
-            &bytes[..5],
-            &[17 + 5, 0, 0, 0, MessageType::Serialized as u8]
-        );
-        assert_eq!(&bytes[5..], b"this is an object");
+        let mut bytes = encode(Message::Serialized(obj));
+        assert_eq!(bytes.pop(), Some(MessageType::Serialized as u8));
+        assert_eq!(&bytes[..], b"this is an object");
     }
 
     #[test]
     fn encode_empty_blob() {
-        let mut bytes = BytesMut::new();
         let empty = Vec::new();
-        let mut encoder = test_framer();
-        encoder.encode(Message::Blob(empty), &mut bytes).ok();
-        assert_eq!(&bytes[..], &[5, 0, 0, 0, MessageType::Blob as u8]);
+        let bytes = encode(Message::Blob(empty));
+        assert_eq!(&bytes[..], &[MessageType::Blob as u8]);
     }
 
     #[test]
     fn encode_blob() {
-        let mut bytes = BytesMut::new();
-        let empty = vec![1, 2, 3, 4];
-        let mut encoder = test_framer();
-        encoder.encode(Message::Blob(empty), &mut bytes).ok();
-        assert_eq!(
-            &bytes[..],
-            &[9, 0, 0, 0, MessageType::Blob as u8, 1, 2, 3, 4]
-        );
+        let nonempty = vec![1, 2, 3, 4];
+        let bytes = encode(Message::Blob(nonempty));
+        assert_eq!(&bytes[..], &[1, 2, 3, 4, MessageType::Blob as u8]);
     }
 
     #[test]
     fn encode_page() {
-        let mut bytes = BytesMut::new();
         let page = [0u8; 4096];
-        let mut encoder = test_framer();
-        encoder.encode(Message::Page(page.to_vec()), &mut bytes).ok();
-        assert_eq!(
-            &bytes[..5],
-            [5, 0b0001_0000, 0, 0, MessageType::Page as u8]
-        );
-        assert!(&bytes[5..].iter().all(|&x| x == 0));
+        let mut bytes = encode(Message::Page(page.to_vec()));
+        assert_eq!(bytes.pop(), Some(MessageType::Page as u8));
+        assert_eq!(bytes, page);
     }
 
     #[test]
     fn encode_mem_query() {
-        let mut bytes = BytesMut::new();
-        let mut encoder = test_framer();
-        encoder.encode(Message::MemQuery(1, 2), &mut bytes).ok();
-        assert_eq!(&bytes[..5], &[21, 0, 0, 0, MessageType::MemQuery as u8]);
-        assert_eq!(&bytes[5..5 + 8], &[1, 0, 0, 0, 0, 0, 0, 0]);
-        assert_eq!(&bytes[5 + 8..], &[2, 0, 0, 0, 0, 0, 0, 0]);
+        let mut bytes = encode(Message::MemQuery(1, 2));
+        assert_eq!(bytes.pop(), Some(MessageType::MemQuery as u8));
+        assert_eq!(&bytes[..8], &[1, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(&bytes[8..], &[2, 0, 0, 0, 0, 0, 0, 0]);
     }
 
     #[test]
     fn encode_mem_offer() {
-        let mut bytes = BytesMut::new();
-        let mut encoder = test_framer();
-        encoder
-            .encode(Message::MemOffer(0, 0x8000, vec![0b1010_0101]), &mut bytes)
-            .ok();
-        assert_eq!(&bytes[..5], [22, 0, 0, 0, MessageType::MemOffer as u8]);
-        assert_eq!(&bytes[5..5 + 8], &[0, 0, 0, 0, 0, 0, 0, 0]);
-        assert_eq!(
-            &bytes[5 + 8..5 + 8 + 8],
-            &[0, 0b1000_0000, 0, 0, 0, 0, 0, 0]
-        );
-        assert_eq!(&bytes[5 + 8 + 8..], &[0b1010_0101]);
+        let mut bytes = encode(Message::MemOffer(0, 0x8000, vec![0b1010_0101]));
+        assert_eq!(bytes.pop(), Some(MessageType::MemOffer as u8));
+        assert_eq!(&bytes[..8], &[0, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(&bytes[8..8 + 8], &[0, 0b1000_0000, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(&bytes[8 + 8..], &[0b1010_0101]);
     }
 
     #[test]
     fn encode_mem_end() {
-        let mut bytes = BytesMut::new();
-        let mut encoder = test_framer();
-        encoder.encode(Message::MemEnd(0, 8 * 4096), &mut bytes).ok();
-        assert_eq!(&bytes[..5], [21, 0, 0, 0, MessageType::MemEnd as u8]);
-        assert_eq!(&bytes[5..5 + 8], &[0, 0, 0, 0, 0, 0, 0, 0]);
-        assert_eq!(
-            &bytes[5 + 8..5 + 8 + 8],
-            &[0, 0b1000_0000, 0, 0, 0, 0, 0, 0]
-        );
+        let mut bytes = encode(Message::MemEnd(0, 8 * 4096));
+        assert_eq!(bytes.pop(), Some(MessageType::MemEnd as u8));
+        assert_eq!(&bytes[..8], &[0, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(&bytes[8..], &[0, 0b1000_0000, 0, 0, 0, 0, 0, 0]);
     }
 
     #[test]
     fn encode_mem_fetch() {
-        let mut bytes = BytesMut::new();
-        let mut encoder = test_framer();
-        encoder
-            .encode(Message::MemFetch(0, 0x4000, vec![0b0000_0101]), &mut bytes)
-            .ok();
-        assert_eq!(&bytes[..5], [22, 0, 0, 0, MessageType::MemFetch as u8]);
-        assert_eq!(&bytes[5..5 + 8], &[0, 0, 0, 0, 0, 0, 0, 0]);
-        assert_eq!(&bytes[5 + 8..5 + 8 + 8], &[0, 0x40, 0, 0, 0, 0, 0, 0]);
-        assert_eq!(&bytes[5 + 8 + 8..], &[0b0000_0101]);
+        let mut bytes = encode(Message::MemFetch(0, 0x4000, vec![0b0000_0101]));
+        assert_eq!(bytes.pop(), Some(MessageType::MemFetch as u8));
+        assert_eq!(&bytes[..8], &[0, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(&bytes[8..8 + 8], &[0, 0x40, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(&bytes[8 + 8..], &[0b0000_0101]);
     }
 
     #[test]
     fn encode_mem_xfer() {
-        let mut bytes = BytesMut::new();
-        let mut encoder = test_framer();
-        encoder
-            .encode(Message::MemXfer(0, 0x8000, vec![0b1010_0101]), &mut bytes)
-            .ok();
-        assert_eq!(&bytes[..5], [22, 0, 0, 0, MessageType::MemXfer as u8]);
-        assert_eq!(&bytes[5..5 + 8], &[0, 0, 0, 0, 0, 0, 0, 0]);
-        assert_eq!(&bytes[5 + 8..5 + 8 + 8], &[0, 0x80, 0, 0, 0, 0, 0, 0]);
-        assert_eq!(&bytes[5 + 8 + 8..], &[0b1010_0101]);
+        let mut bytes = encode(Message::MemXfer(0, 0x8000, vec![0b1010_0101]));
+        assert_eq!(bytes.pop(), Some(MessageType::MemXfer as u8));
+        assert_eq!(&bytes[..8], &[0, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(&bytes[8..8 + 8], &[0, 0x80, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(&bytes[8 + 8..], &[0b1010_0101]);
     }
 
     #[test]
     fn encode_mem_done() {
-        let mut bytes = BytesMut::new();
-        let mut encoder = test_framer();
-        encoder.encode(Message::MemDone, &mut bytes).ok();
-        assert_eq!(&bytes[..], [5, 0, 0, 0, MessageType::MemDone as u8]);
+        let bytes = encode(Message::MemDone);
+        assert_eq!(&bytes[..], [MessageType::MemDone as u8]);
     }
 }
 
@@ -555,159 +364,109 @@ mod live_migration_decoder_tests {
     use super::*;
 
     #[test]
-    fn get_start_end() {
-        let mut bytes = BytesMut::new();
-        bytes.put_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0]);
-        let mut decoder = test_framer();
-        let (_, start, end) =
-            decoder.get_start_end(bytes.remaining(), &mut bytes).unwrap();
+    fn get_start_end_ok() {
+        let one_two = &[1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0];
+        let mut bytes = bytes::Bytes::from_static(one_two);
+        let (start, end) =
+            super::get_start_end(MessageType::MemFetch, &mut bytes).unwrap();
         assert_eq!(start, 1);
         assert_eq!(end, 2);
     }
 
     #[test]
-    fn get_bitmap_empty() {
-        let mut bytes = BytesMut::new();
-        let mut decoder = test_framer();
-        let bitmap = decoder.get_bitmap(0, &mut bytes).unwrap();
-        assert_eq!(bitmap.len(), 0);
-    }
-
-    #[test]
-    fn get_bitmap_exact() {
-        let mut bytes = BytesMut::with_capacity(1);
-        bytes.put_u8(0b1111_0000);
-        let mut decoder = test_framer();
-        let bitmap = decoder.get_bitmap(1, &mut bytes).unwrap();
-        assert_eq!(bitmap.len(), 1);
-        assert_eq!(bitmap[0], 0b1111_0000);
+    fn get_start_end_err() {
+        let one_tw = &[1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0];
+        let mut bytes = bytes::Bytes::from_static(one_tw);
+        assert!(
+            super::get_start_end(MessageType::MemFetch, &mut bytes).is_err()
+        );
     }
 }
 
 #[cfg(test)]
 mod decoder_tests {
     use super::*;
-    use tokio_util::codec::Decoder;
+    use std::convert::TryInto;
+    use tokio_tungstenite::tungstenite;
 
     #[test]
     fn decode_bad_tag_fails() {
-        let mut bytes = BytesMut::with_capacity(5);
-        bytes.put_slice(&[5, 0, 0, 0, 222]);
-        let mut decoder = test_framer();
-        assert!(decoder.decode(&mut bytes).is_err());
+        let bytes = vec![222];
+        let res: Result<Message, _> =
+            tungstenite::Message::Binary(bytes).try_into();
+        assert!(res.is_err());
     }
 
     #[test]
-    fn decode_short() {
-        let mut bytes = BytesMut::with_capacity(5);
-        bytes.put_slice(&[5, 0, 0]);
-        let mut decoder = test_framer();
-        assert!(matches!(decoder.decode(&mut bytes), Ok(None)));
-        bytes.put_slice(&[0, 0]);
-        assert!(matches!(decoder.decode(&mut bytes), Ok(Some(Message::Okay))));
+    fn decode_nonbinary_fails() {
+        let res: Result<Message, _> =
+            tungstenite::Message::Text(String::new()).try_into();
+        assert!(res.is_err());
     }
 
     #[test]
-    fn decode_bad_length_fails() {
-        let mut bytes = BytesMut::with_capacity(5);
-        bytes.put_slice(&[3, 0, 0, 0, 0]);
-        let mut decoder = test_framer();
-        assert!(decoder.decode(&mut bytes).is_err());
+    fn decode_tagless_fails() {
+        let res: Result<Message, _> =
+            tungstenite::Message::Binary(vec![]).try_into();
+        assert!(res.is_err());
     }
 
     #[test]
     fn decode_error() {
-        let mut bytes = BytesMut::with_capacity(16);
-        bytes.put_slice(&[16, 0, 0, 0, MessageType::Error as u8]);
-        bytes.put_slice(&br#"Http("foo")"#[..]);
-        let mut decoder = test_framer();
-        let decoded = decoder.decode(&mut bytes);
-        let expected = MigrateError::Http("foo".into());
-        assert!(
-            matches!(decoded, Ok(Some(Message::Error(e))) if e == expected)
-        );
-    }
-
-    #[test]
-    fn decode_two_errors() {
-        let mut bytes = BytesMut::with_capacity(16 * 2);
-        bytes.put_slice(&[16, 0, 0, 0, MessageType::Error as u8]);
-        bytes.put_slice(&br#"Http("foo")"#[..]);
-        bytes.put_slice(&[16, 0, 0, 0, MessageType::Error as u8]);
-        bytes.put_slice(&br#"Http("bar")"#[..]);
-        let mut decoder = test_framer();
-        let decoded = decoder.decode(&mut bytes);
-        let expected = MigrateError::Http("foo".into());
-        assert!(
-            matches!(decoded, Ok(Some(Message::Error(e))) if e == expected)
-        );
-        let decoded = decoder.decode(&mut bytes);
-        let expected = MigrateError::Http("bar".into());
-        assert!(
-            matches!(decoded, Ok(Some(Message::Error(e))) if e == expected)
-        );
+        let mut bytes = br#"Websocket("foo")"#.to_vec();
+        bytes.push(MessageType::Error as u8);
+        let expected = MigrateError::Websocket("foo".into());
+        let decoded = tungstenite::Message::Binary(bytes).try_into().unwrap();
+        assert!(matches!(decoded, Message::Error(e) if e == expected));
     }
 
     #[test]
     fn decode_blob() {
-        let mut bytes = BytesMut::with_capacity(9);
-        bytes.put_slice(&[9, 0, 0, 0, MessageType::Blob as u8]);
-        bytes.put_slice(&b"asdf"[..]);
-        let mut decoder = test_framer();
-        let decoded = decoder.decode(&mut bytes);
-        assert!(
-            matches!(decoded, Ok(Some(Message::Blob(b))) if b == b"asdf".to_vec())
-        );
+        let mut bytes = b"asdf".to_vec();
+        bytes.push(MessageType::Blob as u8);
+        let decoded = tungstenite::Message::Binary(bytes).try_into().unwrap();
+        assert!(matches!(decoded, Message::Blob(b) if b == b"asdf".to_vec()));
     }
 
     #[test]
     fn decode_page() {
-        let mut bytes = BytesMut::with_capacity(5 + 4096);
-        bytes.put_slice(&[5, 0x10, 0, 0, MessageType::Page as u8]);
-        let page = [0u8; 4096];
-        bytes.put_slice(&page[..]);
-        let mut decoder = test_framer();
-        let decoded = decoder.decode(&mut bytes);
-        assert!(matches!(decoded, Ok(Some(Message::Page(p)))
+        let mut bytes = vec![0u8; 4096];
+        bytes.push(MessageType::Page as u8);
+        let decoded = tungstenite::Message::Binary(bytes).try_into().unwrap();
+        assert!(matches!(decoded, Message::Page(p)
             if p.iter().all(|&b| b == 0)));
     }
 
     #[test]
     fn decode_mem_query() {
-        let mut bytes = BytesMut::with_capacity(5 + 8 + 8);
-        bytes.put_slice(&[5 + 8 + 8, 0, 0, 0, MessageType::MemQuery as u8]);
-        bytes.put_slice(&[1, 0, 0, 0, 0, 0, 0, 0]);
-        bytes.put_slice(&[2, 0, 0, 0, 0, 0, 0, 0]);
-        let mut decoder = test_framer();
-        let decoded = decoder.decode(&mut bytes);
-        assert!(matches!(decoded, Ok(Some(Message::MemQuery(start, end)))
+        let mut bytes = vec![1, 0, 0, 0, 0, 0, 0, 0];
+        bytes.extend(&[2, 0, 0, 0, 0, 0, 0, 0]);
+        bytes.push(MessageType::MemQuery as u8);
+        let decoded = tungstenite::Message::Binary(bytes).try_into().unwrap();
+        assert!(matches!(decoded, Message::MemQuery(start, end)
             if start == 1 && end == 2));
     }
 
     #[test]
     fn decode_mem_offer() {
-        let mut bytes = BytesMut::with_capacity(5 + 8 + 8 + 1);
-        bytes.put_slice(&[5 + 8 + 8 + 1, 0, 0, 0, MessageType::MemOffer as u8]);
-        bytes.put_slice(&[0, 0, 0, 0, 0, 0, 0, 0]);
-        bytes.put_slice(&[0, 0x80, 0, 0, 0, 0, 0, 0]);
-        bytes.put_u8(0b0000_1111);
-        let mut decoder = test_framer();
-        let decoded = decoder.decode(&mut bytes);
-        assert!(matches!(decoded, Ok(Some(Message::MemOffer(start, end, v)))
+        let mut bytes = vec![0, 0, 0, 0, 0, 0, 0, 0];
+        bytes.extend(&[0, 0x80, 0, 0, 0, 0, 0, 0]);
+        bytes.push(0b0000_1111);
+        bytes.push(MessageType::MemOffer as u8);
+        let decoded = tungstenite::Message::Binary(bytes).try_into().unwrap();
+        assert!(matches!(decoded, Message::MemOffer(start, end, v)
             if start == 0 && end == 0x8000 && v == vec![0b0000_1111]));
     }
 
     #[test]
     fn decode_mem_offer_long_bitmap() {
-        let mut bytes = BytesMut::with_capacity(5 + 8 + 8 + 2);
-        bytes.put_slice(&[5 + 8 + 8 + 2, 0, 0, 0, MessageType::MemOffer as u8]);
-        bytes.put_slice(&[0, 0, 0, 0, 0, 0, 0, 0]);
-        bytes.put_slice(&[0, 0x80, 0, 0, 0, 0, 0, 0]);
-        bytes.put_u8(0b0000_1111);
-        bytes.put_u8(0b0000_1010);
-        let mut decoder = test_framer();
-        let decoded = decoder.decode(&mut bytes);
-        assert!(matches!(decoded, Ok(Some(Message::MemOffer(start, end, v)))
+        let mut bytes = vec![0, 0, 0, 0, 0, 0, 0, 0];
+        bytes.extend(&[0, 0x80, 0, 0, 0, 0, 0, 0]);
+        bytes.push(0b0000_1111);
+        bytes.push(0b0000_1010);
+        bytes.push(MessageType::MemOffer as u8);
+        let decoded = tungstenite::Message::Binary(bytes).try_into().unwrap();
+        assert!(matches!(decoded, Message::MemOffer(start, end, v)
             if start == 0 &&
                 end == 0x8000 &&
                 v == vec![0b0000_1111, 0b0000_1010]));
@@ -715,50 +474,40 @@ mod decoder_tests {
 
     #[test]
     fn decode_mem_end() {
-        let mut bytes = BytesMut::with_capacity(5 + 8 + 8);
-        bytes.put_slice(&[5 + 8 + 8, 0, 0, 0, MessageType::MemEnd as u8]);
-        bytes.put_slice(&[0, 0x40, 0, 0, 0, 0, 0, 0]);
-        bytes.put_slice(&[0, 0x40 + 0x80, 0, 0, 0, 0, 0, 0]);
-        let mut decoder = test_framer();
-        let decoded = decoder.decode(&mut bytes);
-        assert!(matches!(decoded, Ok(Some(Message::MemEnd(start, end)))
+        let mut bytes = vec![0, 0x40, 0, 0, 0, 0, 0, 0];
+        bytes.extend(&[0, 0x40 + 0x80, 0, 0, 0, 0, 0, 0]);
+        bytes.push(MessageType::MemEnd as u8);
+        let decoded = tungstenite::Message::Binary(bytes).try_into().unwrap();
+        assert!(matches!(decoded, Message::MemEnd(start, end)
             if start == 0x4000 && end == 0xC000));
     }
 
     #[test]
     fn decode_mem_fetch() {
-        let mut bytes = BytesMut::with_capacity(5 + 8 + 8 + 1);
-        bytes.put_slice(&[5 + 8 + 8 + 1, 0, 0, 0, MessageType::MemFetch as u8]);
-        bytes.put_slice(&[0, 0, 0, 0, 0, 0, 0, 0]);
-        bytes.put_slice(&[0, 0x80, 0, 0, 0, 0, 0, 0]);
-        bytes.put_u8(0b0000_1111);
-        let mut decoder = test_framer();
-        let decoded = decoder.decode(&mut bytes);
-        assert!(matches!(decoded, Ok(Some(Message::MemFetch(start, end, v)))
+        let mut bytes = vec![0, 0, 0, 0, 0, 0, 0, 0];
+        bytes.extend(&[0, 0x80, 0, 0, 0, 0, 0, 0]);
+        bytes.push(0b0000_1111);
+        bytes.push(MessageType::MemFetch as u8);
+        let decoded = tungstenite::Message::Binary(bytes).try_into().unwrap();
+        assert!(matches!(decoded, Message::MemFetch(start, end, v)
             if start == 0 && end == 0x8000 && v == vec![0b0000_1111]));
     }
 
     #[test]
     fn decode_mem_xfer() {
-        let mut bytes = BytesMut::with_capacity(5 + 8 + 8 + 1);
-        bytes.put_slice(&[5 + 8 + 8 + 1, 0, 0, 0, MessageType::MemXfer as u8]);
-        bytes.put_slice(&[0, 0, 0, 0, 0, 0, 0, 0]);
-        bytes.put_slice(&[0, 0x80, 0, 0, 0, 0, 0, 0]);
-        bytes.put_u8(0b0000_1111);
-        let mut decoder = test_framer();
-        let decoded = decoder.decode(&mut bytes);
-        assert!(matches!(decoded, Ok(Some(Message::MemXfer(start, end, v)))
+        let mut bytes = vec![0, 0, 0, 0, 0, 0, 0, 0];
+        bytes.extend(&[0, 0x80, 0, 0, 0, 0, 0, 0]);
+        bytes.push(0b0000_1111);
+        bytes.push(MessageType::MemXfer as u8);
+        let decoded = tungstenite::Message::Binary(bytes).try_into().unwrap();
+        assert!(matches!(decoded, Message::MemXfer(start, end, v)
             if start == 0 && end == 0x8000 && v == vec![0b0000_1111]));
     }
 
     #[test]
     fn decode_mem_done() {
-        let mut bytes = BytesMut::with_capacity(5);
-        bytes.put_slice(&[5, 0, 0, 0, MessageType::MemDone as u8]);
-        let mut decoder = test_framer();
-        assert!(matches!(
-            decoder.decode(&mut bytes),
-            Ok(Some(Message::MemDone))
-        ));
+        let bytes = vec![MessageType::MemDone as u8];
+        let decoded = tungstenite::Message::Binary(bytes).try_into().unwrap();
+        assert!(matches!(decoded, Message::MemDone));
     }
 }

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -1,15 +1,16 @@
 use futures::{SinkExt, StreamExt};
-use hyper::upgrade::Upgraded;
 use propolis::common::GuestAddr;
 use propolis::inventory::Order;
 use propolis::migrate::{MigrateCtx, MigrateStateError, Migrator};
 use slog::{error, info};
+use std::convert::TryInto;
 use std::io;
 use std::ops::{Range, RangeInclusive};
 use std::sync::Arc;
-use tokio_util::codec::Framed;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_tungstenite::WebSocketStream;
 
-use crate::migrate::codec::{self, LiveMigrationFramer};
+use crate::migrate::codec;
 use crate::migrate::memx;
 use crate::migrate::preamble::Preamble;
 use crate::migrate::{
@@ -17,11 +18,11 @@ use crate::migrate::{
 };
 use crate::vm::{MigrateSourceCommand, MigrateSourceResponse, VmController};
 
-pub async fn migrate(
+pub async fn migrate<T: AsyncRead + AsyncWrite + Unpin + Send>(
     vm_controller: Arc<VmController>,
     command_tx: tokio::sync::mpsc::Sender<MigrateSourceCommand>,
     response_rx: tokio::sync::mpsc::Receiver<MigrateSourceResponse>,
-    conn: Upgraded,
+    conn: WebSocketStream<T>,
 ) -> Result<(), MigrateError> {
     let err_tx = command_tx.clone();
     let mut proto =
@@ -37,14 +38,14 @@ pub async fn migrate(
         // Note, we don't use `?` here as this is a best effort and we don't
         // want an error encountered during this send to shadow the run error
         // from the caller.
-        let _ = proto.conn.send(codec::Message::Error(err.clone())).await;
+        let _ = proto.send_msg(codec::Message::Error(err.clone())).await;
         return Err(err);
     }
 
     Ok(())
 }
 
-struct SourceProtocol {
+struct SourceProtocol<T: AsyncRead + AsyncWrite + Unpin + Send> {
     /// The VM controller for the instance of interest.
     vm_controller: Arc<VmController>,
 
@@ -57,23 +58,17 @@ struct SourceProtocol {
     response_rx: tokio::sync::mpsc::Receiver<MigrateSourceResponse>,
 
     /// Transport to the destination Instance.
-    conn: Framed<Upgraded, LiveMigrationFramer>,
+    conn: WebSocketStream<T>,
 }
 
-impl SourceProtocol {
+impl<T: AsyncRead + AsyncWrite + Unpin + Send> SourceProtocol<T> {
     fn new(
         vm_controller: Arc<VmController>,
         command_tx: tokio::sync::mpsc::Sender<MigrateSourceCommand>,
         response_rx: tokio::sync::mpsc::Receiver<MigrateSourceResponse>,
-        conn: Upgraded,
+        conn: WebSocketStream<T>,
     ) -> Self {
-        let codec_log = vm_controller.log().new(slog::o!());
-        Self {
-            vm_controller,
-            command_tx,
-            response_rx,
-            conn: Framed::new(conn, LiveMigrationFramer::new(codec_log)),
-        }
+        Self { vm_controller, command_tx, response_rx, conn }
     }
 
     fn log(&self) -> &slog::Logger {
@@ -323,6 +318,9 @@ impl SourceProtocol {
                     io::ErrorKind::BrokenPipe,
                 ))
             })?
+            .map_err(|e| codec::ProtocolError::WebsocketError(e))
+            // convert tungstenite::Message to codec::Message
+            .and_then(std::convert::TryInto::try_into)
             // If this is an error message, lift that out
             .map(|msg| match msg {
                 codec::Message::Error(err) => {
@@ -365,7 +363,7 @@ impl SourceProtocol {
         &mut self,
         m: codec::Message,
     ) -> Result<(), MigrateError> {
-        Ok(self.conn.send(m).await?)
+        Ok(self.conn.send(m.try_into()?).await?)
     }
 
     async fn vmm_ram_bounds(

--- a/bin/propolis-server/src/main.rs
+++ b/bin/propolis-server/src/main.rs
@@ -12,6 +12,7 @@ use propolis::usdt::register_probes;
 use slog::info;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use propolis_server::server::MetricsEndpointConfig;
 use propolis_server::vnc::setup_vnc;
@@ -106,7 +107,7 @@ async fn main() -> anyhow::Result<()> {
             let server = HttpServerStarter::new(
                 &config_dropshot,
                 server::api(),
-                context,
+                Arc::new(context),
                 &log,
             )
             .map_err(|error| anyhow!("Failed to start server: {}", error))?

--- a/lib/propolis-client/src/handmade/mod.rs
+++ b/lib/propolis-client/src/handmade/mod.rs
@@ -181,14 +181,11 @@ impl Client {
         &self,
         migration_id: Uuid,
     ) -> Result<api::InstanceMigrateStatusResponse, Error> {
-        let path = format!("http://{}/instance/migrate/status", self.address);
-        let body = Body::from(
-            serde_json::to_string(&api::InstanceMigrateStatusRequest {
-                migration_id,
-            })
-            .unwrap(),
+        let path = format!(
+            "http://{}/instance/migrate/{}/status",
+            self.address, migration_id
         );
-        self.get(path, Some(body)).await
+        self.get(path, None).await
     }
 
     /// Returns the WebSocket URI to an instance's serial console stream.

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -112,19 +112,20 @@
         }
       }
     },
-    "/instance/migrate/status": {
+    "/instance/migrate/{migration_id}/status": {
       "get": {
         "operationId": "instance_migrate_status",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InstanceMigrateStatusRequest"
-              }
+        "parameters": [
+          {
+            "in": "path",
+            "name": "migration_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
             }
-          },
-          "required": true
-        },
+          }
+        ],
         "responses": {
           "200": {
             "description": "successful operation",
@@ -779,18 +780,6 @@
         ]
       },
       "InstanceMigrateInitiateResponse": {
-        "type": "object",
-        "properties": {
-          "migration_id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        },
-        "required": [
-          "migration_id"
-        ]
-      },
-      "InstanceMigrateStatusRequest": {
         "type": "object",
         "properties": {
           "migration_id": {


### PR DESCRIPTION
...and (or to be more precise, *because of*) update to Dropshot 0.9.x to match Omicron main.

In Dropshot 0.9.x, an owned copy of the hyper::Request is no longer available to endpoint handlers through the RequestContext. This poses a problem for the custom wire protocol Propolis used for migration data because we can no longer negotiate a HTTP upgrade.

So instead, let's switch out the custom data framing protocol for the one provided in Dropshot `#[channel]` (that being the Websockets support I added a while back) while keeping most of the data format the same. In essence, this means just shoving it into a
`tungstenite::Message::Binary(vec![/* everything but the length, which is now handled for us */])`. The protocol version "negotiation" that was once done in the HTTP upgrade header is now done by exchanging `tungstenite::Message::Text(/* the version string */)` before handing the channel off.

I've also taken a couple small liberties as a matter of preference, since we're breaking compatibility anyhow:
- the API endpoints are now `/instance/migrate/{migration_id}/[start|status]`, which I believe is more idiomatic REST than having the `migration_id` be in the query parameters of one and the request body of the other, especially when it's the *only* parameter in both cases.
- the `MessageType` tag byte in the websocket message is at the end of the message, as it means the `u64`s we read from the beginning of the `Vec` are more likely to be nicely aligned in memory, in case that ever matters (i.e. we someday end up running on some platform where that's necessary).