### PR TITLE
Include buildomat-produced firmware in Propolis zone images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,8 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "omicron-zone-package"
-version = "0.8.3"
-source = "git+https://github.com/oxidecomputer/omicron-package?rev=a425676edcdefe5a40f77d436f74836bb906b302#a425676edcdefe5a40f77d436f74836bb906b302"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dcc25318120198af566dd006a34b15439a59f52c18f3a690338dac18239bfe"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ source = "git+https://github.com/oxidecomputer/omicron?branch=main#bab91f6b5cba8
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -139,7 +139,7 @@ checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -150,7 +150,7 @@ checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -171,18 +171,18 @@ checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.64"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -300,7 +300,7 @@ checksum = "35fd19022c2b750d14eb9724c204d08ab7544570105b3b466d8a9f2f3feded27"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -370,7 +370,7 @@ version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031718ddb8f78aa5def78a09e90defe30151d1f6c672f937af4dd916429ed996"
 dependencies = [
- "semver 1.0.16",
+ "semver 1.0.17",
  "serde",
  "toml 0.5.11",
  "url",
@@ -393,9 +393,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -459,7 +459,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -472,7 +472,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -636,7 +636,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "toml 0.7.2",
+ "toml 0.7.3",
  "tracing",
  "usdt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid",
@@ -668,7 +668,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio-rustls",
- "toml 0.7.2",
+ "toml 0.7.3",
  "twox-hash",
  "uuid",
 ]
@@ -705,7 +705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -751,7 +751,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -768,7 +768,7 @@ checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -792,7 +792,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -803,7 +803,7 @@ checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -941,7 +941,7 @@ dependencies = [
  "slog-term",
  "tokio",
  "tokio-rustls",
- "toml 0.7.2",
+ "toml 0.7.3",
  "usdt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid",
  "version_check",
@@ -956,7 +956,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_tokenstream",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1228,7 +1228,7 @@ checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1309,7 +1309,7 @@ checksum = "41973d4c45f7a35af8753ba3457cc99d406d863941fd7f52663cff54a5ab99b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1877,7 +1877,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1941,15 +1941,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "static_assertions",
-]
-
-[[package]]
-name = "nom8"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2075,7 +2066,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2123,7 +2114,7 @@ dependencies = [
  "reqwest",
  "ring",
  "schemars",
- "semver 1.0.16",
+ "semver 1.0.17",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2139,9 +2130,8 @@ dependencies = [
 
 [[package]]
 name = "omicron-zone-package"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2444a2bdf8bbf30622eeabfe1c6d5caa8ff5e31b679fe7143ef97e514709a3da"
+version = "0.8.3"
+source = "git+https://github.com/oxidecomputer/omicron-package?rev=a425676edcdefe5a40f77d436f74836bb906b302#a425676edcdefe5a40f77d436f74836bb906b302"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2149,14 +2139,17 @@ dependencies = [
  "filetime",
  "flate2",
  "futures-util",
+ "hex",
  "reqwest",
+ "ring",
+ "semver 1.0.17",
  "serde",
  "serde_derive",
  "tar",
  "tempfile",
  "thiserror",
  "tokio",
- "toml 0.7.2",
+ "toml 0.7.3",
  "walkdir",
 ]
 
@@ -2206,7 +2199,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2262,7 +2255,7 @@ source = "git+https://github.com/oxidecomputer/omicron?branch=main#bab91f6b5cba8
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2393,7 +2386,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2438,7 +2431,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2530,7 +2523,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2690,7 +2683,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -2707,9 +2700,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -2762,7 +2755,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "syn",
+ "syn 1.0.107",
  "thiserror",
  "typify",
  "unicode-ident",
@@ -2782,7 +2775,7 @@ dependencies = [
  "serde_json",
  "serde_tokenstream",
  "serde_yaml",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3000,9 +2993,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3343,7 +3336,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3408,9 +3401,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
 ]
@@ -3450,7 +3443,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3461,7 +3454,7 @@ checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3483,7 +3476,7 @@ checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3512,7 +3505,7 @@ checksum = "274f512d6748a01e67cbcde5b4307ab2c9d52a98a2b870a980ef0793a351deff"
 dependencies = [
  "proc-macro2",
  "serde",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3552,7 +3545,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3754,9 +3747,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -3846,7 +3839,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3857,7 +3850,7 @@ checksum = "bafede0d0a2f21910f36d47b1558caae3076ed80f6f3ad0fc85a91e6ba7e5938"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3878,6 +3871,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3885,7 +3889,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "unicode-xid",
 ]
 
@@ -3974,7 +3978,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4054,14 +4058,13 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot",
@@ -4069,18 +4072,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -4165,9 +4168,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -4186,15 +4189,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.3"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6a7712b49e1775fb9a7b998de6635b299237f48b404dde71704f2e0e7f37e5"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
 dependencies = [
  "indexmap",
- "nom8",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4248,7 +4251,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4372,7 +4375,7 @@ dependencies = [
  "rustfmt-wrapper",
  "schemars",
  "serde_json",
- "syn",
+ "syn 1.0.107",
  "thiserror",
  "unicode-ident",
 ]
@@ -4388,7 +4391,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn",
+ "syn 1.0.107",
  "typify-impl",
 ]
 
@@ -4505,7 +4508,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_tokenstream",
- "syn",
+ "syn 1.0.107",
  "usdt-impl 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4518,7 +4521,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_tokenstream",
- "syn",
+ "syn 1.0.107",
  "usdt-impl 0.3.5 (git+https://github.com/oxidecomputer/usdt)",
 ]
 
@@ -4536,7 +4539,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 1.0.107",
  "thiserror",
  "thread-id",
  "version_check",
@@ -4555,7 +4558,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 1.0.107",
  "thiserror",
  "thread-id",
  "version_check",
@@ -4571,7 +4574,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_tokenstream",
- "syn",
+ "syn 1.0.107",
  "usdt-impl 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4584,7 +4587,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_tokenstream",
- "syn",
+ "syn 1.0.107",
  "usdt-impl 0.3.5 (git+https://github.com/oxidecomputer/usdt)",
 ]
 
