### PR TITLE
Tighten up Falcon builds

### DIFF
--- a/.github/buildomat/jobs/falcon-build.sh
+++ b/.github/buildomat/jobs/falcon-build.sh
@@ -17,10 +17,13 @@ set -o xtrace
 cargo --version
 rustc --version
 
-banner build
+banner check
 ptime -m cargo check --features falcon
-ptime -m cargo build --features falcon
-ptime -m cargo build --features falcon --release
+
+banner build
+PKGS="-p propolis-server -p propolis-cli"
+ptime -m cargo build --features falcon $PKGS
+ptime -m cargo build --features falcon $PKGS --release
 
 for x in debug release
 do

--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -67,7 +67,7 @@ version_check.workspace = true
 [features]
 default = ["dtrace-probes", "propolis/crucible-full", "propolis/oximeter"]
 dtrace-probes = ["propolis/dtrace-probes", "dropshot/usdt-probes"]
-falcon = ["propolis/falcon"]
+falcon = ["propolis/falcon", "propolis-client/falcon"]
 # If selected, only build a mock server which does not actually spawn instances
 # (i.e. to test with a facsimile of the API on unsupported platforms)
 mock-only = []


### PR DESCRIPTION
Limit components built for Falcon in buildomat job to only what's required.  Also, fix Falcon feature dependencies in propolis-server.