### PR TITLE
Use single channel for instance & migration state updates

### DIFF
--- a/bin/propolis-server/src/lib/mock_server.rs
+++ b/bin/propolis-server/src/lib/mock_server.rs
@@ -59,6 +59,7 @@ impl InstanceContext {
             watch::channel(api::InstanceStateMonitorResponse {
                 gen: 0,
                 state: api::InstanceState::Creating,
+                migration: None,
             });
         let mock_uart = Arc::new(MockUart::new(&properties.name));
         let sink_size = NonZeroUsize::new(64).unwrap();
@@ -126,6 +127,7 @@ impl InstanceContext {
                         .send(api::InstanceStateMonitorResponse {
                             gen: self.generation,
                             state: self.state.clone(),
+                            migration: None,
                         })
                         .map_err(|_| Error::TransitionSendFail)
                 }
@@ -284,6 +286,7 @@ async fn instance_state_monitor(
             let response = api::InstanceStateMonitorResponse {
                 gen: last.gen,
                 state: last.state,
+                migration: None,
             };
             return Ok(HttpResponseOk(response));
         }

--- a/lib/propolis-client/src/handmade/api.rs
+++ b/lib/propolis-client/src/handmade/api.rs
@@ -74,8 +74,9 @@ pub struct InstanceMigrateStatusRequest {
     pub migration_id: Uuid,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 pub struct InstanceMigrateStatusResponse {
+    pub migration_id: Uuid,
     pub state: MigrationState,
 }
 
@@ -124,6 +125,7 @@ pub struct InstanceStateMonitorRequest {
 pub struct InstanceStateMonitorResponse {
     pub gen: u64,
     pub state: InstanceState,
+    pub migration: Option<InstanceMigrateStatusResponse>,
 }
 
 /// Requested state of an Instance.

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -794,11 +794,16 @@
       "InstanceMigrateStatusResponse": {
         "type": "object",
         "properties": {
+          "migration_id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "state": {
             "$ref": "#/components/schemas/MigrationState"
           }
         },
         "required": [
+          "migration_id",
           "state"
         ]
       },
@@ -971,6 +976,14 @@
             "type": "integer",
             "format": "uint64",
             "minimum": 0
+          },
+          "migration": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceMigrateStatusResponse"
+              }
+            ]
           },
           "state": {
             "$ref": "#/components/schemas/InstanceState"


### PR DESCRIPTION
**N.B.** This is a breaking change for users of the instance state monitor API (notably the sled agent). I'll wait to merge until the sled agent changes that require this API are closer to landing. 

Make `instance_state_monitor` monitor both migration and instance states. The state generation advances when either state changes. This empowers sled agent in two ways:

1. The sled agent monitor can now be notified whenever a migration's state changes.
2. Sled agent can get atomic snapshots of Propolis's instance state and migration state, which makes it easier to reason about these states in tandem (less need to worry about observing X, querying Y, and then having to account for the possibility that X changed while Y was being queried).