### PR TITLE
package: update to new package manifest format and corrupt archive fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -715,7 +715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1631ca6e3c59112501a9d87fd86f21591ff77acd31331e8a73f8d80a65bbdd71"
 dependencies = [
  "nix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1075,14 +1075,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4295cbb7573c16d310e99e713cf9e75101eb190ab31fccd35f2d2691b4352b19"
+checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
 dependencies = [
  "console",
  "number_prefix",
@@ -1595,7 +1595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1622,7 +1622,7 @@ dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1824,7 +1824,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2113,12 +2113,16 @@ dependencies = [
 
 [[package]]
 name = "omicron-zone-package"
-version = "0.1.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd2e4dbdcf6781c86cee71b7d30a7fed585fd1653dd896c2347ff2239b553aa"
+checksum = "2444a2bdf8bbf30622eeabfe1c6d5caa8ff5e31b679fe7143ef97e514709a3da"
 dependencies = [
  "anyhow",
+ "async-trait",
+ "chrono",
+ "filetime",
  "flate2",
+ "futures-util",
  "reqwest",
  "serde",
  "serde_derive",
@@ -2126,7 +2130,8 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml 0.5.11",
+ "toml 0.7.2",
+ "walkdir",
 ]
 
 [[package]]
@@ -2336,7 +2341,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2849,6 +2854,7 @@ name = "propolis-package"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "indicatif",
  "omicron-zone-package",
  "tokio",
 ]
@@ -3192,7 +3198,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3243,7 +3249,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3997,7 +4003,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4769,46 +4775,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ expectorate = "1.0.5"
 futures = "0.3"
 hex = "0.4.3"
 hyper = "0.14"
+indicatif = "0.17.3"
 inventory = "0.3.0"
 ispf = { git = "https://github.com/oxidecomputer/ispf" }
 lazy_static = "1.4"
@@ -78,7 +79,7 @@ libloading = "0.7"
 mockall = "0.11"
 num_enum = "0.5"
 omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-omicron-zone-package = "0.1.2"
+omicron-zone-package = "0.7.1"
 once_cell = "1.13"
 oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }

--- a/packaging/package-manifest.toml
+++ b/packaging/package-manifest.toml
@@ -1,9 +1,10 @@
 [package.propolis-server]
-rust.binary_names = ["propolis-server"]
-rust.release = true
 service_name = "propolis-server"
-zone = true
-blobs = [ "alpine.iso", "OVMF_CODE_20220922.fd" ]
-[[package.propolis-server.paths]]
-from = "packaging/smf/propolis-server"
-to = "/var/svc/manifest/site/propolis-server"
+source.type = "local"
+source.rust.binary_names = ["propolis-server"]
+source.rust.release = true
+source.paths = [
+    { from = "packaging/smf/propolis-server", to = "/var/svc/manifest/site/propolis-server" },
+]
+source.blobs = [ "alpine.iso", "OVMF_CODE_20220922.fd" ]
+output.type = "zone"

--- a/packaging/propolis-package/Cargo.toml
+++ b/packaging/propolis-package/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
-tokio.workspace = true
+indicatif.workspace = true
 omicron-zone-package.workspace = true
+tokio.workspace = true

--- a/packaging/propolis-package/src/main.rs
+++ b/packaging/propolis-package/src/main.rs
@@ -1,8 +1,110 @@
 // Copyright 2022 Oxide Computer Company
 
+use anyhow::anyhow;
+use anyhow::Context;
 use anyhow::Result;
+use indicatif::MultiProgress;
+use indicatif::ProgressBar;
+use indicatif::ProgressStyle;
+use omicron_zone_package::progress::Progress;
 use std::fs::create_dir_all;
 use std::path::Path;
+use std::time::Duration;
+
+const PKG_NAME: &'static str = "propolis-server";
+
+fn in_progress_style() -> ProgressStyle {
+    ProgressStyle::default_bar()
+        .template(
+            "[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}",
+        )
+        .expect("Invalid template")
+        .progress_chars("#>.")
+}
+
+fn completed_progress_style() -> ProgressStyle {
+    ProgressStyle::default_bar()
+        .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg:.green}")
+        .expect("Invalid template")
+        .progress_chars("#>.")
+}
+
+/// Progress UI for the package creation.
+struct ProgressUI {
+    /// Shared handle for managing all progress bars.
+    multi: MultiProgress,
+
+    /// Progress bar for the overall package creation.
+    pkg_pb: ProgressBar,
+}
+
+impl ProgressUI {
+    fn new(total: u64) -> Self {
+        // Create overall handle for managing all progress bars.
+        let multi = MultiProgress::new();
+
+        // We start off with one main progress bar for the overall package
+        // creation. Sub-tasks (e.g. blob download) will dynamically create
+        // their own progress bars via `Progress::sub_progress()`.
+        let pkg_pb = multi.add(ProgressBar::new(total));
+        pkg_pb.set_style(in_progress_style());
+
+        // Don't want to appear stuck while copying large files (e.g. blobs)
+        // so enable steady ticks to keep the elapsed time moving.
+        pkg_pb.enable_steady_tick(Duration::from_millis(500));
+
+        Self { multi, pkg_pb }
+    }
+}
+
+impl Progress for ProgressUI {
+    fn set_message(&self, msg: std::borrow::Cow<'static, str>) {
+        self.pkg_pb.set_message(msg);
+    }
+
+    fn increment(&self, delta: u64) {
+        self.pkg_pb.inc(delta);
+    }
+
+    fn sub_progress(&self, total: u64) -> Box<dyn Progress> {
+        let sub_pb = self.multi.add(ProgressBar::new(total));
+        sub_pb.set_style(in_progress_style());
+
+        Box::new(SubProgress::new(self.multi.clone(), sub_pb))
+    }
+}
+
+/// Progress UI for a sub-task (e.g. downloading blobs).
+struct SubProgress {
+    /// Shared handle for managing all progress bars.
+    multi: MultiProgress,
+
+    /// Progress bar for this specific sub-task.
+    pb: ProgressBar,
+}
+
+impl SubProgress {
+    fn new(multi: MultiProgress, pb: ProgressBar) -> Self {
+        Self { multi, pb }
+    }
+}
+
+impl Progress for SubProgress {
+    fn set_message(&self, msg: std::borrow::Cow<'static, str>) {
+        self.pb.set_message(msg);
+    }
+
+    fn increment(&self, delta: u64) {
+        self.pb.inc(delta);
+    }
+}
+
+impl Drop for SubProgress {
+    fn drop(&mut self) {
+        // Sub-task has completed, so remove the progress bar.
+        self.multi.remove(&self.pb);
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -12,9 +114,21 @@ async fn main() -> Result<()> {
     let output_dir = Path::new("out");
     create_dir_all(output_dir)?;
 
-    for package in cfg.packages.values() {
-        package.create(output_dir).await?;
-    }
+    // We only expect a single package so just look it directly
+    let pkg = cfg
+        .packages
+        .get(PKG_NAME)
+        .with_context(|| anyhow!("missing propolis-server package"))?;
+
+    let progress = ProgressUI::new(pkg.get_total_work());
+
+    pkg.create_with_progress(&progress, PKG_NAME, output_dir).await?;
+
+    progress.pkg_pb.set_style(completed_progress_style());
+    progress.pkg_pb.finish_with_message(format!(
+        "done: {}",
+        pkg.get_output_file(PKG_NAME)
+    ));
 
     Ok(())
 }


### PR DESCRIPTION
The CI image job has been failing due to a corrupt propolis-server package archive. It's been hard to reproduce locally (I think I managed to once or twice) but I did find at least one possible cause: a race between syncing the downloaded the package blobs (alpine, ovmf) to the filesystem and adding them to the archive. See block comment added in https://github.com/oxidecomputer/omicron-package/pull/37.

Also updated our package manifest to the new format and added some QoL improvements like downloading the blobs concurrently and progress indicators:

https://user-images.githubusercontent.com/287063/218859881-3cb3c643-83df-47c0-8fe9-f82a489e6eaa.mov

