### PR TITLE
migration: make source/target mutually acknowledge completion

### DIFF
--- a/bin/propolis-server/src/lib/migrate/destination.rs
+++ b/bin/propolis-server/src/lib/migrate/destination.rs
@@ -326,8 +326,6 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> DestinationProtocol<T> {
     }
 
     async fn finish(&mut self) -> Result<(), MigrateError> {
-        self.update_state(MigrationState::Finish).await;
-
         // Tell the source this destination is ready to run the VM.
         self.send_msg(codec::Message::Okay).await?;
 
@@ -336,6 +334,10 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> DestinationProtocol<T> {
         // to be sure the source hasn't decided the migration has failed and
         // that it should resume the VM.
         self.read_ok().await?;
+
+        // Now that control is definitely being transferred, publish that the
+        // migration has succeeded.
+        self.update_state(MigrationState::Finish).await;
         Ok(())
     }
 

--- a/bin/propolis-server/src/lib/migrate/destination.rs
+++ b/bin/propolis-server/src/lib/migrate/destination.rs
@@ -327,8 +327,15 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> DestinationProtocol<T> {
 
     async fn finish(&mut self) -> Result<(), MigrateError> {
         self.update_state(MigrationState::Finish).await;
+
+        // Tell the source this destination is ready to run the VM.
         self.send_msg(codec::Message::Okay).await?;
-        let _ = self.read_ok().await; // A failure here is ok.
+
+        // Wait for the source to acknowledge that it's handing control to this
+        // destination. If this acknolwedgement doesn't arrive, there's no way
+        // to be sure the source hasn't decided the migration has failed and
+        // that it should resume the VM.
+        self.read_ok().await?;
         Ok(())
     }
 

--- a/bin/propolis-server/src/lib/migrate/destination.rs
+++ b/bin/propolis-server/src/lib/migrate/destination.rs
@@ -330,7 +330,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> DestinationProtocol<T> {
         self.send_msg(codec::Message::Okay).await?;
 
         // Wait for the source to acknowledge that it's handing control to this
-        // destination. If this acknolwedgement doesn't arrive, there's no way
+        // destination. If this acknowledgement doesn't arrive, there's no way
         // to be sure the source hasn't decided the migration has failed and
         // that it should resume the VM.
         self.read_ok().await?;


### PR DESCRIPTION
In the current migration protocol's Finish phase, if the destination successfully sends its final "OK" message, it will think migration has succeeded irrespective of whether the source received or acknowledged that message. This can create a scenario where both source and target think they're supposed to be running a VM (the target because it thinks migration succeeded, the source because it thinks migration failed).

Fix this by changing this phase so that (a) the source succeeds only if it successfully sends a final "OK" message, and (b) the target succeeds only if it successfully receives that message. This creates the possibility that *no one* will run the VM (source sent the last handoff, target didn't receive it), but that's not much different from the VM successfully migrating and then immediately crashing (and is probably better than having two identical instances fighting over the same backends, etc.).

Also change this phase to publish the "Finish" state only after passing the point of no return. This lets callers use the Finish migration state to mean "migration completed successfully" without having to worry about a later transition to the Error state.

Fixes #350.