@@ -4719,7 +4722,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -4753,7 +4756,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4919,6 +4922,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
+name = "winnow"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4972,7 +4984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -4984,7 +4996,7 @@ checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ libloading = "0.7"
 mockall = "0.11"
 num_enum = "0.5"
 omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-omicron-zone-package = "0.7.1"
+omicron-zone-package = { git = "https://github.com/oxidecomputer/omicron-package", rev = "a425676edcdefe5a40f77d436f74836bb906b302" }
 once_cell = "1.13"
 oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ libloading = "0.7"
 mockall = "0.11"
 num_enum = "0.5"
 omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-omicron-zone-package = { git = "https://github.com/oxidecomputer/omicron-package", rev = "a425676edcdefe5a40f77d436f74836bb906b302" }
+omicron-zone-package = "0.9.0"
 once_cell = "1.13"
 oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }

--- a/README.md
+++ b/README.md
@@ -169,9 +169,7 @@ are some options to get up-and-running quickly:
 #### Guest bootrom
 
 The current recommended and tested guest bootrom is available
-[here](https://oxide-omicron-build.s3.amazonaws.com/OVMF_CODE_20220922.fd).
-Rename this file to `OVMF_CODE.fd` to use it with the example configuration
-below.
+[here](https://buildomat.eng.oxide.computer/public/file/oxidecomputer/edk2/image_debug/6d92acf0a22718dd4175d7c64dbcf7aaec3740bd/OVMF_CODE.fd).
 
 Other UEFI firmware images built from the [Open Virtual Machine Firmware
 project](https://github.com/tianocore/tianocore.github.io/wiki/OVMF) may also

--- a/packaging/package-manifest.toml
+++ b/packaging/package-manifest.toml
@@ -9,6 +9,7 @@ source.paths = [
 source.blobs = [ "alpine.iso" ]
 output.type = "zone"
 
+# N.B. Should be kept in sync with phd-tests/artifacts.toml.
 [[package.propolis-server.source.buildomat_blobs]]
 repo = "edk2"
 series = "image_debug"

--- a/packaging/package-manifest.toml
+++ b/packaging/package-manifest.toml
@@ -6,5 +6,12 @@ source.rust.release = true
 source.paths = [
     { from = "packaging/smf/propolis-server", to = "/var/svc/manifest/site/propolis-server" },
 ]
-source.blobs = [ "alpine.iso", "OVMF_CODE_20220922.fd" ]
+source.blobs = [ "alpine.iso" ]
 output.type = "zone"
+
+[[package.propolis-server.source.buildomat_blobs]]
+repo = "edk2"
+series = "image_debug"
+commit = "6d92acf0a22718dd4175d7c64dbcf7aaec3740bd"
+artifact = "OVMF_CODE.fd"
+sha256 = "29813374b58e3b77fb665f2d95cb3bab37d44fdd2c4fce2a70de9d76a3512a4f"

--- a/packaging/propolis-package/src/main.rs
+++ b/packaging/propolis-package/src/main.rs
@@ -7,6 +7,8 @@ use indicatif::MultiProgress;
 use indicatif::ProgressBar;
 use indicatif::ProgressStyle;
 use omicron_zone_package::progress::Progress;
+use omicron_zone_package::target::Target;
+use std::collections::BTreeMap;
 use std::fs::create_dir_all;
 use std::path::Path;
 use std::time::Duration;
@@ -120,9 +122,13 @@ async fn main() -> Result<()> {
         .get(PKG_NAME)
         .with_context(|| anyhow!("missing propolis-server package"))?;
 
-    let progress = ProgressUI::new(pkg.get_total_work());
+    let target = Target(BTreeMap::new());
+    let progress = ProgressUI::new(pkg.get_total_work_for_target(&target)?);
 
-    pkg.create_with_progress(&progress, PKG_NAME, output_dir).await?;
+    pkg.create_with_progress_for_target(
+        &progress, &target, PKG_NAME, output_dir,
+    )
+    .await?;
 
     progress.pkg_pb.set_style(completed_progress_style());
     progress.pkg_pb.finish_with_message(format!(

--- a/packaging/smf/propolis-server/config.toml
+++ b/packaging/smf/propolis-server/config.toml
@@ -3,7 +3,7 @@
 # Refer to https://github.com/oxidecomputer/propolis#readme
 # for more detail on the config format.
 
-bootrom = "/opt/oxide/propolis-server/blob/OVMF_CODE_20220922.fd"
+bootrom = "/opt/oxide/propolis-server/blob/OVMF_CODE.fd"
 
 # NOTE: This VNIC is here for reference, but VNICs are typically managed by the
 # Sled Agent.

--- a/phd-tests/README.md
+++ b/phd-tests/README.md
@@ -77,8 +77,6 @@ entries:
 
 - `local_root`: The path to the local directory in which artifacts are stored.
   PHD requires read/write access to this directory.
-- `remote_root`: Optional. The URI of a remote path from which artifacts can be
-  downloaded if they're missing from the local path or appear to be corrupted.
 - One or more `guest_images` tables, written as `[guest_images.$KEY]`. The
   runner uses the value of its `--default-guest-artifact` parameter to choose a
   guest image to use for tests that don't attach their own disks.
@@ -107,8 +105,8 @@ entries:
     If not specified, PHD will skip pre-test integrity checks for this artifact.
     Note that this can cause changes to a disk image to persist between test
     cases!
-  - `metadata.relative_remote_path`: Optional. The path to this artifact
-    relative to the `remote_root` in this artifact file.
+  - `metadata.remote_uri`: Optional. A URI from which to try to download this
+    artifact.
 
     If an artifact is not present on disk or has the wrong SHA256 digest, the
     runner will try to redownload the artifact from this path.
@@ -120,8 +118,8 @@ entries:
   use for tests that don't select their own bootrom.
 
   The fields in these tables are `relative_local_path`, `expected_digest`, and
-  `relative_remote_path`, with the same semantics as for guest images (just
-  without the `metadata.` prefix).
+  `remote_uri`, with the same semantics as for guest images (just without the
+  `metadata.` prefix).
 
 ## Authoring tests
 

--- a/phd-tests/artifacts.toml
+++ b/phd-tests/artifacts.toml
@@ -1,13 +1,11 @@
-remote_root = "https://oxide-omicron-build.s3.amazonaws.com"
-
 [guest_images.alpine]
 guest_os_kind = "alpine"
 metadata.relative_local_path = "alpine.iso"
 metadata.expected_digest = "ba8007f74f9b54fbae3b2520da577831b4834778a498d732f091260c61aa7ca1"
-metadata.relative_remote_path = "alpine.iso"
+metadata.remote_uri = "https://oxide-omicron-build.s3.amazonaws.com/alpine.iso"
 
-[bootroms.ovmf_20220922]
-relative_local_path = "OVMF_CODE_20220922.fd"
-expected_digest = "319d678f093c43502ca360911d52b475dea7fa6dcd962150c84fff18f5b32221"
-relative_remote_path = "OVMF_CODE_20220922.fd"
+[bootroms.ovmf]
+relative_local_path = "OVMF_CODE.fd"
+expected_digest = "29813374b58e3b77fb665f2d95cb3bab37d44fdd2c4fce2a70de9d76a3512a4f"
+remote_uri = "https://buildomat.eng.oxide.computer/public/file/oxidecomputer/edk2/image_debug/6d92acf0a22718dd4175d7c64dbcf7aaec3740bd/OVMF_CODE.fd"
 

--- a/phd-tests/framework/src/artifacts.rs
+++ b/phd-tests/framework/src/artifacts.rs
@@ -385,11 +385,11 @@ mod test {
             guest_os_kind = "alpine"
             metadata.relative_local_path = "alpine.raw"
             metadata.expected_digest = "abcd1234"
-            metadata.relative_remote_path = "alpine.raw"
+            metadata.remote_uri = "https://127.0.0.1/alpine.raw"
 
             [bootroms.bootrom]
             relative_local_path = "OVMF_CODE.fd"
-            relative_remote_path = "OVMF_CODE.fd"
+            remote_uri = "https://127.0.0.1/OVMF_CODE.fd"
         "#;
 
         let store = ArtifactStoreConfig::from_toml(raw).unwrap();

--- a/phd-tests/framework/src/artifacts.rs
+++ b/phd-tests/framework/src/artifacts.rs
@@ -57,6 +57,7 @@ pub enum ArtifactStoreError {
 
 /// A single artifact.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ArtifactMetadata {
     /// The path to the artifact relative to the root directory specified in
     /// this artifact's store.
@@ -157,6 +158,7 @@ impl ArtifactMetadata {
 
 /// A wrapper for guest OS artifacts that includes their OS kind.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct GuestOsArtifact {
     guest_os_kind: GuestOsKind,
     metadata: ArtifactMetadata,
@@ -164,6 +166,7 @@ struct GuestOsArtifact {
 
 /// A collection of artifacts that can be loaded by test VMs.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ArtifactStoreConfig {
     /// A map from names to guest OS artifacts.
     guest_images: BTreeMap<String, GuestOsArtifact>,

--- a/phd-tests/framework/src/artifacts.rs
+++ b/phd-tests/framework/src/artifacts.rs
@@ -70,7 +70,7 @@ struct ArtifactMetadata {
     /// An optional path to this artifact relative to the file server root
     /// stored in the artifact store. If present, the store will use this to
     /// replace the artifact at startup if it appears to be corrupted.
-    relative_remote_path: Option<String>,
+    remote_uri: Option<String>,
 }
 
 impl ArtifactMetadata {
@@ -79,7 +79,7 @@ impl ArtifactMetadata {
     fn check_local_artifact(
         &self,
         local_root: &Path,
-        remote_root: Option<&str>,
+        remote_uri: Option<&str>,
     ) -> Result<()> {
         let mut local_path = PathBuf::new();
         local_path.push(local_root);
@@ -119,16 +119,8 @@ impl ArtifactMetadata {
 
         // The artifact is not usable as-is. See if it can be reacquired from
         // the remote source.
-        if remote_root.is_none() {
-            return Err(anyhow!("Can't download artifact: no remote root"));
-        }
-        let remote_root = remote_root.unwrap();
-        if self.relative_remote_path.is_none() {
-            return Err(anyhow!("Can't download artifact: no remote path"));
-        }
-        let remote_relative = self.relative_remote_path.as_ref().unwrap();
-        let remote_path = format!("{}/{}", remote_root, remote_relative);
-
+        let remote_uri = remote_uri
+            .ok_or_else(|| anyhow!("Can't download artifact: no remote URI"))?;
         if exists {
             info!(?local_path, "Removing mismatched artifact before replacing");
             std::fs::remove_file(&local_path)?;
@@ -137,7 +129,7 @@ impl ArtifactMetadata {
         let download_timeout = Duration::from_secs(600);
         info!(
             ?local_path,
-            ?remote_path,
+            ?remote_uri,
             "Downloading artifact with timeout {:?}",
             download_timeout,
         );
@@ -145,7 +137,7 @@ impl ArtifactMetadata {
         let client = reqwest::blocking::ClientBuilder::new()
             .timeout(download_timeout)
             .build()?;
-        let request = client.get(remote_path).build()?;
+        let request = client.get(remote_uri).build()?;
         let response = client.execute(request)?;
         let mut new_file = std::fs::File::create(&local_path)?;
         new_file.write_all(&response.bytes()?)?;
@@ -173,10 +165,6 @@ struct GuestOsArtifact {
 /// A collection of artifacts that can be loaded by test VMs.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ArtifactStoreConfig {
-    /// An optional remote file server from which to download artifacts whose
-    /// digests do not match when the store is refreshed.
-    remote_root: Option<String>,
-
     /// A map from names to guest OS artifacts.
     guest_images: BTreeMap<String, GuestOsArtifact>,
 
@@ -309,7 +297,7 @@ impl ArtifactStore {
             let _guard = span.enter();
             if let Err(e) = metadata.check_local_artifact(
                 &self.local_root,
-                self.config.remote_root.as_deref(),
+                metadata.remote_uri.as_deref(),
             ) {
                 error!(?e, "Metadata check failed");
                 all_ok = false;
@@ -364,18 +352,17 @@ mod test {
             metadata: ArtifactMetadata {
                 relative_local_path: "alpine.raw".into(),
                 expected_digest: Some("abcd1234".to_string()),
-                relative_remote_path: Some("alpine.raw".to_string()),
+                remote_uri: Some("https://127.0.0.1/alpine.raw".to_string()),
             },
         };
 
         let bootrom_artifact = ArtifactMetadata {
             relative_local_path: "OVMF_CODE.fd".into(),
             expected_digest: None,
-            relative_remote_path: Some("OVMF_CODE.fd".to_string()),
+            remote_uri: Some("https://127.0.0.1/OVMF_CODE.fd".to_string()),
         };
 
         let config = ArtifactStoreConfig {
-            remote_root: Some("https://10.0.0.255".to_string()),
             guest_images: BTreeMap::from([(
                 "alpine".to_string(),
                 guest_artifact,
@@ -394,8 +381,6 @@ mod test {
     #[test]
     fn verify_raw_toml() {
         let raw = r#"
-            remote_root = "https://10.0.0.255"
-
             [guest_images.alpine]
             guest_os_kind = "alpine"
             metadata.relative_local_path = "alpine.raw"

--- a/phd-tests/framework/src/artifacts.rs
+++ b/phd-tests/framework/src/artifacts.rs
@@ -397,5 +397,31 @@ mod test {
 
         let store = ArtifactStoreConfig::from_toml(raw).unwrap();
         println!("Generated store: {:#?}", store);
+
+        let guest_image = store.guest_images.get("alpine").unwrap();
+        assert!(matches!(guest_image.guest_os_kind, GuestOsKind::Alpine));
+        assert_eq!(
+            guest_image.metadata.relative_local_path.to_string_lossy(),
+            "alpine.raw"
+        );
+        assert_eq!(
+            guest_image.metadata.expected_digest.as_ref().unwrap(),
+            "abcd1234"
+        );
+        assert_eq!(
+            guest_image.metadata.remote_uri.as_ref().unwrap(),
+            "https://127.0.0.1/alpine.raw"
+        );
+
+        let bootrom = store.bootroms.get("bootrom").unwrap();
+        assert_eq!(
+            bootrom.relative_local_path.to_string_lossy(),
+            "OVMF_CODE.fd"
+        );
+        assert!(bootrom.expected_digest.is_none());
+        assert_eq!(
+            bootrom.remote_uri.as_ref().unwrap(),
+            "https://127.0.0.1/OVMF_CODE.fd"
+        );
     }
 }

--- a/phd-tests/runner/src/config.rs
+++ b/phd-tests/runner/src/config.rs
@@ -92,7 +92,7 @@ pub struct RunOptions {
 
     /// The default artifact store key to use to load a guest bootrom in tests
     /// that do not explicitly specify one.
-    #[clap(long, value_parser, default_value = "ovmf_20220922")]
+    #[clap(long, value_parser, default_value = "ovmf")]
     pub default_bootrom_artifact: String,
 
     /// Only run tests whose fully-qualified names contain this string.


### PR DESCRIPTION
Move to the latest omicron-zone-package rev to pick up support for including Buildomat artifacts in packages, then use that to include a Buildomat-produced firmware image in Propolis zones. (This PR uses an explicit rev of the packaging tools because a new version of the crate hasn't been cut yet.)

Also update PHD to use this firmware image. PHD previously assumed that all artifacts were available from a single common remote artifact root, but now they aren't (the Alpine image used for testing still lives in S3). Lightly refactor artifact management to remove this restriction.

Tests: PHD; manually examined the `propolis-server.tar.gz` image produced by `propolis-package` and verified that all the files are in the right places.

Fixes #362.