### PR TITLE
Fix "mock-only" propolis-server build & a logic error in mock serial console

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: dtolnay/rust-toolchain@stable
+    - name: Build mock-only server
+      run: cargo build --bin propolis-server --features mock-only
     - name: Build
       run: cargo build --verbose
     - name: Test Libraries


### PR DESCRIPTION
Adds a [step to CI](https://github.com/oxidecomputer/propolis/actions/runs/4516517369/jobs/7954934463?pr=354#step:4:637) for building with this feature too so we ensure it keeps working (this didn't break sled-agent-sim because it links it as a lib instead)

The fixed logic error is a panic if attaching to serial console before the mock instance is *created*.
```
called `Option::unwrap()` on a `None` value', bin/propolis-server/src/lib/mock_server.rs:338:30
```