### PR TITLE
Fix circular reference in async block scheduler

### DIFF
--- a/lib/propolis/src/block/mod.rs
+++ b/lib/propolis/src/block/mod.rs
@@ -793,15 +793,8 @@ impl Inner {
         let _old_ctrl = self.sched_ctrl.lock().unwrap().replace(tctrl);
         assert!(_old_ctrl.is_none(), "driver already attached");
 
-        // This scheduler holds a reference to the block device, so the back
-        // reference from the device's notification closure to the scheduler
-        // needs to be weak.
-        let wake_self = Arc::downgrade(self);
-        bdev.set_notifier(Some(Box::new(move |_bdev| {
-            if let Some(wake_self) = wake_self.upgrade() {
-                wake_self.wake.notify_one()
-            }
-        })));
+        let wake_self = self.wake.clone();
+        bdev.set_notifier(Some(Box::new(move |_bdev| wake_self.notify_one())));
     }
 
     fn with_ctrl(&self, f: impl FnOnce(&mut TaskCtrl)) {


### PR DESCRIPTION
Make the async block scheduler's device-to-scheduler notification closure take a reference to the scheduler's `tokio::sync::notify::Notify` instead of taking a strong reference to the schedule itself. This breaks a circular reference between the scheduler and the device.

Tested by creating a VM with a Crucible disk, stopping it immediately, and verifying that the bhyve VMM goes away immediately as well (instead of disappearing only when the Propolis process exits).

Fixes #380.