### PR TITLE
Temporarily disable migration tests in CI

### DIFF
--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -56,13 +56,17 @@ ls $propolis
 
 # Disable errexit so that we still upload logs on failure
 set +e
+
+# TODO: reenable migration tests once all relevant OS changes have landed and
+# been deployed.
 (RUST_BACKTRACE=1 ptime -m pfexec $runner \
 	--emit-bunyan \
 	run \
 	--propolis-server-cmd $propolis \
 	--artifact-toml-path $artifacts \
 	--tmp-directory $tmpdir \
-	--artifact-directory $tmpdir | \
+	--artifact-directory $tmpdir \
+	--exclude-filter migrate | \
 	tee /tmp/phd-runner.log)
 failcount=$?
 set -e


### PR DESCRIPTION
This prevents PHD runs from failing for some in-flight PRs that depend on host OS changes that haven't integrated yet.

These can be reenabled once all the relevant changes have landed and new master images have been deployed to the Buildomat runners.