### PR TITLE
add crucible to propolis-standalone config toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,12 +3024,14 @@ dependencies = [
  "anyhow",
  "bhyve_api",
  "clap 4.2.4",
+ "crucible-client-types",
  "ctrlc",
  "erased-serde",
  "futures",
  "libc",
  "num_enum",
  "propolis",
+ "propolis-client",
  "propolis-standalone-config",
  "serde",
  "serde_json",
@@ -3038,6 +3040,7 @@ dependencies = [
  "slog-term",
  "tokio",
  "toml 0.5.11",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3031,7 +3031,6 @@ dependencies = [
  "libc",
  "num_enum",
  "propolis",
- "propolis-client",
  "propolis-standalone-config",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -157,6 +157,72 @@ which acts as a serial port. One such tool for accessing this serial port is
 [sercons](https://github.com/jclulow/vmware-sercons), though others (such as
 "screen") would also work.
 
+propolis-standalone also supports defining crucible-backed storage devices,
+thought it is somewhat inconvenient to do so without scripting. Currently you can only use a single region per block device. Read the comments in this TOML example for more details:
+
+```toml
+[block_dev.some_datastore]
+type = "crucible"
+
+# === REQUIRED OPTIONS ===
+# these MUST match the region configuration downstairs
+block_size = 512
+blocks_per_extent = 262144
+extent_count = 32
+
+# Array of the SocketAddrs of the Downstairs instances. There must be three
+# of these, or propolis-standalone will panic.
+targets = [
+  "127.0.0.1:3810",
+  "127.0.0.1:3820",
+  "127.0.0.1:3830",
+]
+
+# Generation number used when connecting to Downstairs. This must
+# monotonically increase with each successive connection to the Downstairs,
+# which means that you need to bump this number every time you restart
+# your VM. Kind of annoying, maybe we can get a better way to pass it in.
+# Anyway, if you don't want to read-modify-write this value, a hack you
+# could do is set this to the current number of seconds since the epoch.
+# This'll always work, except for if the system time goes backwards, which
+# it can definitely do! So, you know. Be careful.
+generation = 1
+# === END REQUIRED OPTIONS ===
+
+
+# === OPTIONAL OPTIONS ===
+# This should be a UUID. It can be anything, really. When unset, defaults
+# to a random UUIDv4
+# upstairs_id = "e4396bd0-ede1-48d7-ac14-3d2094dfba5b"
+
+# When true, some random amount of IO requests will synthetically "fail".
+# This is useful when testing IO behavior under Bad Conditions.
+# Defaults to false.
+# lossy = false
+
+# YYY what does this do?
+# flush_timeout = <number>
+
+# Base64'd encryption key used to encrypt data at rest. Keys are 256 bits.
+# Note that the region must have already been created with encryption
+# enabled for this to work. That may change later though.
+# encryption_key = ""
+
+# These three values are pem files for TLS encryption of data between
+# propolis and the downstairs.
+# cert_pem = ""
+# key_pem = ""
+# root_cert_pem = ""
+
+# Specifies the SocketAddr of the crucible control interface. YYY I'm not
+# really sure what this actually does, but it defaults to Nothing
+# control_addr = ""
+
+# When true, the device will be read-only. Defaults to false
+# read_only = false
+# === END OPTIONAL OPTIONS ===
+```
+
 ### Quickstart to Alpine
 
 In the aforementioned config files, there are three major components

--- a/README.md
+++ b/README.md
@@ -157,8 +157,19 @@ which acts as a serial port. One such tool for accessing this serial port is
 [sercons](https://github.com/jclulow/vmware-sercons), though others (such as
 "screen") would also work.
 
-propolis-standalone also supports defining crucible-backed storage devices,
-thought it is somewhat inconvenient to do so without scripting. Currently you can only use a single region per block device. Read the comments in this TOML example for more details:
+propolis-standalone also supports defining crucible-backed storage devices in
+the TOML config. It is somewhat inconvenient to do this without scripting,
+because `generation` must monotonically increase with each successive connection
+to the Downstairs datastore. So if you use this, you need to somehow
+monotonically bump up that number in the TOML file before re-launching the VM,
+unless you're also creating a new Downstairs region from scratch.
+
+All the crucible configuration options are crucible-specific, so future changes
+to crucible may result in changes to the config options here as well. Consult
+the [oxidecomputer/crucible](https://github.com/oxidecomputer/crucible) codebase
+if you need low level details on what certain options actually do.
+
+Here's an example config. Read the comments for parameter-specific details:
 
 ```toml
 [block_dev.some_datastore]
@@ -200,7 +211,9 @@ generation = 1
 # Defaults to false.
 # lossy = false
 
-# YYY what does this do?
+# the Upstairs (propolis-side) component of crucible currently regularly
+# dispatches flushes to act as IO barriers. By default this happens once every 5
+# seconds, but you can adjust it with this option.
 # flush_timeout = <number>
 
 # Base64'd encryption key used to encrypt data at rest. Keys are 256 bits.
@@ -214,8 +227,10 @@ generation = 1
 # key_pem = ""
 # root_cert_pem = ""
 
-# Specifies the SocketAddr of the crucible control interface. YYY I'm not
-# really sure what this actually does, but it defaults to Nothing
+# Specifies the SocketAddr of the Upstairs crucible control interface. When
+# ommitted, the control interface won't be started. The control interface is an
+# HTTP server that exposes commands to take snapshots, simulate faults, and
+# retrieve runtime debug information.
 # control_addr = ""
 
 # When true, the device will be read-only. Defaults to false

--- a/bin/propolis-standalone/Cargo.toml
+++ b/bin/propolis-standalone/Cargo.toml
@@ -18,14 +18,17 @@ libc.workspace = true
 toml.workspace = true
 tokio = { workspace = true, features = ["io-util", "rt-multi-thread"] }
 serde = { workspace = true, features = ["derive"] }
-propolis.workspace = true
+propolis = { workspace = true, features = ["crucible-full"], default-features = false }
+crucible-client-types.workspace = true
 propolis-standalone-config = { workspace = true }
+propolis-client = { workspace = true, features = ["generated"] }
 erased-serde.workspace = true
 serde_json.workspace = true
 slog.workspace = true
 slog-async.workspace = true
 slog-term.workspace = true
 num_enum.workspace = true
+uuid.workspace = true
 
 [features]
 default = ["dtrace-probes"]

--- a/bin/propolis-standalone/Cargo.toml
+++ b/bin/propolis-standalone/Cargo.toml
@@ -18,7 +18,7 @@ libc.workspace = true
 toml.workspace = true
 tokio = { workspace = true, features = ["io-util", "rt-multi-thread"] }
 serde = { workspace = true, features = ["derive"] }
-propolis = { workspace = true, features = ["crucible-full"], default-features = false }
+propolis = { workspace = true }
 crucible-client-types.workspace = true
 propolis-standalone-config = { workspace = true }
 propolis-client = { workspace = true, features = ["generated"] }

--- a/bin/propolis-standalone/Cargo.toml
+++ b/bin/propolis-standalone/Cargo.toml
@@ -18,10 +18,9 @@ libc.workspace = true
 toml.workspace = true
 tokio = { workspace = true, features = ["io-util", "rt-multi-thread"] }
 serde = { workspace = true, features = ["derive"] }
-propolis = { workspace = true }
-crucible-client-types.workspace = true
+propolis.workspace = true
+crucible-client-types = { workspace = true, optional = true }
 propolis-standalone-config = { workspace = true }
-propolis-client = { workspace = true, features = ["generated"] }
 erased-serde.workspace = true
 serde_json.workspace = true
 slog.workspace = true
@@ -33,4 +32,4 @@ uuid.workspace = true
 [features]
 default = ["dtrace-probes"]
 dtrace-probes = ["propolis/dtrace-probes"]
-crucible = ["propolis/crucible-full", "propolis/oximeter"]
+crucible = ["propolis/crucible-full", "propolis/oximeter", "crucible-client-types"]

--- a/bin/propolis-standalone/Cargo.toml
+++ b/bin/propolis-standalone/Cargo.toml
@@ -33,4 +33,4 @@ uuid.workspace = true
 [features]
 default = ["dtrace-probes"]
 dtrace-probes = ["propolis/dtrace-probes"]
-crucible = ["propolis/crucible", "propolis/oximeter"]
+crucible = ["propolis/crucible-full", "propolis/oximeter"]

--- a/bin/propolis-standalone/src/config.rs
+++ b/bin/propolis-standalone/src/config.rs
@@ -1,7 +1,6 @@
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::SystemTime;
-use std::{num::NonZeroUsize, time::Instant};
+use std::num::NonZeroUsize;
 
 use anyhow::Context;
 
@@ -147,20 +146,20 @@ pub fn block_backend(
 
             let req =
                 crucible_client_types::VolumeConstructionRequest::Region {
-                    block_size: block_size,
-                    blocks_per_extent: blocks_per_extent,
-                    extent_count: extent_count,
+                    block_size,
+                    blocks_per_extent,
+                    extent_count,
                     opts: crucible_client_types::CrucibleOpts {
                         id: uuid,
                         target: targets,
-                        lossy: lossy,
-                        flush_timeout: flush_timeout,
-                        key: key,
-                        cert_pem: cert_pem,
-                        key_pem: key_pem,
-                        root_cert_pem: root_cert_pem,
+                        lossy,
+                        flush_timeout,
+                        key,
+                        cert_pem,
+                        key_pem,
+                        root_cert_pem,
                         control: control_addr,
-                        read_only: read_only,
+                        read_only,
                     },
                     gen: generation,
                 };

--- a/bin/propolis-standalone/src/config.rs
+++ b/bin/propolis-standalone/src/config.rs
@@ -1,6 +1,6 @@
+use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::num::NonZeroUsize;
 
 use anyhow::Context;
 
@@ -137,12 +137,9 @@ pub fn block_backend(
             // the current system time, and this will usually give us a newer
             // generation than the last connection. NEVER do this in prod
             // EVER.
-            let generation = be
-                .options
-                .get("generation")
-                .unwrap()
-                .as_integer()
-                .unwrap() as u64;
+            let generation =
+                be.options.get("generation").unwrap().as_integer().unwrap()
+                    as u64;
 
             let req =
                 crucible_client_types::VolumeConstructionRequest::Region {

--- a/bin/propolis-standalone/src/config.rs
+++ b/bin/propolis-standalone/src/config.rs
@@ -1,6 +1,7 @@
-use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::SystemTime;
+use std::{num::NonZeroUsize, time::Instant};
 
 use anyhow::Context;
 
@@ -10,6 +11,9 @@ use propolis::inventory::ChildRegister;
 
 use propolis_standalone_config::Device;
 pub use propolis_standalone_config::{Config, SnapshotTag};
+
+use slog::info;
+use uuid::Uuid;
 
 pub fn block_backend(
     config: &Config,
@@ -23,13 +27,11 @@ pub fn block_backend(
         "file" => {
             let path = be.options.get("path").unwrap().as_str().unwrap();
 
-            let readonly: bool = || -> Option<bool> {
-                match be.options.get("readonly") {
-                    Some(toml::Value::Boolean(read_only)) => Some(*read_only),
-                    Some(toml::Value::String(v)) => v.parse().ok(),
-                    _ => None,
-                }
-            }()
+            let readonly = (match be.options.get("readonly") {
+                Some(toml::Value::Boolean(read_only)) => Some(*read_only),
+                Some(toml::Value::String(v)) => v.parse().ok(),
+                _ => None,
+            })
             .unwrap_or(false);
 
             let be = block::FileBackend::create(
@@ -41,6 +43,136 @@ pub fn block_backend(
             .unwrap();
 
             let creg = ChildRegister::new(&be, Some(path.to_string()));
+            (be, creg)
+        }
+        "crucible" => {
+            info!(log, "Building a crucible VolumeConstructionRequest from options {:?}", be.options);
+
+            // No defaults on here because we really shouldn't try and guess
+            // what block size the downstairs is using. A lot of things
+            // default to 512, but it's best not to assume it'll always be
+            // that way.
+            let block_size =
+                be.options.get("block_size").unwrap().as_integer().unwrap()
+                    as u64;
+
+            let blocks_per_extent = be
+                .options
+                .get("blocks_per_extent")
+                .unwrap()
+                .as_integer()
+                .unwrap() as u64;
+
+            let extent_count =
+                be.options.get("extent_count").unwrap().as_integer().unwrap()
+                    as u32;
+
+            // Parse a UUID, or generate a random one if none is specified.
+            // Reasonable in something primarily used for testing like
+            // propolis-standalone, but you wouldn't want to do this in
+            // prod.
+            let uuid = be
+                .options
+                .get("upstairs_id")
+                .map(|x| Uuid::parse_str(x.as_str().unwrap()).unwrap())
+                .unwrap_or_else(Uuid::new_v4);
+
+            // The actual addresses of the three downstairs we're going to connect to.
+            let targets: Vec<_> = be
+                .options
+                .get("targets")
+                .unwrap()
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|target_val| target_val.as_str().unwrap().parse().unwrap())
+                .collect();
+            // There is currently no universe where an amount of Downstairs
+            // other than 3 is valid.
+            assert_eq!(targets.len(), 3);
+
+            let lossy = be
+                .options
+                .get("lossy")
+                .map(|x| x.as_bool().unwrap())
+                .unwrap_or(false);
+
+            let flush_timeout = be
+                .options
+                .get("flush_timeout")
+                .map(|x| x.as_integer().unwrap() as u32);
+
+            let key = be
+                .options
+                .get("encryption_key")
+                .map(|x| x.as_str().unwrap().to_string());
+
+            let cert_pem = be
+                .options
+                .get("cert_pem")
+                .map(|x| x.as_str().unwrap().to_string());
+
+            let key_pem = be
+                .options
+                .get("key_pem")
+                .map(|x| x.as_str().unwrap().to_string());
+
+            let root_cert_pem = be
+                .options
+                .get("root_cert_pem")
+                .map(|x| x.as_str().unwrap().to_string());
+
+            let control_addr =
+                be.options.get("control_addr").map(|target_val| {
+                    target_val.as_str().unwrap().parse().unwrap()
+                });
+
+            let read_only = be
+                .options
+                .get("read_only")
+                .map(|x| x.as_bool().unwrap())
+                .unwrap_or(false);
+
+            // This needs to increase monotonically with each successive
+            // connection to the downstairs. As a hack, you can set it to
+            // the current system time, and this will usually give us a newer
+            // generation than the last connection. NEVER do this in prod
+            // EVER.
+            let generation = be
+                .options
+                .get("generation")
+                .unwrap()
+                .as_integer()
+                .unwrap() as u64;
+
+            let req =
+                crucible_client_types::VolumeConstructionRequest::Region {
+                    block_size: block_size,
+                    blocks_per_extent: blocks_per_extent,
+                    extent_count: extent_count,
+                    opts: crucible_client_types::CrucibleOpts {
+                        id: uuid,
+                        target: targets,
+                        lossy: lossy,
+                        flush_timeout: flush_timeout,
+                        key: key,
+                        cert_pem: cert_pem,
+                        key_pem: key_pem,
+                        root_cert_pem: root_cert_pem,
+                        control: control_addr,
+                        read_only: read_only,
+                    },
+                    gen: generation,
+                };
+            info!(log, "Creating Crucible disk from request {:?}", req);
+            // QUESTION: is producer_registry: None correct here?
+            let be =
+                block::CrucibleBackend::create(req.clone(), read_only, None)
+                    .unwrap();
+            let creg = ChildRegister::new(
+                &be,
+                Some(be.get_uuid().unwrap().to_string()),
+            );
             (be, creg)
         }
         _ => {


### PR DESCRIPTION
this adds basic support for configuring propolis-standalone to use Crucible. I'm not super familiar with propolis internals; let me know if anything needs adjusting.

There's currently an issue with it where if there's a connection problem between crucible upstairs/downstairs, upstairs will get stuck in a reconnection loop, blocking the VM from exiting in response to Ctrl-C or shutdown. It's definitely something just blocking on waiting for all the async jobs to complete, which they never do. Things exit normally if the connection doesn't have any problems before the exit.

 i don't like that it does that, but I'm not really sure how to fix it. for the main thing i want to use this in, it doesnt matter and i can just `kill -9`.