### PR TITLE
Cleanup cargo warnings re: default-features on workspace deps.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,13 +91,13 @@ phd-testcase-macros = { path = "phd-tests/testcase_macro" }
 phd-tests = { path = "phd-tests/tests" }
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-propolis = { path = "lib/propolis" }
+propolis = { path = "lib/propolis", default-features = false }
 propolis-client = { path = "lib/propolis-client" }
 propolis-server-config = { path = "crates/propolis-server-config" }
 propolis_types = { path = "crates/propolis-types" }
 quote = "1.0"
 rand = "0.8"
-reqwest = "0.11.12"
+reqwest = { version = "0.11.12", default-features = false }
 rfb = { git = "https://github.com/oxidecomputer/rfb", rev = "0cac8d9c25eb27acfa35df80f3b9d371de98ab3b" }
 ring = "0.16"
 ron = "0.7"
@@ -122,7 +122,7 @@ tracing = "0.1.35"
 tracing-appender = "0.2.2"
 tracing-bunyan-formatter = "0.3.3"
 tracing-subscriber = "0.3.14"
-usdt = "0.3.2"
+usdt = { version = "0.3.2", default-features = false }
 uuid = "1.0.0"
 version_check = "0.9"
 viona_api = { path = "crates/viona-api" }

--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -43,7 +43,7 @@ serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
 slog.workspace = true
-propolis = { workspace = true, features = ["crucible-full", "oximeter"], default-features = false }
+propolis = { workspace = true, features = ["crucible-full", "oximeter"] }
 propolis-client = { workspace = true, features = ["generated"] }
 propolis-server-config.workspace = true
 rfb.workspace = true
@@ -54,7 +54,7 @@ schemars = { workspace = true, features = ["chrono", "uuid1"] }
 
 [dev-dependencies]
 hex.workspace = true
-reqwest = { workspace = true, default-features = false, features = ["rustls-tls"] }
+reqwest = { workspace = true, features = ["rustls-tls"] }
 ring.workspace = true
 slog = { workspace = true, features = [ "max_level_trace", "release_max_level_debug" ] }
 expectorate.workspace = true

--- a/bin/propolis-standalone/Cargo.toml
+++ b/bin/propolis-standalone/Cargo.toml
@@ -25,7 +25,7 @@ libc.workspace = true
 toml.workspace = true
 tokio = { workspace = true, features = ["io-util", "rt-multi-thread"] }
 serde = { workspace = true, features = ["derive"] }
-propolis = { workspace = true, default-features = false }
+propolis.workspace = true
 erased-serde.workspace = true
 serde_json.workspace = true
 slog.workspace = true

--- a/lib/propolis-client/Cargo.toml
+++ b/lib/propolis-client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 propolis_types.workspace = true
-reqwest = { workspace = true, default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 base64.workspace = true
 rand.workspace = true
 ring.workspace = true

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -19,7 +19,7 @@ bhyve_api.workspace = true
 dladm.workspace = true
 viona_api.workspace = true
 propolis_types.workspace = true
-usdt = { workspace = true, default-features = false }
+usdt.workspace = true
 tokio = { workspace = true, features = ["full"] }
 futures.workspace = true
 anyhow.workspace = true


### PR DESCRIPTION
These warnings were getting annoying

```console
$ cargo c
warning: /oxide/propolis/lib/propolis/Cargo.toml: `default-features` is ignored for usdt, since `default-features` was not specified for `workspace.dependencies.usdt`, this could become a hard error in the future
warning: /oxide/propolis/bin/propolis-server/Cargo.toml: `default-features` is ignored for propolis, since `default-features` was not specified for `workspace.dependencies.propolis`, this could become a hard error in the future
warning: /oxide/propolis/bin/propolis-server/Cargo.toml: `default-features` is ignored for reqwest, since `default-features` was not specified for `workspace.dependencies.reqwest`, this could become a hard error in the future
warning: /oxide/propolis/bin/propolis-standalone/Cargo.toml: `default-features` is ignored for propolis, since `default-features` was not specified for `workspace.dependencies.propolis`, this could become a hard error in the future
warning: /oxide/propolis/lib/propolis-client/Cargo.toml: `default-features` is ignored for reqwest, since `default-features` was not specified for `workspace.dependencies.reqwest`, this could become a hard error in the future
```