### PR TITLE
Bring more formality to device migration state payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,8 +307,6 @@ version = "0.0.0"
 dependencies = [
  "libc",
  "num_enum",
- "serde",
- "serde_arrays",
 ]
 
 [[package]]

--- a/bin/propolis-standalone/src/snapshot.rs
+++ b/bin/propolis-standalone/src/snapshot.rs
@@ -22,8 +22,11 @@ use propolis::{
     chardev::UDSock,
     common::{GuestAddr, GuestRegion},
     inventory::Order,
-    migrate::{MigrateCtx, Migrator},
+    migrate::{
+        MigrateCtx, Migrator, PayloadOffer, PayloadOffers, PayloadOutputs,
+    },
 };
+use serde::{Deserialize, Serialize};
 use slog::{info, warn};
 use tokio::{
     fs::File,
@@ -32,6 +35,18 @@ use tokio::{
 
 use super::config::{Config, SnapshotTag};
 use super::Instance;
+
+#[derive(Deserialize, Serialize)]
+struct SnapshotDevice {
+    pub instance_name: String,
+    pub payload: Vec<SnapshotDevicePayload>,
+}
+#[derive(Deserialize, Serialize)]
+struct SnapshotDevicePayload {
+    pub kind: String,
+    pub version: u32,
+    pub data: Vec<u8>,
+}
 
 /// Save a snapshot of the current state of the given instance to disk.
 pub(crate) async fn save(
@@ -74,17 +89,39 @@ pub(crate) async fn save(
                     rec.name()
                 );
                 }
-                Migrator::Simple => {}
-                Migrator::Custom(migrate) => {
-                    let payload = migrate.export(&migratectx);
-                    device_states.push((
-                        rec.name().to_owned(),
-                        serde_json::to_vec(&payload)?,
-                    ));
+                Migrator::Empty => {}
+                Migrator::Single(mech) => {
+                    let output = mech.export(&migratectx)?;
+                    device_states.push(SnapshotDevice {
+                        instance_name: rec.name().to_owned(),
+                        payload: vec![SnapshotDevicePayload {
+                            kind: output.kind.to_owned(),
+                            version: output.version,
+                            data: serde_json::to_vec(&output.payload)?,
+                        }],
+                    });
+                }
+                Migrator::Multi(mech) => {
+                    let mut outputs = PayloadOutputs::new();
+                    mech.export(&mut outputs, &migratectx)?;
+
+                    let mut payloads = Vec::new();
+                    for part in outputs {
+                        payloads.push(SnapshotDevicePayload {
+                            kind: part.kind.to_owned(),
+                            version: part.version,
+                            data: serde_json::to_vec(&part.payload)?,
+                        });
+                    }
+                    device_states.push(SnapshotDevice {
+                        instance_name: rec.name().to_owned(),
+                        payload: payloads,
+                    });
                 }
             }
             Ok(())
         })?;
+
         serde_json::to_vec(&device_states)?
     };
 
