### PR TITLE
propolis-server: simplfy parts of the VM state driver

### DIFF
--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -343,6 +343,11 @@ struct SharedVmStateInner {
     /// The state worker's queue of unprocessed events from guest devices.
     guest_event_queue: VecDeque<GuestEvent>,
 
+    /// The expected ID of the next live migration this instance will
+    /// participate in (either in or out). If this is `Some`, external callers
+    /// who query migration state will observe that a live migration is in
+    /// progress even if the state driver has yet to pick up the live migration
+    /// tasks from its queue.
     pending_migration_id: Option<Uuid>,
 }
 

--- a/bin/propolis-server/src/lib/vm/state_driver.rs
+++ b/bin/propolis-server/src/lib/vm/state_driver.rs
@@ -200,7 +200,6 @@ where
                         // expecting.
                         self.start_vm(false)
                             .expect("failed to start VM after migrating");
-                        self.update_external_state(ApiInstanceState::Running);
                         *next_lifecycle = Some(LifecycleStage::Active);
                         HandleEventOutcome::Continue
                     }
@@ -218,7 +217,6 @@ where
                 // TODO(#209) Transition to a "failed" state instead of
                 // expecting.
                 self.start_vm(true).expect("failed to start VM");
-                self.update_external_state(ApiInstanceState::Running);
                 *next_lifecycle = Some(LifecycleStage::Active);
                 HandleEventOutcome::Continue
             }
@@ -307,6 +305,7 @@ where
 
         self.controller.start_entities()?;
         self.vcpu_tasks.resume_all();
+        self.update_external_state(ApiInstanceState::Running);
         Ok(())
     }
 

--- a/bin/propolis-server/src/lib/vm/state_driver.rs
+++ b/bin/propolis-server/src/lib/vm/state_driver.rs
@@ -10,6 +10,7 @@ use super::{
 
 use propolis_client::handmade::{
     api::InstanceState as ApiInstanceState,
+    api::InstanceStateMonitorResponse as ApiMonitoredState,
     api::MigrationState as ApiMigrationState,
 };
 use slog::{info, Logger};
@@ -43,6 +44,10 @@ pub(super) struct StateDriver<
 
     /// Whether the worker's VM's entities are paused.
     paused: bool,
+
+    api_state_tx: tokio::sync::watch::Sender<ApiMonitoredState>,
+    migration_state_tx:
+        tokio::sync::watch::Sender<Option<(Uuid, ApiMigrationState)>>,
 }
 
 impl<V, C> StateDriver<V, C>
@@ -55,20 +60,46 @@ where
         controller: Arc<V>,
         vcpu_tasks: C,
         log: Logger,
-        state_gen: u64,
+        api_state_tx: tokio::sync::watch::Sender<ApiMonitoredState>,
+        migration_state_tx: tokio::sync::watch::Sender<
+            Option<(Uuid, ApiMigrationState)>,
+        >,
     ) -> Self {
         Self {
             runtime_hdl,
             controller,
             vcpu_tasks,
             log,
-            state_gen,
+            state_gen: 0,
             paused: false,
+            api_state_tx,
+            migration_state_tx,
         }
     }
 
+    fn update_external_state(&mut self, state: ApiInstanceState) {
+        self.state_gen += 1;
+        let _ = self
+            .api_state_tx
+            .send(ApiMonitoredState { gen: self.state_gen, state });
+    }
+
+    fn get_migration_state(&self) -> Option<(Uuid, ApiMigrationState)> {
+        *self.migration_state_tx.borrow()
+    }
+
+    fn set_migration_state(
+        &mut self,
+        migration_id: Uuid,
+        state: ApiMigrationState,
+    ) {
+        let _ = self.migration_state_tx.send(Some((migration_id, state)));
+    }
+
     /// Manages an instance's lifecycle once it has moved to the Running state.
