### PR TITLE
Add VMM time data interface to bhyve-api

### DIFF
--- a/crates/bhyve-api/src/lib.rs
+++ b/crates/bhyve-api/src/lib.rs
@@ -258,6 +258,9 @@ unsafe fn ioctl(
 #[repr(u32)]
 #[derive(IntoPrimitive)]
 pub enum ApiVersion {
+    /// Add support for modifing guest time data via vmm-data interface
+    V11 = 11,
+
     /// Interrupt and exception state is properly saved/restored on VM
     /// pause/resume, and is exposed via vmm-data interface
     V10 = 10,
@@ -282,7 +285,7 @@ pub enum ApiVersion {
 }
 impl ApiVersion {
     pub const fn current() -> Self {
-        Self::V10
+        Self::V11
     }
 }
 

--- a/crates/bhyve-api/sys/src/lib.rs
+++ b/crates/bhyve-api/sys/src/lib.rs
@@ -13,4 +13,4 @@ pub const VM_MAXCPU: usize = 32;
 /// This is the VMM interface version which bhyve_api expects to operate
 /// against.  All constants and structs defined by the crate are done so in
 /// terms of that specific version.
-pub const VMM_CURRENT_INTERFACE_VERSION: u32 = 10;
+pub const VMM_CURRENT_INTERFACE_VERSION: u32 = 11;

--- a/crates/bhyve-api/sys/src/vmm_data.rs
+++ b/crates/bhyve-api/sys/src/vmm_data.rs
@@ -21,6 +21,7 @@ pub const VDC_ATPIC: u16 = 9;
 pub const VDC_HPET: u16 = 10;
 pub const VDC_PM_TIMER: u16 = 11;
 pub const VDC_RTC: u16 = 12;
+pub const VDC_VMM_TIME: u16 = 13;
 
 #[repr(C)]
 #[derive(Copy, Clone, Default, Serialize, Deserialize)]
@@ -189,16 +190,23 @@ impl Default for vdi_rtc_v1 {
     }
 }
 
+// VDC_VMM_TIME v1 interface
+
+#[repr(C)]
+#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+pub struct vdi_time_info_v1 {
+    pub vt_guest_freq: u64,
+    pub vt_guest_tsc: u64,
+    pub vt_boot_hrtime: i64,
+    pub vt_hrtime: i64,
+    pub vt_hres_sec: u64,
+    pub vt_hres_ns: u64,
+}
+
 // VDC_VMM_ARCH v1 data identifiers
 
 // VM-wide:
 
-/// Offset of guest TSC from system at time of boot
-pub const VAI_TSC_BOOT_OFFSET: u32 = 1;
-/// Time that guest (nominally) booted, as hrtime
-pub const VAI_BOOT_HRTIME: u32 = 2;
-/// Guest TSC frequency measured by hrtime (not effected by wall clock adj.)
-pub const VAI_TSC_FREQ: u32 = 3;
 /// Guest instance has been placed in paused state
 pub const VAI_VM_IS_PAUSED: u32 = 4;
 

--- a/lib/propolis/src/vmm/hdl.rs
+++ b/lib/propolis/src/vmm/hdl.rs
@@ -505,13 +505,8 @@ pub mod migrate {
         }
 
         pub(super) fn write(self, hdl: &VmmHdl) -> io::Result<()> {
-            let mut arch_entries: Vec<bhyve_api::vdi_field_entry_v1> = self
-                .arch_entries
-                .into_iter()
-                // TODO: Guest TSC frequency is not currently adjustable
-                .filter(|e| e.ident != bhyve_api::VAI_TSC_FREQ)
-                .map(From::from)
-                .collect();
+            let mut arch_entries: Vec<bhyve_api::vdi_field_entry_v1> =
+                self.arch_entries.into_iter().map(From::from).collect();
             vmm::data::write_many(
                 hdl,
                 -1,


### PR DESCRIPTION
Since the illumos side of #337 is merged, add bhyve structs and VMM interface version info for the time data interface.