### PR TITLE
Expose API for reservoir manipulation

### DIFF
--- a/bin/propolis-utils/Cargo.toml
+++ b/bin/propolis-utils/Cargo.toml
@@ -10,6 +10,9 @@ name = "savex"
 [[bin]]
 name = "cpuid-gen"
 
+[[bin]]
+name = "rsrvrctl"
+
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/bin/propolis-utils/README.md
+++ b/bin/propolis-utils/README.md
@@ -9,3 +9,5 @@ development activities, but are otherwise not meant for general consumption.
   halted and saved with the `-s` flag.
 - `cpuid-gen`: Generated CPUID profile using the legacy emulated output from the
   local host CPU, as filtered by the kernel VMM logic.
+- `rsrvrctl`: Manipulate the kernel VMM memory reservoir in the same manner
+  offered by the utility shipped by the OS

--- a/bin/propolis-utils/src/bin/rsrvrctl.rs
+++ b/bin/propolis-utils/src/bin/rsrvrctl.rs
@@ -1,0 +1,101 @@
+use bhyve_api::{ReservoirError, VmmCtlFd};
+use clap::Parser;
+
+#[derive(clap::Parser, Debug)]
+struct Opts {
+    #[clap(subcommand)]
+    cmd: Command,
+}
+
+#[derive(clap::Subcommand, Debug)]
+enum Command {
+    /// Add to reservoir capacity
+    Add {
+        /// Size to add (MiB)
+        sz: usize,
+        /// Chunk size (MiB)
+        chunk: Option<usize>,
+    },
+    /// Remove from reservoir capacity
+    Remove {
+        /// Size to remove (MiB)
+        sz: usize,
+        /// Chunk size (MiB)
+        chunk: Option<usize>,
+    },
+    /// Set reservoir capacity
+    Set {
+        /// Target size (MiB)
+        sz: usize,
+        /// Chunk size (MiB)
+        chunk: Option<usize>,
+    },
+    /// Query current reservoir information
+    Query,
+}
+
+const MB: usize = 1024 * 1024;
+
+fn do_resize(
+    ctl: &VmmCtlFd,
+    sz_bytes: usize,
+    chunk_mb: usize,
+) -> std::io::Result<()> {
+    loop {
+        match ctl.reservoir_resize(sz_bytes, chunk_mb * MB) {
+            Err(ReservoirError::Interrupted(sz)) => {
+                println!("Reservoir size: {}MiB", sz / MB);
+            }
+            Err(ReservoirError::Io(e)) => return Err(e),
+            Ok(_) => return Ok(()),
+        }
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let opts = Opts::parse();
+
+    let ctl = VmmCtlFd::open()?;
+
+    let size_total =
+        |q: bhyve_api::vmm_resv_query| q.vrq_free_sz + q.vrq_alloc_sz;
+
+    match opts.cmd {
+        Command::Add { sz, chunk } => {
+            let cur_sz = ctl.reservoir_query().map(size_total)?;
+
+            do_resize(
+                &ctl,
+                cur_sz.saturating_add(sz * MB),
+                chunk.unwrap_or(0),
+            )?;
+        }
+        Command::Remove { sz, chunk } => {
+            let cur_sz = ctl.reservoir_query().map(size_total)?;
+
+            do_resize(
+                &ctl,
+                cur_sz.saturating_sub(sz * MB),
+                chunk.unwrap_or(0),
+            )?;
+        }
+        Command::Set { sz, chunk } => {
+            do_resize(&ctl, sz * MB, chunk.unwrap_or(0))?;
+        }
+        Command::Query => {
+            let sz = ctl.reservoir_query()?;
+            println!(
+                "Free KiB:\t\t\t{}\n\
+                Allocated KiB:\t\t\t{}\n\
+                Transient Allocated KiB:\t{}\n\
+                Size limit KiB:\t\t\t{}",
+                sz.vrq_free_sz / 1024,
+                sz.vrq_alloc_sz / 1024,
+                sz.vrq_alloc_transient_sz / 1024,
+                sz.vrq_limit / 1024
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/bhyve-api/sys/src/structs.rs
+++ b/crates/bhyve-api/sys/src/structs.rs
@@ -491,3 +491,18 @@ pub struct vmm_resv_query {
     pub vrq_alloc_transient_sz: size_t,
     pub vrq_limit: size_t,
 }
+
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct vmm_resv_target {
+    /// Target size for VMM reservoir
+    pub vrt_target_sz: size_t,
+
+    /// Change of reservoir size to meet target will be done in multiple steps
+    /// of chunk size (or smaller)
+    pub vrt_chunk_sz: size_t,
+
+    /// Resultant size of reservoir after operation.  Should match target size,
+    /// except when interrupted.
+    pub vrt_result_sz: size_t,
+}


### PR DESCRIPTION
This includes a rust clone of `rsrvrctl` as an example of the API usage.