### PR TITLE
Remove MigrateStart instance state request

### DIFF
--- a/bin/propolis-cli/src/main.rs
+++ b/bin/propolis-cli/src/main.rs
@@ -441,14 +441,6 @@ async fn migrate_instance(
         cloud_init_bytes: None,
     };
 
-    // Get the source instance ready
-    src_client
-        .instance_state_put(InstanceStateRequested::MigrateStart)
-        .await
-        .with_context(|| {
-        anyhow!("failed to place src instance in migrate start state")
-    })?;
-
     // Initiate the migration via the destination instance
     let migration_id = dst_client
         .instance_ensure(&request)

--- a/bin/propolis-server/src/lib/mock_server.rs
+++ b/bin/propolis-server/src/lib/mock_server.rs
@@ -133,9 +133,6 @@ impl InstanceContext {
                     self.state = api::InstanceState::Stopped;
                     Ok(())
                 }
-                api::InstanceStateRequested::MigrateStart => {
-                    unimplemented!("migration not yet implemented")
-                }
             },
         }
     }

--- a/lib/propolis-client/src/handmade/api.rs
+++ b/lib/propolis-client/src/handmade/api.rs
@@ -138,7 +138,6 @@ pub enum InstanceStateRequested {
     Run,
     Stop,
     Reboot,
-    MigrateStart,
 }
 
 /// Current state of an Instance.

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -986,8 +986,7 @@
         "enum": [
           "Run",
           "Stop",
-          "Reboot",
-          "MigrateStart"
+          "Reboot"
         ]
       },
       "MigrationState": {

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -242,14 +242,6 @@ impl TestVm {
         })
     }
 
-    /// Moves this VM into the migrate-start state.
-    fn start_migrate(&self) -> StdResult<(), PropolisClientError> {
-        self.rt.block_on(async {
-            self.put_instance_state_async(InstanceStateRequested::MigrateStart)
-                .await
-        })
-    }
-
     async fn put_instance_state_async(
         &self,
         state: InstanceStateRequested,
@@ -303,7 +295,6 @@ impl TestVm {
                     source.server.server_addr()
                 );
 
-                source.start_migrate()?;
                 let console = self.rt.block_on(async {
                     self.instance_ensure_async(Some(
                         InstanceMigrateInitiateRequest {


### PR DESCRIPTION
This request sets a flag in the VM controller that lets a VM act as a migration source if its state otherwise permits it. There's no way to clear the flag, which makes it tough to write an undo action for this in the Nexus live migration saga that (presumably) would issue this call.

Since the request has no other side effects, the VM controller already rejects other invalid requests to migrate out, and sled agent doesn't presently use this request type, just remove it entirely.

Tested with an ad hoc migration & PHD tests.

Fixes #331. See that issue for discussion of alternative approaches.