### PR TITLE
`propolis-standalone` doesn't need usdt-related features

### DIFF
--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -1,9 +1,3 @@
-// Required for USDT
-#![cfg_attr(
-    all(feature = "dtrace-probes", target_os = "macos"),
-    feature(asm_sym)
-)]
-
 use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{Error, ErrorKind, Result};


### PR DESCRIPTION
Even where supported, the use of the feature(s) in the library is sufficient.

This fixed a build error on macOS