@@ -290,11 +327,12 @@ pub(crate) async fn restore(
     // Finally, let's restore the device state
     let inv = guard.inventory();
     let migratectx = MigrateCtx { mem: &memctx };
-    let devices: Vec<(String, Vec<u8>)> =
+    let devices: Vec<SnapshotDevice> =
         serde_json::from_slice(&device_states)
             .context("Failed to deserialize device state")?;
-    for (name, payload) in devices {
-        let dev_ent = inv.get_by_name(&name).ok_or_else(|| {
+    for snap_dev in devices {
+        let name = snap_dev.instance_name.as_ref();
+        let dev_ent = inv.get_by_name(name).ok_or_else(|| {
             anyhow::anyhow!("unknown device in snapshot {}", name)
         })?;
 
@@ -303,27 +341,77 @@ pub(crate) async fn restore(
                 "can't restore snapshot with non-migratable device ({})",
                 name
             ),
-            Migrator::Simple => {
+            Migrator::Empty => {
                 // There really shouldn't be a payload for this
                 warn!(
                     log,
                     "unexpected device state for device {} in snapshot", name
                 );
             }
-            Migrator::Custom(migrate) => {
-                let mut deserializer =
-                    serde_json::Deserializer::from_slice(&payload);
-                let deserializer = &mut <dyn erased_serde::Deserializer>::erase(
-                    &mut deserializer,
-                );
-                migrate
-                    .import(dev_ent.type_name(), deserializer, &migratectx)
-                    .with_context(|| {
-                        anyhow::anyhow!(
-                            "Failed to restore device state for {}",
-                            name
-                        )
-                    })?;
+            Migrator::Single(mech) => {
+                if snap_dev.payload.len() != 1 {
+                    anyhow::bail!(
+                        "Unexpected payload count {}",
+                        snap_dev.payload.len()
+                    );
+                }
+                let payload = &snap_dev.payload[0];
+                let mut deser_data =
+                    serde_json::Deserializer::from_slice(&payload.data);
+
+                let offer = PayloadOffer {
+                    kind: &payload.kind,
+                    version: payload.version,
+                    payload: Box::new(<dyn erased_serde::Deserializer>::erase(
+                        &mut deser_data,
+                    )),
+                };
+                mech.import(offer, &migratectx).with_context(|| {
+                    anyhow::anyhow!(
+                        "Failed to restore device state for {}",
+                        name
+                    )
+                })?;
+            }
+            Migrator::Multi(mech) => {
+                let mut payload_desers: Vec<
+                    serde_json::Deserializer<serde_json::de::SliceRead>,
+                > = Vec::with_capacity(snap_dev.payload.len());
+                let mut metadata: Vec<(&str, u32)> =
+                    Vec::with_capacity(snap_dev.payload.len());
+                for payload in snap_dev.payload.iter() {
+                    payload_desers.push(serde_json::Deserializer::from_slice(
+                        &payload.data,
+                    ));
+                    metadata.push((&payload.kind, payload.version));
+                }
+                let offer_iter = metadata
+                    .iter()
+                    .zip(payload_desers.iter_mut())
+                    .map(|(meta, deser)| PayloadOffer {
+                        kind: meta.0,
+                        version: meta.1,
+                        payload: Box::new(
+                            <dyn erased_serde::Deserializer>::erase(deser),
+                        ),
+                    });
+
+                let mut offer = PayloadOffers::new(offer_iter);
+                mech.import(&mut offer, &migratectx).with_context(|| {
+                    anyhow::anyhow!(
+                        "Failed to restore device state for {}",
+                        name
+                    )
+                })?;
+
+                let remain = offer.remaining().count();
+                if remain > 0 {
+                    return Err(anyhow::anyhow!(
+                        "Device {} had {} remaining payload(s)",
+                        name,
+                        remain
+                    ));
+                }
             }
         }
     }

--- a/crates/bhyve-api/sys/Cargo.toml
+++ b/crates/bhyve-api/sys/Cargo.toml
@@ -9,5 +9,3 @@ edition = "2021"
 [dependencies]
 libc.workspace = true
 num_enum.workspace = true
-serde = { workspace = true, features = ["derive"] }
-serde_arrays = { workspace = true }

--- a/crates/bhyve-api/sys/src/vmm_data.rs
+++ b/crates/bhyve-api/sys/src/vmm_data.rs
@@ -1,8 +1,6 @@
 #![allow(non_camel_case_types)]
 // VMM Data Classes
 
-use serde::{Deserialize, Serialize};
-
 pub const VDC_VERSION: u16 = 1;
 
 // Classes bearing per-vCPU data
@@ -24,7 +22,7 @@ pub const VDC_RTC: u16 = 12;
 pub const VDC_VMM_TIME: u16 = 13;
 
 #[repr(C)]
-#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default)]
 pub struct vdi_version_entry_v1 {
     pub vve_class: u16,
     pub vve_version: u16,
@@ -33,7 +31,7 @@ pub struct vdi_version_entry_v1 {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default)]
 pub struct vdi_field_entry_v1 {
     pub vfe_ident: u32,
     pub _pad: u32,
@@ -41,7 +39,7 @@ pub struct vdi_field_entry_v1 {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default)]
 pub struct vdi_lapic_page_v1 {
     pub vlp_id: u32,
     pub vlp_version: u32,
@@ -67,7 +65,7 @@ pub struct vdi_lapic_page_v1 {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default)]
 pub struct vdi_lapic_v1 {
     pub vl_lapic: vdi_lapic_page_v1,
     pub vl_msr_apicbase: u64,
@@ -76,7 +74,7 @@ pub struct vdi_lapic_v1 {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default)]
 pub struct vdi_ioapic_v1 {
     pub vi_pin_reg: [u64; 32],
     pub vi_pin_level: [u32; 32],
@@ -85,7 +83,7 @@ pub struct vdi_ioapic_v1 {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default)]
 pub struct vdi_atpit_channel_v1 {
     pub vac_initial: u16,
     pub vac_reg_cr: u16,
@@ -105,13 +103,13 @@ pub struct vdi_atpit_channel_v1 {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default)]
 pub struct vdi_atpit_v1 {
     pub va_channel: [vdi_atpit_channel_v1; 3],
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default)]
 pub struct vdi_atpic_chip_v1 {
     pub vac_icw_state: u8,
 
@@ -135,13 +133,13 @@ pub struct vdi_atpic_chip_v1 {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default)]
 pub struct vdi_atpic_v1 {
     pub va_chip: [vdi_atpic_chip_v1; 2],
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default)]
 pub struct vdi_hpet_timer_v1 {
     pub vht_config: u64,
     pub vht_msi: u64,
@@ -151,7 +149,7 @@ pub struct vdi_hpet_timer_v1 {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default)]
 pub struct vdi_hpet_v1 {
     pub vh_config: u64,
     pub vh_isr: u64,
@@ -162,16 +160,15 @@ pub struct vdi_hpet_v1 {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default)]
 pub struct vdi_pm_timer_v1 {
     pub vpt_time_base: i64,
     pub vpt_ioport: u16,
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Serialize, Deserialize)]
+#[derive(Copy, Clone)]
 pub struct vdi_rtc_v1 {
-    #[serde(with = "serde_arrays")]
     pub vr_content: [u8; 128],
     pub vr_addr: u8,
     pub vr_time_base: i64,
@@ -193,7 +190,7 @@ impl Default for vdi_rtc_v1 {
 // VDC_VMM_TIME v1 interface
 
 #[repr(C)]
-#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default)]
 pub struct vdi_time_info_v1 {
     pub vt_guest_freq: u64,
     pub vt_guest_tsc: u64,

--- a/lib/propolis/src/hw/bhyve/atpic.rs
+++ b/lib/propolis/src/hw/bhyve/atpic.rs
@@ -25,7 +25,7 @@ impl Entity for BhyveAtPic {
 }
 impl Migrate for BhyveAtPic {
     fn export(&self, _ctx: &MigrateCtx) -> Box<dyn Serialize> {
-        Box::new(migrate::BhyveAtPicV1::read(&self.hdl))
+        Box::new(migrate::AtPicV1::read(&self.hdl).unwrap())
     }
 
     fn import(
@@ -34,7 +34,7 @@ impl Migrate for BhyveAtPic {
         deserializer: &mut dyn erased_serde::Deserializer,
         _ctx: &MigrateCtx,
     ) -> Result<(), MigrateStateError> {
-        let deserialized: migrate::BhyveAtPicV1 =
+        let deserialized: migrate::AtPicV1 =
             erased_serde::deserialize(deserializer)?;
         deserialized.write(&self.hdl)?;
         Ok(())
@@ -47,21 +47,75 @@ pub mod migrate {
     use serde::{Deserialize, Serialize};
 
     #[derive(Copy, Clone, Default, Deserialize, Serialize)]
-    pub struct BhyveAtPicV1 {
-        /// XXX: do not expose vdi struct
-        pub data: bhyve_api::vdi_atpic_v1,
+    pub struct AtPicV1 {
+        pub chips: [AtPicChipV1; 2],
+    }
+    #[derive(Copy, Clone, Default, Deserialize, Serialize)]
+    pub struct AtPicChipV1 {
+        pub icw_state: u8,
+        pub status: u8,
+        pub reg_irr: u8,
+        pub reg_isr: u8,
+        pub reg_imr: u8,
+        pub irq_base: u8,
+        pub lowprio: u8,
+        pub elc: u8,
+        pub level: [u32; 8],
+    }
+    impl AtPicV1 {
+        fn from_raw(inp: &bhyve_api::vdi_atpic_v1) -> Self {
+            Self {
+                chips: [
+                    AtPicChipV1::from_raw(&inp.va_chip[0]),
+                    AtPicChipV1::from_raw(&inp.va_chip[1]),
+                ],
+            }
+        }
+        fn to_raw(&self) -> bhyve_api::vdi_atpic_v1 {
+            bhyve_api::vdi_atpic_v1 {
+                va_chip: [self.chips[0].to_raw(), self.chips[1].to_raw()],
+            }
+        }
+    }
+    impl AtPicChipV1 {
+        fn from_raw(inp: &bhyve_api::vdi_atpic_chip_v1) -> Self {
+            Self {
+                icw_state: inp.vac_icw_state,
+                status: inp.vac_status,
+                reg_irr: inp.vac_reg_irr,
+                reg_isr: inp.vac_reg_isr,
+                reg_imr: inp.vac_reg_imr,
+                irq_base: inp.vac_irq_base,
+                lowprio: inp.vac_lowprio,
+                elc: inp.vac_elc,
+                level: inp.vac_level,
+            }
+        }
+        fn to_raw(&self) -> bhyve_api::vdi_atpic_chip_v1 {
+            bhyve_api::vdi_atpic_chip_v1 {
+                vac_icw_state: self.icw_state,
+                vac_status: self.status,
+                vac_reg_irr: self.reg_irr,
+                vac_reg_isr: self.reg_isr,
+                vac_reg_imr: self.reg_imr,
+                vac_irq_base: self.irq_base,
+                vac_lowprio: self.lowprio,
+                vac_elc: self.elc,
+                vac_level: self.level,
+            }
+        }
     }
 
-    impl BhyveAtPicV1 {
-        pub(super) fn read(hdl: &vmm::VmmHdl) -> Self {
-            Self {
-                data: vmm::data::read(hdl, -1, bhyve_api::VDC_ATPIC, 1)
-                    .unwrap(),
-            }
+    impl AtPicV1 {
+        pub(super) fn read(hdl: &vmm::VmmHdl) -> std::io::Result<Self> {
+            let vdi: bhyve_api::vdi_atpic_v1 =
+                vmm::data::read(hdl, -1, bhyve_api::VDC_ATPIC, 1)?;
+
+            Ok(Self::from_raw(&vdi))
         }
 
         pub(super) fn write(self, hdl: &vmm::VmmHdl) -> std::io::Result<()> {
-            vmm::data::write(hdl, -1, bhyve_api::VDC_ATPIC, 1, self.data)?;
+            vmm::data::write(hdl, -1, bhyve_api::VDC_ATPIC, 1, self.to_raw())?;
             Ok(())
         }
     }

--- a/lib/propolis/src/hw/bhyve/atpic.rs
+++ b/lib/propolis/src/hw/bhyve/atpic.rs
@@ -4,8 +4,6 @@ use crate::inventory::Entity;
 use crate::migrate::*;
 use crate::vmm::VmmHdl;
 
-use erased_serde::Serialize;
-
 pub struct BhyveAtPic {
     hdl: Arc<VmmHdl>,
 }
@@ -20,28 +18,29 @@ impl Entity for BhyveAtPic {
         "lpc-bhyve-atpic"
     }
     fn migrate(&self) -> Migrator {
-        Migrator::Custom(self)
+        Migrator::Single(self)
     }
 }
-impl Migrate for BhyveAtPic {
-    fn export(&self, _ctx: &MigrateCtx) -> Box<dyn Serialize> {
-        Box::new(migrate::AtPicV1::read(&self.hdl).unwrap())
+impl MigrateSingle for BhyveAtPic {
+    fn export(
+        &self,
+        _ctx: &MigrateCtx,
+    ) -> Result<PayloadOutput, MigrateStateError> {
+        Ok(migrate::AtPicV1::read(&self.hdl)?.emit())
     }
 
     fn import(
         &self,
-        _dev: &str,
-        deserializer: &mut dyn erased_serde::Deserializer,
+        mut offer: PayloadOffer,
         _ctx: &MigrateCtx,
     ) -> Result<(), MigrateStateError> {
-        let deserialized: migrate::AtPicV1 =
-            erased_serde::deserialize(deserializer)?;
-        deserialized.write(&self.hdl)?;
+        offer.parse::<migrate::AtPicV1>()?.write(&self.hdl)?;
         Ok(())
     }
 }
 
 pub mod migrate {
+    use crate::migrate::*;
     use crate::vmm;
 
     use serde::{Deserialize, Serialize};
@@ -117,6 +116,11 @@ pub mod migrate {
         pub(super) fn write(self, hdl: &vmm::VmmHdl) -> std::io::Result<()> {
             vmm::data::write(hdl, -1, bhyve_api::VDC_ATPIC, 1, self.to_raw())?;
             Ok(())
+        }
+    }
+    impl Schema<'_> for AtPicV1 {
+        fn id() -> SchemaId {
+            ("bhyve-atpic", 1)
         }
     }
 }

--- a/lib/propolis/src/hw/bhyve/atpit.rs
+++ b/lib/propolis/src/hw/bhyve/atpit.rs
@@ -25,7 +25,7 @@ impl Entity for BhyveAtPit {
 }
 impl Migrate for BhyveAtPit {
     fn export(&self, _ctx: &MigrateCtx) -> Box<dyn Serialize> {
-        Box::new(migrate::BhyveAtPitV1::read(&self.hdl))
+        Box::new(migrate::AtPitV1::read(&self.hdl).unwrap())
     }
 
     fn import(
@@ -34,7 +34,7 @@ impl Migrate for BhyveAtPit {
         deserializer: &mut dyn erased_serde::Deserializer,
         _ctx: &MigrateCtx,
     ) -> Result<(), MigrateStateError> {
-        let deserialized: migrate::BhyveAtPitV1 =
+        let deserialized: migrate::AtPitV1 =
             erased_serde::deserialize(deserializer)?;
         deserialized.write(&self.hdl)?;
         Ok(())
@@ -47,22 +47,73 @@ pub mod migrate {
     use serde::{Deserialize, Serialize};
 
     #[derive(Copy, Clone, Default, Deserialize, Serialize)]
-    pub struct BhyveAtPitV1 {
-        /// XXX: do not expose vdi struct
-        pub data: bhyve_api::vdi_atpit_v1,
+    pub struct AtPitV1 {
+        pub channel: [AtPitChannelV1; 3],
     }
 
-    impl BhyveAtPitV1 {
-        pub(super) fn read(hdl: &vmm::VmmHdl) -> Self {
+    #[derive(Copy, Clone, Default, Serialize, Deserialize)]
+    pub struct AtPitChannelV1 {
+        pub initial: u16,
+        pub reg_cr: u16,
+        pub reg_ol: u16,
+        pub reg_status: u8,
+        pub mode: u8,
+        pub status: u8,
+        pub time_target: i64,
+    }
+    impl AtPitV1 {
+        fn from_raw(inp: &bhyve_api::vdi_atpit_v1) -> Self {
             Self {
-                data: vmm::data::read(hdl, -1, bhyve_api::VDC_ATPIT, 1)
-                    .unwrap(),
+                channel: [
+                    AtPitChannelV1::from_raw(&inp.va_channel[0]),
+                    AtPitChannelV1::from_raw(&inp.va_channel[1]),
+                    AtPitChannelV1::from_raw(&inp.va_channel[2]),
+                ],
             }
+        }
+        fn to_raw(&self) -> bhyve_api::vdi_atpit_v1 {
+            bhyve_api::vdi_atpit_v1 {
+                va_channel: [
+                    self.channel[0].to_raw(),
+                    self.channel[1].to_raw(),
+                    self.channel[2].to_raw(),
+                ],
+            }
+        }
+        pub(super) fn read(hdl: &vmm::VmmHdl) -> std::io::Result<Self> {
+            let vdi: bhyve_api::vdi_atpit_v1 =
+                vmm::data::read(hdl, -1, bhyve_api::VDC_ATPIT, 1)?;
+
+            Ok(Self::from_raw(&vdi))
         }
 
         pub(super) fn write(self, hdl: &vmm::VmmHdl) -> std::io::Result<()> {
-            vmm::data::write(hdl, -1, bhyve_api::VDC_ATPIT, 1, self.data)?;
+            vmm::data::write(hdl, -1, bhyve_api::VDC_ATPIT, 1, self.to_raw())?;
             Ok(())
+        }
+    }
+    impl AtPitChannelV1 {
+        fn from_raw(inp: &bhyve_api::vdi_atpit_channel_v1) -> Self {
+            Self {
+                initial: inp.vac_initial,
+                reg_cr: inp.vac_reg_cr,
+                reg_ol: inp.vac_reg_ol,
+                reg_status: inp.vac_reg_status,
+                mode: inp.vac_mode,
+                status: inp.vac_status,
+                time_target: inp.vac_time_target,
+            }
+        }
+        fn to_raw(&self) -> bhyve_api::vdi_atpit_channel_v1 {
+            bhyve_api::vdi_atpit_channel_v1 {
+                vac_initial: self.initial,
+                vac_reg_cr: self.reg_cr,
+                vac_reg_ol: self.reg_ol,
+                vac_reg_status: self.reg_status,
+                vac_mode: self.mode,
+                vac_status: self.status,
+                vac_time_target: self.time_target,
+            }
         }
     }
 }

--- a/lib/propolis/src/inventory.rs
+++ b/lib/propolis/src/inventory.rs
@@ -599,7 +599,7 @@ pub trait Entity: Send + Sync + 'static {
     /// methods. A device which shouldn't be migrated should instead
     /// override this method and explicity return `Migrator::NonMigratable`.
     fn migrate(&'_ self) -> Migrator<'_> {
-        Migrator::Simple
+        Migrator::Empty
     }
 }
 

--- a/lib/propolis/src/migrate.rs
+++ b/lib/propolis/src/migrate.rs
@@ -1,39 +1,39 @@
 use crate::vmm::MemCtx;
 
-use erased_serde::{Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Errors encountered while trying to export/import device state.
-#[derive(
-    Clone, Debug, Error, serde::Deserialize, PartialEq, serde::Serialize,
-)]
+#[derive(Debug, Error)]
 pub enum MigrateStateError {
     /// The device doesn't support live migration.
     #[error("device not migratable")]
     NonMigratable,
 
-    /// Encountered an error trying to deserialize the device state during import.
-    #[error("couldn't deserialize device state: {0}")]
-    ImportDeserialization(String),
+    /// I/O Error encounted while performing import/export
+    #[error("IO Error")]
+    Io(#[from] std::io::Error),
 
-    /// The device doesn't implement [`Migrate::import`].
-    #[error("device state importation unimplemented for `{0}`")]
-    ImportUnimplmented(String),
+    /// Encountered an error trying to deserialize the device state during import.
+    #[error("could not deserialize device state: {0}")]
+    DeserializationFailed(String),
 
     /// The device failed to import the deserialized device state.
     #[error("failed to apply deserialized device state: {0}")]
     ImportFailed(String),
+
+    /// State of kind/version suitable for import not found
+    #[error("failed to find suitable import payload")]
+    DataMissing,
+
+    /// The kind and/or version of payload was not expected
+    #[error("kind/version of payload not expected: {0} v{1}")]
+    UnexpectedPayload(String, u32),
 }
 
 impl From<erased_serde::Error> for MigrateStateError {
     fn from(err: erased_serde::Error) -> Self {
-        MigrateStateError::ImportDeserialization(err.to_string())
-    }
-}
-
-impl From<std::io::Error> for MigrateStateError {
-    fn from(err: std::io::Error) -> Self {
-        MigrateStateError::ImportFailed(err.to_string())
+        MigrateStateError::DeserializationFailed(err.to_string())
     }
 }
 
@@ -43,28 +43,207 @@ pub enum Migrator<'a> {
     NonMigratable,
 
     /// No device specific logic is needed
-    Simple,
+    Empty,
 
-    /// Device specific logic used to export/import device state
-    Custom(&'a dyn Migrate),
+    /// Migration state for the device consists of a single payload.
+    ///
+    /// The device may be capable of handing differing formats and/or versions
+    /// of said payload, but only one at a time is expected for a given device
+    /// during migration.
+    Single(&'a dyn MigrateSingle),
+
+    /// Migration state for the device consists of multiple payloads.  This is
+    /// the case for more complex devices where emulation is composed from
+    /// several abstractions.
+    ///
+    /// One example would be pci-virtio-block, where one payload contains to the
+    /// emulated PCI state, while another contains the virtio state (virtqueues,
+    /// etc).
+    Multi(&'a dyn MigrateMulti),
 }
 
+/// A device which can be migrated using a single typed payload to represent its
+/// internal state.
+pub trait MigrateSingle: Send + Sync + 'static {
+    fn export(
+        &self,
+        ctx: &MigrateCtx,
+    ) -> Result<PayloadOutput, MigrateStateError>;
+    fn import(
+        &self,
+        offer: PayloadOffer,
+        ctx: &MigrateCtx,
+    ) -> Result<(), MigrateStateError>;
+}
+
+/// A device which can be migrated using multiple differently-typed payloads to
+/// represent its internal state.
+pub trait MigrateMulti: Send + Sync {
+    fn export(
+        &self,
+        output: &mut PayloadOutputs,
+        ctx: &MigrateCtx,
+    ) -> Result<(), MigrateStateError>;
+    fn import(
+        &self,
+        offer: &mut PayloadOffers,
+        ctx: &MigrateCtx,
+    ) -> Result<(), MigrateStateError>;
+}
+
+/// Additional (borrowed) context data used during device import and export.
 pub struct MigrateCtx<'a> {
     pub mem: &'a MemCtx,
 }
 
-pub trait Migrate: Send + Sync + 'static {
-    /// Return a serialization of the current device state.
-    fn export(&self, ctx: &MigrateCtx) -> Box<dyn Serialize>;
+/// Device state payload (of a given kind/version) offered to the import logic
+/// for that device during a migration.
+pub struct PayloadOffer<'a> {
+    pub kind: &'a str,
+    pub version: u32,
+    pub payload: Box<dyn erased_serde::Deserializer<'a> + 'a>,
+}
+impl<'a> PayloadOffer<'a> {
+    /// Attempt to parse the data in this payload if the offer matches the
+    /// kind/version of a specified Schema
+    pub fn parse<T: Schema<'a>>(&mut self) -> Result<T, MigrateStateError> {
+        if !T::matches(self.kind, self.version) {
+            return Err(MigrateStateError::UnexpectedPayload(
+                self.kind.into(),
+                self.version,
+            ));
+        }
+        let res = erased_serde::deserialize(&mut self.payload)?;
+        Ok(res)
+    }
+}
 
-    #[allow(unused_variables)]
-    /// Update the current device state by using the given deserializer.
-    fn import(
-        &self,
-        dev: &str,
-        deserializer: &mut dyn Deserializer,
-        ctx: &MigrateCtx,
+/// Collection of [`PayloadOffer`] instances, as provided to device state import
+/// logic during a migration.
+pub struct PayloadOffers<'a>(Vec<PayloadOffer<'a>>);
+impl<'a> PayloadOffers<'a> {
+    /// Create new [`PayloadOffers`] from iterator of [`PayloadOffer`]
+    /// instances.
+    pub fn new(items: impl IntoIterator<Item = PayloadOffer<'a>>) -> Self {
+        Self(Vec::from_iter(items))
+    }
+
+    /// Attempt to take a payload from the contained offers, provided that it
+    /// matches the specified [`Schema`](trait@Schema).
+    pub fn take<T: Schema<'a>>(&mut self) -> Result<T, MigrateStateError> {
+        self.take_schema(T::id())
+            .ok_or_else(|| MigrateStateError::DataMissing)?
+            .parse()
+    }
+
+    /// Returns `true` if all of the payload offers been consumed via
+    /// [`Self::take()`].
+    pub fn is_consumed(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Return the remaining PayloadOffer instances which have not been
+    /// consumed.
+    ///
+    /// Intended for use by the logic driving the migration itself to determine
+    /// if a given device importation failed to consume all of its payload(s).
+    pub fn remaining(self) -> Remaining<'a> {
+        Remaining(self.0.into_iter())
+    }
+
+    fn take_schema(&mut self, id: SchemaId) -> Option<PayloadOffer<'a>> {
+        let mut search = self.0.iter().enumerate().filter(|(_idx, offer)| {
+            offer.kind == id.0 && offer.version == id.1
+        });
+
+        // Success if we find one, and only one, matching the criteria
+        if let (Some((idx, _offer)), None) = (search.next(), search.next()) {
+            return Some(self.0.remove(idx));
+        }
+
+        None
+    }
+}
+
+pub struct Remaining<'a>(std::vec::IntoIter<PayloadOffer<'a>>);
+impl<'a> Iterator for Remaining<'a> {
+    type Item = PayloadOffer<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+/// Device state payload (of a given kind/version) output as part of the export
+/// logic for that device during a migration.
+///
+/// Easiest to safely instantiate via [`Schema::emit`] to ensure that the
+/// kind/version matches the serialized payload.
+pub struct PayloadOutput {
+    pub kind: &'static str,
+    pub version: u32,
+    pub payload: Box<dyn erased_serde::Serialize>,
+}
+
+pub struct PayloadOutputs(Vec<PayloadOutput>);
+impl PayloadOutputs {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Add a provided [`PayloadOutput`] to be included in the payload(s) for a
+    /// given exported device
+    pub fn push(
+        &mut self,
+        output: PayloadOutput,
     ) -> Result<(), MigrateStateError> {
-        Err(MigrateStateError::ImportUnimplmented(dev.to_string()))
+        self.0.push(output);
+        Ok(())
+    }
+}
+impl IntoIterator for PayloadOutputs {
+    type Item = PayloadOutput;
+
+    type IntoIter = OutputIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        OutputIter(self.0.into_iter())
+    }
+}
+// Hide the internal implementation details of PayloadOutputs by providing a
+// wrapper type for its output iterator.
+pub struct OutputIter(std::vec::IntoIter<PayloadOutput>);
+impl Iterator for OutputIter {
+    type Item = PayloadOutput;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+/// Combination of kind (`&str`) and version (u32) which identifies a specific
+/// data schema for device migration state.
+pub type SchemaId = (&'static str, u32);
+
+/// Define the type (kind) and version for a migration payload data structure.
+pub trait Schema<'de>: Serialize + Deserialize<'de> + Sized + 'static {
+    /// The [`SchemaId`] associated with a given device state data type.
+    ///
+    /// This would be `const` if such functions were allowed in traits without
+    /// an unstable rust feature.
+    fn id() -> SchemaId;
+
+    /// Returns `true` if theprovided `kind` and `version` match those defined
+    /// for this Schema.
+    fn matches(kind: &str, version: u32) -> bool {
+        let id = Self::id();
+        id.0 == kind && id.1 == version
+    }
+
+    /// Emit a [`PayloadOutput`] with the `kind` and `version` set appropriately
+    /// for this Schema.
+    fn emit(self) -> PayloadOutput {
+        let id = Self::id();
+        PayloadOutput { kind: id.0, version: id.1, payload: Box::new(self) }
     }
 }

--- a/lib/propolis/src/vcpu.rs
+++ b/lib/propolis/src/vcpu.rs
@@ -11,8 +11,6 @@ use crate::pio::PioBus;
 use crate::tasks;
 use crate::vmm::VmmHdl;
 
-use erased_serde::Serialize;
-
 /// A handle to a virtual CPU.
 pub struct Vcpu {
     hdl: Arc<VmmHdl>,
@@ -227,27 +225,27 @@ impl Entity for Vcpu {
         "bhyve-vcpu"
     }
     fn migrate(&self) -> Migrator {
-        Migrator::Custom(self)
+        Migrator::Single(self)
     }
 
     // The consumer is expected to handle run/pause/halt events directly, since
     // the vCPUs are mostly likely to be driven in manner separate from the
     // other emulated devices.
 }
-impl Migrate for Vcpu {
-    fn export(&self, _ctx: &MigrateCtx) -> Box<dyn Serialize> {
-        Box::new(migrate::BhyveVcpuV1::read(self))
+impl MigrateSingle for Vcpu {
+    fn export(
+        &self,
+        _ctx: &MigrateCtx,
+    ) -> std::result::Result<PayloadOutput, MigrateStateError> {
+        Ok(migrate::BhyveX86CpuV1::read(self)?.emit())
     }
 
     fn import(
         &self,
-        _dev: &str,
-        deserializer: &mut dyn erased_serde::Deserializer,
+        mut offer: PayloadOffer,
         _ctx: &MigrateCtx,
     ) -> std::result::Result<(), MigrateStateError> {
-        let deserialized: migrate::BhyveVcpuV1 =
-            erased_serde::deserialize(deserializer)?;
-        deserialized.write(self)?;
+        offer.parse::<migrate::BhyveX86CpuV1>()?.write(self)?;
         Ok(())
     }
 }
@@ -256,20 +254,26 @@ pub mod migrate {
     use std::{convert::TryInto, io};
 
     use super::Vcpu;
+    use crate::migrate::*;
     use crate::vmm;
 
     use bhyve_api::{vdi_field_entry_v1, vm_reg_name};
     use serde::{Deserialize, Serialize};
 
     #[derive(Clone, Default, Deserialize, Serialize)]
-    pub struct BhyveVcpuV1 {
-        run_state: BhyveVcpuRunStateV1,
-        gp_regs: GpRegsV1,
-        ctrl_regs: CtrlRegsV1,
-        seg_regs: SegRegsV1,
-        fpu_state: FpuStateV1,
-        lapic: LapicV1,
-        ms_regs: Vec<MsrEntryV1>,
+    pub struct BhyveX86CpuV1 {
+        pub run_state: BhyveVcpuRunStateV1,
+        pub gp_regs: GpRegsV1,
+        pub ctrl_regs: CtrlRegsV1,
+        pub seg_regs: SegRegsV1,
+        pub fpu_state: FpuStateV1,
+        pub lapic: LapicV1,
+        pub ms_regs: Vec<MsrEntryV1>,
+    }
+    impl Schema<'_> for BhyveX86CpuV1 {
+        fn id() -> SchemaId {
+            ("bhyve-x86-cpu", 1)
+        }
     }
 
     #[derive(Clone, Default, Deserialize, Serialize)]
@@ -812,22 +816,21 @@ pub mod migrate {
         }
     }
 
-    impl BhyveVcpuV1 {
-        pub(super) fn read(vcpu: &Vcpu) -> Self {
+    impl BhyveX86CpuV1 {
+        pub(super) fn read(vcpu: &Vcpu) -> io::Result<Self> {
             let hdl = &vcpu.hdl;
             let msrs: Vec<bhyve_api::vdi_field_entry_v1> =
-                vmm::data::read_many(hdl, vcpu.id, bhyve_api::VDC_MSR, 1)
-                    .unwrap();
+                vmm::data::read_many(hdl, vcpu.id, bhyve_api::VDC_MSR, 1)?;
             let res = Self {
-                run_state: BhyveVcpuRunStateV1::read(vcpu).unwrap(),
-                gp_regs: GpRegsV1::read(vcpu).unwrap(),
-                ctrl_regs: CtrlRegsV1::read(vcpu).unwrap(),
-                seg_regs: SegRegsV1::read(vcpu).unwrap(),
-                fpu_state: FpuStateV1::read(vcpu).unwrap(),
-                lapic: LapicV1::read(vcpu).unwrap(),
+                run_state: BhyveVcpuRunStateV1::read(vcpu)?,
+                gp_regs: GpRegsV1::read(vcpu)?,
+                ctrl_regs: CtrlRegsV1::read(vcpu)?,
+                seg_regs: SegRegsV1::read(vcpu)?,
+                fpu_state: FpuStateV1::read(vcpu)?,
+                lapic: LapicV1::read(vcpu)?,
                 ms_regs: msrs.into_iter().map(MsrEntryV1::from).collect(),
             };
-            res
+            Ok(res)
         }
 
         pub(super) fn write(self, vcpu: &Vcpu) -> io::Result<()> {


### PR DESCRIPTION
This adds explicit payload type (kind) and version information when device state is imported/exported as part of a migration.  Furthermore, it allows the payload for a given device to be made up of multiple components (bearing said type/version tagging) so that devices which share similar state (such as the PCI state) can rely on the underlying component to deal with how to handle import/export.

There is certainly more polishing and extension of the mechanisms to be done, at least internally, but it'd be nice to get past the flag day for the payload expectations in the migration protocol for now.