-    pub(super) fn run_state_worker(&mut self) {
+    pub(super) fn run_state_worker(
+        mut self,
+    ) -> tokio::sync::watch::Sender<ApiMonitoredState> {
         info!(self.log, "State worker launched");
 
         // Allow actions to queue up state changes that are applied on the next
@@ -87,8 +118,7 @@ where
             //
             // N.B. This check must be last, because it breaks out of the loop.
             if let Some(next_external) = next_external.take() {
-                self.controller
-                    .update_external_state(&mut self.state_gen, next_external);
+                self.update_external_state(next_external);
                 if matches!(next_external, ApiInstanceState::Stopped) {
                     break;
                 }
@@ -99,6 +129,8 @@ where
         }
 
         info!(self.log, "State worker exiting");
+
+        self.api_state_tx
     }
 
     fn handle_event(
@@ -123,10 +155,7 @@ where
                 start_tx,
                 command_rx,
             } => {
-                self.controller.update_external_state(
-                    &mut self.state_gen,
-                    ApiInstanceState::Migrating,
-                );
+                self.update_external_state(ApiInstanceState::Migrating);
 
                 // The controller API should have updated the lifecycle
                 // stage prior to queuing this work, and neither it nor the
@@ -164,7 +193,7 @@ where
                         self.controller.set_lifecycle_stage(
                             LifecycleStage::NotStarted(StartupStage::Migrated),
                         );
-                        self.controller.set_migration_state(
+                        self.set_migration_state(
                             migration_id,
                             ApiMigrationState::Finish,
                         );
@@ -203,11 +232,7 @@ where
                 command_rx,
                 response_tx,
             } => {
-                self.controller.update_external_state(
-                    &mut self.state_gen,
-                    ApiInstanceState::Migrating,
-                );
-
+                self.update_external_state(ApiInstanceState::Migrating);
                 let result = self.migrate_as_source(
                     migration_id,
                     task,
@@ -265,10 +290,7 @@ where
 
         // Requests to start should put the instance into the 'starting' stage.
         // Reflect this out to callers who ask what state the VM is in.
-        self.controller.update_external_state(
-            &mut self.state_gen,
-            ApiInstanceState::Starting,
-        );
+        self.update_external_state(ApiInstanceState::Starting);
 
         if reset_required {
             self.reset_vcpus();
@@ -288,10 +310,7 @@ where
             LifecycleStage::Active
         ));
 
-        self.controller.update_external_state(
-            &mut self.state_gen,
-            ApiInstanceState::Rebooting,
-        );
+        self.update_external_state(ApiInstanceState::Rebooting);
 
         let next_external = Some(ApiInstanceState::Running);
 
@@ -319,10 +338,7 @@ where
         &mut self,
     ) -> (Option<ApiInstanceState>, Option<LifecycleStage>) {
         info!(self.log, "Stopping instance");
-        self.controller.update_external_state(
-            &mut self.state_gen,
-            ApiInstanceState::Stopping,
-        );
+        self.update_external_state(ApiInstanceState::Stopping);
         let next_external = Some(ApiInstanceState::Stopped);
         let next_lifecycle = Some(LifecycleStage::NoLongerActive);
 
@@ -341,7 +357,7 @@ where
     }
 
     fn migrate_as_target(
-        &self,
+        &mut self,
         migration_id: Uuid,
         mut task: tokio::task::JoinHandle<Result<(), MigrateError>>,
         start_tx: tokio::sync::oneshot::Sender<()>,
@@ -380,8 +396,7 @@ where
                     if matches!(state, ApiMigrationState::Finish) {
                         finished = true;
                     } else {
-                        self.controller
-                            .set_migration_state(migration_id, state);
+                        self.set_migration_state(migration_id, state);
                     }
                 }
             }
@@ -422,14 +437,14 @@ where
                             self.controller.resume_entities();
                             self.vcpu_tasks.resume_all();
                             self.paused = false;
-                            self.controller.set_migration_state(
+                            self.set_migration_state(
                                 migration_id,
                                 ApiMigrationState::Error,
                             );
                         }
                     } else {
                         assert!(matches!(
-                            self.controller.get_migration_state(),
+                            self.get_migration_state(),
                             Some((_, ApiMigrationState::Finish))
                         ));
                     }
