### PR TITLE
Seamless migration of serial console connections (and data)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,6 +2874,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.21.0",
  "crucible-client-types",
+ "futures",
  "progenitor",
  "propolis_types",
  "rand",
@@ -2885,6 +2886,7 @@ dependencies = [
  "slog",
  "thiserror",
  "tokio",
+ "tokio-tungstenite",
  "uuid",
 ]
 

--- a/bin/propolis-server/src/lib/migrate/destination.rs
+++ b/bin/propolis-server/src/lib/migrate/destination.rs
@@ -5,6 +5,7 @@ use propolis::migrate::{MigrateCtx, MigrateStateError, Migrator};
 use slog::{error, info, trace, warn};
 use std::convert::TryInto;
 use std::io;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_tungstenite::WebSocketStream;
@@ -24,9 +25,11 @@ pub async fn migrate<T: AsyncRead + AsyncWrite + Unpin + Send>(
     vm_controller: Arc<VmController>,
     command_tx: tokio::sync::mpsc::Sender<MigrateTargetCommand>,
     conn: WebSocketStream<T>,
+    local_addr: SocketAddr,
 ) -> Result<(), MigrateError> {
     let err_tx = command_tx.clone();
-    let mut proto = DestinationProtocol::new(vm_controller, command_tx, conn);
+    let mut proto =
+        DestinationProtocol::new(vm_controller, command_tx, conn, local_addr);
 
     if let Err(err) = proto.run().await {
         err_tx
@@ -57,6 +60,10 @@ struct DestinationProtocol<T: AsyncRead + AsyncWrite + Unpin + Send> {
 
     /// Transport to the source Instance.
     conn: WebSocketStream<T>,
+
+    /// Local propolis-server address
+    /// (to inform the source-side where to redirect its clients)
+    local_addr: SocketAddr,
 }
 
 impl<T: AsyncRead + AsyncWrite + Unpin + Send> DestinationProtocol<T> {
@@ -64,8 +71,9 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> DestinationProtocol<T> {
         vm_controller: Arc<VmController>,
         command_tx: tokio::sync::mpsc::Sender<MigrateTargetCommand>,
         conn: WebSocketStream<T>,
+        local_addr: SocketAddr,
     ) -> Self {
-        Self { vm_controller, command_tx, conn }
+        Self { vm_controller, command_tx, conn, local_addr }
     }
 
     fn log(&self) -> &slog::Logger {
@@ -97,6 +105,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> DestinationProtocol<T> {
             MigratePhase::RamPush => self.ram_push().await,
             MigratePhase::DeviceState => self.device_state().await,
             MigratePhase::RamPull => self.ram_pull().await,
+            MigratePhase::ServerState => self.server_state().await,
             MigratePhase::Finish => self.finish().await,
         };
 
@@ -112,6 +121,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> DestinationProtocol<T> {
         self.run_phase(MigratePhase::RamPush).await?;
         self.run_phase(MigratePhase::DeviceState).await?;
         self.run_phase(MigratePhase::RamPull).await?;
+        self.run_phase(MigratePhase::ServerState).await?;
         self.run_phase(MigratePhase::Finish).await?;
 
         info!(self.log(), "Destination Migration Successful");
@@ -323,6 +333,29 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> DestinationProtocol<T> {
         let m = self.read_msg().await?;
         info!(self.log(), "ram_pull: got end {:?}", m);
         self.send_msg(codec::Message::MemDone).await
+    }
+
+    async fn server_state(&mut self) -> Result<(), MigrateError> {
+        self.update_state(MigrationState::Server).await;
+        self.send_msg(codec::Message::Serialized(
+            ron::to_string(&self.local_addr)
+                .map_err(codec::ProtocolError::from)?,
+        ))
+        .await?;
+        let com1_history = match self.read_msg().await? {
+            codec::Message::Serialized(encoded) => encoded,
+            msg => {
+                error!(self.log(), "server_state: unexpected message: {msg:?}");
+                return Err(MigrateError::UnexpectedMessage);
+            }
+        };
+
+        self.vm_controller
+            .com1()
+            .import(&com1_history)
+            .await
+            .map_err(|e| MigrateError::Codec(e.to_string()))?;
+        self.send_msg(codec::Message::Okay).await
     }
 
     async fn finish(&mut self) -> Result<(), MigrateError> {

--- a/bin/propolis-server/src/lib/serial/mod.rs
+++ b/bin/propolis-server/src/lib/serial/mod.rs
@@ -1,6 +1,11 @@
 //! Routines to expose a connection to an instance's serial port.
 
+#![cfg_attr(feature = "mock-only", allow(unused))]
+#[cfg(not(feature = "mock-only"))]
+use crate::migrate::MigrateError;
+
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::ops::Range;
 use std::sync::Arc;
@@ -12,9 +17,10 @@ use futures::stream::SplitSink;
 use futures::{FutureExt, SinkExt, StreamExt};
 use hyper::upgrade::Upgraded;
 use propolis::chardev::{pollers, Sink, Source};
+use propolis_client::handmade::api::InstanceSerialConsoleControlMessage;
 use slog::{info, warn, Logger};
 use thiserror::Error;
-use tokio::sync::{mpsc, oneshot, RwLock as AsyncRwLock};
+use tokio::sync::{mpsc, oneshot, Mutex, RwLock as AsyncRwLock};
 use tokio::task::JoinHandle;
 use tokio_tungstenite::tungstenite::protocol::{
     frame::coding::CloseCode, CloseFrame,
@@ -49,20 +55,32 @@ pub enum SerialTaskError {
 
     #[error("Mismatched websocket streams while closing")]
     MismatchedStreams,
+
+    #[error("Error while waiting for notification: {0}")]
+    OneshotRecv(#[from] oneshot::error::RecvError),
+
+    #[error("JSON marshalling error while processing control message: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+pub enum SerialTaskControlMessage {
+    Stopping,
+    Migration { destination: SocketAddr, from_start: u64 },
 }
 
 pub struct SerialTask {
     /// Handle to attached serial session
     pub task: JoinHandle<()>,
-    /// Oneshot channel used to signal the task to terminate gracefully
-    pub close_ch: oneshot::Sender<()>,
+    /// Channel used to signal the task to terminate gracefully or notify
+    /// clients of a migration
+    pub control_ch: mpsc::Sender<SerialTaskControlMessage>,
     /// Channel used to send new client connections to the streaming task
     pub websocks_ch: mpsc::Sender<WebSocketStream<Upgraded>>,
 }
 
 pub async fn instance_serial_task<Device: Sink + Source>(
     mut websocks_recv: mpsc::Receiver<WebSocketStream<Upgraded>>,
-    mut close_recv: oneshot::Receiver<()>,
+    mut control_recv: mpsc::Receiver<SerialTaskControlMessage>,
     serial: Arc<Serial<Device>>,
     log: Logger,
 ) -> Result<(), SerialTaskError> {
@@ -129,8 +147,9 @@ pub async fn instance_serial_task<Device: Sink + Source>(
             ),
         };
 
-        let recv_ch_fut = recv_ch.recv().fuse();
+        let input_recv_ch_fut = recv_ch.recv().fuse();
         let new_ws_recv = websocks_recv.recv().fuse();
+        let control_recv_fut = control_recv.recv().fuse();
 
         tokio::select! {
             // Poll in the order written
@@ -139,16 +158,36 @@ pub async fn instance_serial_task<Device: Sink + Source>(
             // It's important we always poll the close channel first
             // so that a constant stream of incoming/outgoing messages
             // don't cause us to ignore it
-            _ = &mut close_recv => {
+            message = control_recv_fut => {
                 probes::serial_close_recv!(|| {});
-                // Gracefully close the connections to any clients
-                for (i, ws0) in ws_sinks.into_iter() {
-                    let ws1 = ws_streams.remove(&i).ok_or(SerialTaskError::MismatchedStreams)?;
-                    let mut ws = ws0.reunite(ws1).map_err(|_| SerialTaskError::MismatchedStreams)?;
-                    let _ = ws.close(Some(CloseFrame {
-                        code: CloseCode::Away,
-                        reason: "VM stopped".into(),
-                    })).await;
+                match message {
+                    Some(SerialTaskControlMessage::Stopping) | None => {
+                        // Gracefully close the connections to any clients
+                        for (i, ws0) in ws_sinks.into_iter() {
+                            let ws1 = ws_streams.remove(&i).ok_or(SerialTaskError::MismatchedStreams)?;
+                            let mut ws = ws0.reunite(ws1).map_err(|_| SerialTaskError::MismatchedStreams)?;
+                            let _ = ws.close(Some(CloseFrame {
+                                code: CloseCode::Away,
+                                reason: "VM stopped".into(),
+                            })).await;
+                        }
+                    }
+                    Some(SerialTaskControlMessage::Migration { destination, from_start }) => {
+                        let mut failures = 0;
+                        for sink in ws_sinks.values_mut() {
+                            if sink.send(Message::Text(serde_json::to_string(
+                                &InstanceSerialConsoleControlMessage::Migrating {
+                                    destination,
+                                    from_start,
+                                }
+                            )?)).await.is_err() {
+                                failures += 1;
+                            }
+                        }
+                        if failures > 0 {
+                            warn!(log, "Failed to send migration info to {} connected clients.", failures);
+                        }
+                    }
                 }
                 info!(log, "Terminating serial task");
                 break;
@@ -207,7 +246,7 @@ pub async fn instance_serial_task<Device: Sink + Source>(
             // the UART. This needs to be checked before `ws_recv` so that
             // "close" messages can be processed and their indicated
             // sinks/streams removed before they are polled again.
-            pair = recv_ch_fut => {
+            pair = input_recv_ch_fut => {
                 probes::serial_inject_uart!(|| {});
                 if let Some((i, msg)) = pair {
                     match msg {
@@ -242,6 +281,8 @@ pub async fn instance_serial_task<Device: Sink + Source>(
 pub struct Serial<Device: Sink + Source> {
     uart: Arc<Device>,
 
+    task_control_ch: Mutex<Option<mpsc::Sender<SerialTaskControlMessage>>>,
+
     sink_poller: Arc<pollers::SinkBuffer>,
     source_poller: Arc<pollers::SourceBuffer>,
     history: AsyncRwLock<HistoryBuffer>,
@@ -274,18 +315,21 @@ impl<Device: Sink + Source> Serial<Device> {
         source_poller.attach(uart.as_ref());
         uart.set_autodiscard(false);
 
-        Serial { uart, sink_poller, source_poller, history }
+        let task_control_ch = Default::default();
+
+        Serial { uart, task_control_ch, sink_poller, source_poller, history }
     }
 
     pub async fn read_source(&self, buf: &mut [u8]) -> Option<usize> {
-        let bytes_read =
-            self.source_poller.read(buf, self.uart.as_ref()).await?;
+        let uart = self.uart.clone();
+        let bytes_read = self.source_poller.read(buf, uart.as_ref()).await?;
         self.history.write().await.consume(&buf[..bytes_read]);
         Some(bytes_read)
     }
 
     pub async fn write_sink(&self, buf: &[u8]) -> Option<usize> {
-        self.sink_poller.write(buf, self.uart.as_ref()).await
+        let uart = self.uart.clone();
+        self.sink_poller.write(buf, uart.as_ref()).await
     }
 
     pub(crate) async fn history_vec(
@@ -294,6 +338,54 @@ impl<Device: Sink + Source> Serial<Device> {
         max_bytes: Option<usize>,
     ) -> Result<(Vec<u8>, usize), history_buffer::Error> {
         self.history.read().await.contents_vec(byte_offset, max_bytes)
+    }
+
+    // provide the channel through which we inform connected websocket clients
+    // that a migration has occurred, and where to reconnect.
+    // (the server's serial-to-websocket task -- and thus the receiving end of
+    // this channel -- are spawned in `instance_ensure_common`, after the
+    // construction of `Serial`)
+    pub(crate) async fn set_task_control_sender(
+        &self,
+        control_ch: mpsc::Sender<SerialTaskControlMessage>,
+    ) {
+        self.task_control_ch.lock().await.replace(control_ch);
+    }
+
+    #[cfg(not(feature = "mock-only"))]
+    pub(crate) async fn export_history(
+        &self,
+        destination: SocketAddr,
+    ) -> Result<String, MigrateError> {
+        let read_hist = self.history.read().await;
+        let from_start = read_hist.bytes_from_start() as u64;
+        let encoded = ron::to_string(&*read_hist)
+            .map_err(|e| MigrateError::Codec(e.to_string()))?;
+        drop(read_hist);
+        if let Some(ch) = self.task_control_ch.lock().await.as_ref() {
+            ch.send(SerialTaskControlMessage::Migration {
+                destination,
+                from_start,
+            })
+            .await
+            .map_err(|_| MigrateError::InvalidInstanceState)?;
+        }
+        Ok(encoded)
+    }
+
+    #[cfg(not(feature = "mock-only"))]
+    pub(crate) async fn import(
+        &self,
+        serialized_hist: &str,
+    ) -> Result<(), MigrateError> {
+        self.sink_poller.attach(self.uart.as_ref());
+        self.source_poller.attach(self.uart.as_ref());
+        self.uart.set_autodiscard(false);
+        let decoded = ron::from_str(serialized_hist)
+            .map_err(|e| MigrateError::Codec(e.to_string()))?;
+        let mut write_hist = self.history.write().await;
+        *write_hist = decoded;
+        Ok(())
     }
 }
 

--- a/lib/propolis-client/Cargo.toml
+++ b/lib/propolis-client/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 propolis_types.workspace = true
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 base64.workspace = true
+futures = { workspace = true, optional = true }
 rand.workspace = true
 ring.workspace = true
 schemars = { workspace = true, features = [ "uuid1" ] }
@@ -19,10 +20,11 @@ thiserror.workspace = true
 uuid = { workspace = true, features = [ "serde", "v4" ] }
 progenitor = { workspace = true, optional = true }
 tokio = { workspace = true, features = [ "net" ], optional = true }
+tokio-tungstenite = { workspace = true, optional = true }
 crucible-client-types.workspace = true
 
 [features]
 default = []
-generated = ["progenitor", "tokio"]
+generated = ["progenitor", "tokio", "tokio-tungstenite", "futures"]
 generated-migration = ["generated"]
 falcon = []

--- a/lib/propolis-client/src/handmade/api.rs
+++ b/lib/propolis-client/src/handmade/api.rs
@@ -100,6 +100,7 @@ pub enum MigrationState {
     Device,
     Resume,
     RamPull,
+    Server,
     Finish,
     Error,
 }
@@ -227,6 +228,13 @@ pub struct InstanceSerialConsoleStreamRequest {
     /// recently buffered data retrieved from the instance. (See note on `from_start` about mutual
     /// exclusivity)
     pub most_recent: Option<u64>,
+}
+
+/// Send things besides raw bytes to connected serial console clients, such as
+/// the change-of-address notice when the VM migrates
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum InstanceSerialConsoleControlMessage {
+    Migrating { destination: SocketAddr, from_start: u64 },
 }
 
 /// Describes how to connect to one or more storage agent services.

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -1012,6 +1012,7 @@
           "Device",
           "Resume",
           "RamPull",
+          "Server",
           "Finish",
           "Error"
         ]

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -10,8 +10,9 @@ use anyhow::{anyhow, Context, Result};
 use core::result::Result as StdResult;
 use propolis_client::types::{
     InstanceGetResponse, InstanceMigrateInitiateRequest, InstanceProperties,
-    InstanceSpecEnsureRequest, InstanceSpecGetResponse, InstanceState,
-    InstanceStateRequested, MigrationState,
+    InstanceSerialConsoleHistoryResponse, InstanceSpecEnsureRequest,
+    InstanceSpecGetResponse, InstanceState, InstanceStateRequested,
+    MigrationState,
 };
 use propolis_client::{Client, ResponseValue};
 use thiserror::Error;
@@ -365,6 +366,21 @@ impl TestVm {
                 .send()
                 .await?
                 .state)
+        })
+    }
+
+    pub fn get_serial_console_history(
+        &self,
+        from_start: u64,
+    ) -> Result<InstanceSerialConsoleHistoryResponse> {
+        self.rt.block_on(async {
+            Ok(self
+                .client
+                .instance_serial_history_get()
+                .from_start(from_start)
+                .send()
+                .await?
+                .into_inner())
         })
     }
 


### PR DESCRIPTION
This implements transfer of serial console history during migration, by adding a new stage to the migration for 'server' state.

propolis-cli has an implementation of live client hand-off between servers, using an abstraction added to the propolis-client library (to also simplify integration into other clients such as nexus)