### PR TITLE
Support illumos#15143 data and vCPU pause/resume

### DIFF
--- a/crates/bhyve-api/sys/src/lib.rs
+++ b/crates/bhyve-api/sys/src/lib.rs
@@ -13,4 +13,4 @@ pub const VM_MAXCPU: usize = 32;
 /// This is the VMM interface version which bhyve_api expects to operate
 /// against.  All constants and structs defined by the crate are done so in
 /// terms of that specific version.
-pub const VMM_CURRENT_INTERFACE_VERSION: u32 = 9;
+pub const VMM_CURRENT_INTERFACE_VERSION: u32 = 10;

--- a/crates/bhyve-api/sys/src/vmm_data.rs
+++ b/crates/bhyve-api/sys/src/vmm_data.rs
@@ -191,9 +191,24 @@ impl Default for vdi_rtc_v1 {
 
 // VDC_VMM_ARCH v1 data identifiers
 
+// VM-wide:
+
 /// Offset of guest TSC from system at time of boot
 pub const VAI_TSC_BOOT_OFFSET: u32 = 1;
 /// Time that guest (nominally) booted, as hrtime
 pub const VAI_BOOT_HRTIME: u32 = 2;
 /// Guest TSC frequency measured by hrtime (not effected by wall clock adj.)
 pub const VAI_TSC_FREQ: u32 = 3;
+/// Guest instance has been placed in paused state
+pub const VAI_VM_IS_PAUSED: u32 = 4;
+
+// per-vCPU
+
+/// NMI pending injection for vCPU (0 or 1)
+pub const VAI_PEND_NMI: u32 = 10;
+/// extint pending injection for vCPU (0 or 1)
+pub const VAI_PEND_EXTINT: u32 = 11;
+/// HW exception pending injection for vCPU
+pub const VAI_PEND_EXCP: u32 = 12;
+/// exception/interrupt pending injection for vCPU
+pub const VAI_PEND_INTINFO: u32 = 13;


### PR DESCRIPTION
With the integration of illumos#15143, additional pending interrupt and exception state for guest vCPUs is exposed to userspace.  In order to take a consistent snapshot of said state, as well as the guest devices emulated in-kernel, propolis-server needs to issue VM_PAUSE requests prior to exporting or importing state, and VM_RESUME requests when starting a VM after a migration.

Importation of the "new" vCPU state is guarded with a version check for now, so that propolis continues to work on hosts which have not yet updated to bits featuring illumos#15143.

Closes #291 as well.