### PR TITLE
softnpu: handle cpu/aux port

### DIFF
--- a/bin/propolis-server/src/lib/migrate/codec.rs
+++ b/bin/propolis-server/src/lib/migrate/codec.rs
@@ -185,7 +185,7 @@ impl std::convert::TryInto<Message> for tungstenite::Message {
                 // Attempt decode and return the received message.
                 let m = match tag {
                     MessageType::Okay => {
-                        if src.len() != 0 {
+                        if !src.is_empty() {
                             return Err(ProtocolError::UnexpectedMessageLen(
                                 tag as u8,
                                 src.len(),
@@ -235,7 +235,7 @@ impl std::convert::TryInto<Message> for tungstenite::Message {
                         Message::MemXfer(start, end, bitmap)
                     }
                     MessageType::MemDone => {
-                        if src.len() != 0 {
+                        if !src.is_empty() {
                             return Err(ProtocolError::UnexpectedMessageLen(
                                 tag as u8,
                                 src.len(),

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -318,7 +318,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SourceProtocol<T> {
                     io::ErrorKind::BrokenPipe,
                 ))
             })?
-            .map_err(|e| codec::ProtocolError::WebsocketError(e))
+            .map_err(codec::ProtocolError::WebsocketError)
             // convert tungstenite::Message to codec::Message
             .and_then(std::convert::TryInto::try_into)
             // If this is an error message, lift that out

--- a/lib/propolis/src/hw/virtio/p9fs.rs
+++ b/lib/propolis/src/hw/virtio/p9fs.rs
@@ -91,7 +91,7 @@ impl VirtioDevice for PciVirtio9pfs {
                             if i == 256 {
                                 break;
                             }
-                            bs[i] = x as u8;
+                            bs[i] = x;
                         }
                         ro.write_bytes(&bs);
                         ro.fill(0);
@@ -365,8 +365,7 @@ impl HostFSHandler {
             - size_of::<u32>(); // Rread.data.len
 
         let buflen =
-            std::cmp::min(space_left, (metadata.len() - msg.offset) as usize)
-                as usize;
+            std::cmp::min(space_left, (metadata.len() - msg.offset) as usize);
 
         let mut content: Vec<u8> = vec![0; buflen];
 

--- a/lib/propolis/src/hw/virtio/softnpu.rs
+++ b/lib/propolis/src/hw/virtio/softnpu.rs
@@ -582,7 +582,7 @@ impl PacketHandler {
         log: &Logger,
     ) {
         if usize::from(port) >= data_handles.len() {
-            error!(log, "port out of range {} > {}", port, data_handles.len());
+            error!(log, "port out of range {} >= {}", port, data_handles.len());
             return;
         }
         // get the dlpi handle for this port

--- a/lib/propolis/src/hw/virtio/softnpu.rs
+++ b/lib/propolis/src/hw/virtio/softnpu.rs
@@ -521,9 +521,9 @@ impl PacketHandler {
 
     /// Run a packet coming into the ASIC from an external port through the
     /// loaded pipeline and forward it on to its destination.
-    fn process_external_packet<'a>(
+    fn process_external_packet(
         index: usize,
-        mut pkt: packet_in<'a>,
+        mut pkt: packet_in<'_>,
         data_handles: &Vec<dlpi::DlpiHandle>,
         virtio: &Arc<PortVirtioState>,
         pipeline: &mut Box<dyn Pipeline>,
@@ -550,8 +550,8 @@ impl PacketHandler {
 
     /// Run a packet coming into the ASIC from the guest pci port through the
     /// loaded pipeline and forward it on to its destination.
-    fn process_guest_packet<'a>(
-        mut pkt: packet_in<'a>,
+    fn process_guest_packet(
+        mut pkt: packet_in<'_>,
         data_handles: &Vec<dlpi::DlpiHandle>,
         pipeline: &mut Box<dyn Pipeline>,
         log: &Logger,
@@ -575,8 +575,8 @@ impl PacketHandler {
     }
 
     /// Send a packet out an external port using dlpi.
-    fn send_packet_to_ext_port<'a>(
-        pkt: &mut packet_out<'a>,
+    fn send_packet_to_ext_port(
+        pkt: &mut packet_out<'_>,
         data_handles: &Vec<dlpi::DlpiHandle>,
         port: u16,
         log: &Logger,
@@ -598,8 +598,8 @@ impl PacketHandler {
     }
 
     /// Send a packet out the guest pci port using virtio.
-    fn send_packet_to_cpu_port<'a>(
-        pkt: &mut packet_out<'a>,
+    fn send_packet_to_cpu_port(
+        pkt: &mut packet_out<'_>,
         virtio: &Arc<PortVirtioState>,
         log: &Logger,
     ) {

--- a/lib/propolis/src/hw/virtio/softnpu.rs
+++ b/lib/propolis/src/hw/virtio/softnpu.rs
@@ -41,6 +41,8 @@ use slog::{error, info, warn, Logger};
 // TODO make configurable
 const MTU: usize = 1600;
 
+const SOFTNPU_CPU_AUX_PORT: u16 = 1000;
+
 pub const MANAGEMENT_MESSAGE_PREAMBLE: u8 = 0b11100101;
 pub const SOFTNPU_TTY: &str = "/dev/tty03";
 
@@ -559,6 +561,10 @@ impl PacketHandler {
                 // no looping packets back to the guest
                 return;
             }
+            if port == SOFTNPU_CPU_AUX_PORT {
+                // we are not currently emulating this port type
+                return;
+            }
             Self::send_packet_to_ext_port(
                 &mut out_pkt,
                 data_handles,
@@ -575,6 +581,10 @@ impl PacketHandler {
         port: u16,
         log: &Logger,
     ) {
+        if usize::from(port) >= data_handles.len() {
+            error!(log, "port out of range {} > {}", port, data_handles.len());
+            return;
+        }
         // get the dlpi handle for this port
         let dh = data_handles[port as usize];
 


### PR DESCRIPTION
In `tfportd`/`tfport` based environments, a CPU/AUX port is now present. This device is not emulated by softnpu. However, we do need to be aware of and gracefully handle packets from this port, which has an index that is outside the range of normal softnpu ports.

All of the changes in the 2nd commit of this PR are taking care of clippy issues.