@@ -437,8 +452,7 @@ where
                 }
                 MigrateTaskEvent::Command(cmd) => match cmd {
                     MigrateSourceCommand::UpdateState(state) => {
-                        self.controller
-                            .set_migration_state(migration_id, state);
+                        self.set_migration_state(migration_id, state);
                     }
                     MigrateSourceCommand::Pause => {
                         self.vcpu_tasks.pause_all();
@@ -496,18 +510,38 @@ mod tests {
     use crate::vcpu_tasks::MockVcpuTaskController;
     use crate::vm::MockStateDriverVmController;
 
+    struct TestStateDriver {
+        driver:
+            StateDriver<MockStateDriverVmController, MockVcpuTaskController>,
+        _state_rx: tokio::sync::watch::Receiver<ApiMonitoredState>,
+        _migrate_rx:
+            tokio::sync::watch::Receiver<Option<(Uuid, ApiMigrationState)>>,
+    }
+
     fn make_state_driver(
         vm_ctrl: MockStateDriverVmController,
         vcpu_ctrl: MockVcpuTaskController,
-    ) -> StateDriver<MockStateDriverVmController, MockVcpuTaskController> {
+    ) -> TestStateDriver {
         let logger = slog::Logger::root(slog::Discard, slog::o!());
-        StateDriver::new(
-            tokio::runtime::Handle::current(),
-            Arc::new(vm_ctrl),
-            vcpu_ctrl,
-            logger,
-            0,
-        )
+        let (state_tx, state_rx) =
+            tokio::sync::watch::channel(ApiMonitoredState {
+                gen: 0,
+                state: ApiInstanceState::Creating,
+            });
+        let (migrate_tx, migrate_rx) = tokio::sync::watch::channel(None);
+
+        TestStateDriver {
+            driver: StateDriver::new(
+                tokio::runtime::Handle::current(),
+                Arc::new(vm_ctrl),
+                vcpu_ctrl,
+                logger,
+                state_tx,
+                migrate_tx,
+            ),
+            _state_rx: state_rx,
+            _migrate_rx: migrate_rx,
+        }
     }
 
     /// Generates default mocks for the VM controller and vCPU task controller
@@ -520,23 +554,6 @@ mod tests {
         vm_ctrl
             .expect_get_lifecycle_stage()
             .returning(|| LifecycleStage::Active);
-        vm_ctrl.expect_get_migration_state().returning(|| None);
-
-        (vm_ctrl, vcpu_ctrl)
-    }
-
-    fn make_migration_source_mocks(
-        migration_id: Uuid,
-    ) -> (MockStateDriverVmController, MockVcpuTaskController) {
-        let mut vm_ctrl = MockStateDriverVmController::new();
-        let vcpu_ctrl = MockVcpuTaskController::new();
-
-        vm_ctrl
-            .expect_get_lifecycle_stage()
-            .returning(|| LifecycleStage::Active);
-        vm_ctrl
-            .expect_get_migration_state()
-            .returning(move || Some((migration_id, ApiMigrationState::Finish)));
 
         (vm_ctrl, vcpu_ctrl)
     }
@@ -557,12 +574,6 @@ mod tests {
         vm_ctrl: &mut MockStateDriverVmController,
         vcpu_ctrl: &mut MockVcpuTaskController,
     ) {
-        vm_ctrl
-            .expect_update_external_state()
-            .times(1)
-            .withf(|&_gen, &state| state == ApiInstanceState::Rebooting)
-            .returning(|_, _| ());
-
         // The reboot process requires careful ordering of steps to make sure
         // the VM's vCPUs are put into the correct state when the machine starts
         // up.
@@ -625,7 +636,7 @@ mod tests {
 
         add_reboot_expectations(&mut vm_ctrl, &mut vcpu_ctrl);
         let mut driver = make_state_driver(vm_ctrl, vcpu_ctrl);
-        driver.handle_event(
+        driver.driver.handle_event(
             StateDriverEvent::Guest(GuestEvent::VcpuSuspendTripleFault(0)),
             &mut next_external,
             &mut next_lifecycle,
@@ -642,7 +653,7 @@ mod tests {
 
         add_reboot_expectations(&mut vm_ctrl, &mut vcpu_ctrl);
         let mut driver = make_state_driver(vm_ctrl, vcpu_ctrl);
-        driver.handle_event(
+        driver.driver.handle_event(
             StateDriverEvent::Guest(GuestEvent::ChipsetReset),
             &mut next_external,
             &mut next_lifecycle,
@@ -658,11 +669,6 @@ mod tests {
         let mut next_lifecycle: Option<LifecycleStage> = None;
 
         let mut seq = Sequence::new();
-        vm_ctrl
-            .expect_update_external_state()
-            .times(1)
-            .withf(|&_gen, &state| state == ApiInstanceState::Starting)
-            .returning(|_, _| ());
         vcpu_ctrl
             .expect_new_generation()
             .times(1)
@@ -685,7 +691,7 @@ mod tests {
             .returning(|| ());
 
         let mut driver = make_state_driver(vm_ctrl, vcpu_ctrl);
-        driver.handle_event(
+        driver.driver.handle_event(
             StateDriverEvent::External(ExternalRequest::Start),
             &mut next_external,
             &mut next_lifecycle,
@@ -702,11 +708,6 @@ mod tests {
         let mut next_lifecycle: Option<LifecycleStage> = None;
 
         let mut seq = Sequence::new();
-        vm_ctrl
-            .expect_update_external_state()
-            .times(1)
-            .withf(|&_gen, &state| state == ApiInstanceState::Stopping)
-            .returning(|_, _| ());
         vcpu_ctrl
             .expect_pause_all()
             .times(1)
@@ -729,7 +730,7 @@ mod tests {
             .returning(|| ());
 
         let mut driver = make_state_driver(vm_ctrl, vcpu_ctrl);
-        driver.handle_event(
+        driver.driver.handle_event(
             StateDriverEvent::External(ExternalRequest::Stop),
             &mut next_external,
             &mut next_lifecycle,
@@ -748,8 +749,7 @@ mod tests {
             task_exit_rx.await.unwrap()
         });
 
-        let (mut vm_ctrl, mut vcpu_ctrl) =
-            make_migration_source_mocks(migration_id);
+        let (mut vm_ctrl, mut vcpu_ctrl) = make_default_mocks();
         let mut next_external: Option<ApiInstanceState> = None;
         let mut next_lifecycle: Option<LifecycleStage> = None;
 
@@ -763,11 +763,6 @@ mod tests {
         vm_ctrl.expect_halt_entities().times(1).returning(|| ());
         vm_ctrl.expect_resume_entities().never();
         vcpu_ctrl.expect_resume_all().never();
-
-        // The driver may update the external state during this operation.
-        // Permit any of these mutations (the specific sequence thereof is
-        // out of this test's scope).
-        vm_ctrl.expect_update_external_state().times(..).returning(|_, _| ());
         vm_ctrl
             .expect_finish_migrate_as_source()
             .times(1)
@@ -780,7 +775,7 @@ mod tests {
         // runtime so that it can call `block_on` to wait for messages from the
         // migration task.
         let hdl = std::thread::spawn(move || {
-            driver.handle_event(
+            driver.driver.handle_event(
                 StateDriverEvent::External(ExternalRequest::MigrateAsSource {
                     migration_id,
                     task: migrate_task,
@@ -801,6 +796,10 @@ mod tests {
         command_tx.send(MigrateSourceCommand::Pause).await.unwrap();
         let resp = response_rx.recv().await.unwrap();
         assert!(matches!(resp, MigrateSourceResponse::Pause(Ok(()))));
+        command_tx
+            .send(MigrateSourceCommand::UpdateState(ApiMigrationState::Finish))
+            .await
+            .unwrap();
 
         drop(command_tx);
         task_exit_tx.send(Ok(())).unwrap();
@@ -811,7 +810,7 @@ mod tests {
             .await
             .unwrap();
 
-        driver.handle_event(
+        driver.driver.handle_event(
             StateDriverEvent::External(ExternalRequest::Stop),
             &mut next_external,
             &mut next_lifecycle,
@@ -831,19 +830,6 @@ mod tests {
 
         let (mut vm_ctrl, mut vcpu_ctrl) = make_migration_target_mocks();
 
-        let mut state_seq = Sequence::new();
-        vm_ctrl
-            .expect_update_external_state()
-            .times(1)
-            .in_sequence(&mut state_seq)
-            .withf(|&_gen, &state| state == ApiInstanceState::Migrating)
-            .returning(|_, _| ());
-        vm_ctrl
-            .expect_update_external_state()
-            .times(1)
-            .in_sequence(&mut state_seq)
-            .withf(|&_gen, &state| state == ApiInstanceState::Starting)
-            .returning(|_, _| ());
         vm_ctrl
             .expect_set_lifecycle_stage()
             .times(1)
@@ -854,11 +840,6 @@ mod tests {
                 )
             })
             .returning(|_| ());
-        vm_ctrl
-            .expect_set_migration_state()
-            .times(1)
-            .withf(|&_gen, &state| state == ApiMigrationState::Finish)
-            .returning(|_, _| ());
         vcpu_ctrl.expect_new_generation().times(1).returning(|| ());
         vm_ctrl.expect_reset_vcpu_state().times(1).returning(|| ());
         vm_ctrl.expect_start_entities().times(1).returning(|| Ok(()));
@@ -873,7 +854,7 @@ mod tests {
             let mut next_external: Option<ApiInstanceState> = None;
             let mut next_lifecycle: Option<LifecycleStage> = None;
 
-            driver.handle_event(
+            driver.driver.handle_event(
                 StateDriverEvent::External(ExternalRequest::MigrateAsTarget {
                     migration_id,
                     task: migrate_task,
@@ -945,7 +926,7 @@ mod tests {
         vcpu_ctrl.expect_resume_all().never();
 
         let mut driver = make_state_driver(vm_ctrl, vcpu_ctrl);
-        driver.handle_event(
+        driver.driver.handle_event(
             StateDriverEvent::External(ExternalRequest::MigrateAsSource {
                 migration_id,
                 task: migrate_task,


### PR DESCRIPTION
Today, an instance's VM controller owns the objects that record and publish an instance's externally visible instance state and its migration state, even though these statuses are logically owned by the VM state driver. This forces the state driver to call up to the VM controller every time it wants to update the externally-visible instance state.

Simplify matters as follows:

- Make the VM state driver own the sender side of the external state channel. Get rid of the `next_external` variable in the state driver loop; just publish to the channel directly when external state changes.
- Introduce a similar channel for migration state, also owned by the VM state driver. Add a bit of state to the VM controller to allow it to report on migrations that an external caller has requested but that the involved Propolises have not yet started.
- Remove the obsolete `StateDriverVmController` functions. The unit tests that set expectations on these mocks can now just read the states published by the state drivers under test.

Also remove the commented-out unit test for #252, since that issue is obsolete. 