### PR TITLE
migration: reduce page transfers during pause

### DIFF
--- a/bin/propolis-server/src/lib/migrate/destination.rs
+++ b/bin/propolis-server/src/lib/migrate/destination.rs
@@ -168,10 +168,14 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> DestinationProtocol<T> {
         &mut self,
         phase: &MigratePhase,
     ) -> Result<(), MigrateError> {
-        // Move to the RamPush state only when receiving memory for the first
-        // time.
-        if matches!(phase, MigratePhase::RamPushPrePause) {
-            self.update_state(MigrationState::RamPush).await;
+        match phase {
+            MigratePhase::RamPushPrePause => {
+                self.update_state(MigrationState::RamPush).await
+            }
+            MigratePhase::RamPushPostPause => {
+                self.update_state(MigrationState::RamPushDirty).await
+            }
+            _ => unreachable!("should only push RAM in a RAM push phase"),
         }
 
         let (dirty, highest) = self.query_ram().await?;

--- a/bin/propolis-server/src/lib/migrate/mod.rs
+++ b/bin/propolis-server/src/lib/migrate/mod.rs
@@ -405,5 +405,6 @@ impl<'a> Iterator for PageIter<'a> {
 mod probes {
     fn migrate_phase_begin(step_desc: &str) {}
     fn migrate_phase_end(step_desc: &str) {}
-    fn migrate_xfer_ram_page(addr: u64, size: u64, paused: u8) {}
+    fn migrate_xfer_ram_region(pages: u64, size: u64, paused: u8) {}
+    fn migrate_xfer_ram_page(addr: u64, size: u64) {}
 }

--- a/bin/propolis-server/src/lib/migrate/mod.rs
+++ b/bin/propolis-server/src/lib/migrate/mod.rs
@@ -57,6 +57,7 @@ pub enum MigrateRole {
     Destination,
 }
 
+// N.B. Keep in sync with scripts/live-migration-times.d.
 #[derive(Debug)]
 enum MigratePhase {
     MigrateSync,
@@ -404,5 +405,5 @@ impl<'a> Iterator for PageIter<'a> {
 mod probes {
     fn migrate_phase_begin(step_desc: &str) {}
     fn migrate_phase_end(step_desc: &str) {}
-    fn migrate_xfer_ram_page(addr: u64, size: u64) {}
+    fn migrate_xfer_ram_page(addr: u64, size: u64, paused: u8) {}
 }

--- a/bin/propolis-server/src/lib/migrate/mod.rs
+++ b/bin/propolis-server/src/lib/migrate/mod.rs
@@ -57,10 +57,12 @@ pub enum MigrateRole {
     Destination,
 }
 
+#[derive(Debug)]
 enum MigratePhase {
     MigrateSync,
     Pause,
-    RamPush,
+    RamPushPrePause,
+    RamPushPostPause,
     DeviceState,
     RamPull,
     ServerState,
@@ -72,7 +74,8 @@ impl std::fmt::Display for MigratePhase {
         let s = match self {
             MigratePhase::MigrateSync => "Sync",
             MigratePhase::Pause => "Pause",
-            MigratePhase::RamPush => "RamPush",
+            MigratePhase::RamPushPrePause => "RamPushPrePause",
+            MigratePhase::RamPushPostPause => "RamPushPostPause",
             MigratePhase::DeviceState => "DeviceState",
             MigratePhase::RamPull => "RamPull",
             MigratePhase::ServerState => "ServerState",

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -168,9 +168,9 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SourceProtocol<T> {
             vmm_ram_range
         );
 
-        // TODO: Ideally, both the pre-pause and post-pause phases would offer
-        // just dirty pages. To do this safely, the source must remember all
-        // the pages it has ever offered to any target so that they can be
+        // TODO(#387): Ideally, both the pre-pause and post-pause phases would
+        // offer just dirty pages. To do this safely, the source must remember
+        // all the pages it has ever offered to any target so that they can be
         // re-offered if migration fails and is later retried.
         //
         // Offering all pages before pausing guarantees that all modified pages

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -243,9 +243,9 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SourceProtocol<T> {
 
         let step = bits.len() * 8 * 4096;
         for gpa in (start_gpa..end_gpa).step_by(step) {
-            // Call bhyve to get the dirty page mask irrespective of the offer
-            // discipline. This ensures that any pages that are dirty at this
-            // point will be marked clean when this call returns.
+            // Always capture the dirty page mask even if the offer discipline
+            // says to offer all pages. This ensures that pages that are
+            // transferred now and not touched again will not be offered again.
             self.track_dirty(GuestAddr(gpa), &mut bits).await?;
             match offer_discipline {
                 RamOfferDiscipline::OfferAll => {

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -416,7 +416,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SourceProtocol<T> {
         // VM to resume, which is forbidden at this point (see above).
         let vmm_range = self.vmm_ram_bounds().await.unwrap();
         let mut bits = [0u8; 4096];
-        let step = bits.len() * 8 * 4096;
+        let step = bits.len() * 8 * PAGE_SIZE;
         for gpa in (vmm_range.start().0..vmm_range.end().0).step_by(step) {
             self.track_dirty(GuestAddr(gpa), &mut bits).await.unwrap();
             assert!(bits.iter().all(|&b| b == 0));

--- a/bin/propolis-server/src/lib/vm/state_driver.rs
+++ b/bin/propolis-server/src/lib/vm/state_driver.rs
@@ -791,6 +791,11 @@ mod tests {
             .times(1)
             .in_sequence(&mut seq)
             .returning(|| ());
+        vm_ctrl
+            .expect_pause_vm()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|| ());
         vcpu_ctrl
             .expect_exit_all()
             .times(1)

--- a/scripts/live-migration-times.d
+++ b/scripts/live-migration-times.d
@@ -61,9 +61,9 @@ dtrace:::BEGIN
 	this->phase = "";
 }
 
-propolis$1:::migrate_xfer_ram_page
+propolis$1:::migrate_xfer_ram_region
 {
-	xfer_pages[arg2]++;
+	xfer_pages[arg2] += arg0;
 	xfer_bytes[arg2] += arg1;
 }
 

--- a/scripts/live-migration-times.d
+++ b/scripts/live-migration-times.d
@@ -23,12 +23,16 @@
  *   added/removed, this script will break.
  */
 
-
 #pragma D option quiet
 #pragma D option defaultargs
 
-uint64_t xfer_pages;
-uint64_t xfer_bytes;
+enum vm_paused {
+	VM_UNPAUSED = 0,
+	VM_PAUSED = 1,
+};
+
+uint64_t xfer_pages[uint8_t];
+uint64_t xfer_bytes[uint8_t];
 
 dtrace:::BEGIN
 {
@@ -43,12 +47,14 @@ dtrace:::BEGIN
 	if ($$2 == "v") {
 		printf("%-12s %-10s %30s\n", "PHASE", "", "TIMESTAMP");
 	}
+
+	this->phase = "";
 }
 
 propolis$1:::migrate_xfer_ram_page
 {
-	xfer_pages++;
-	xfer_bytes += arg1;
+	xfer_pages[arg2]++;
+	xfer_bytes[arg2] += arg1;
 }
 
 propolis$1:::migrate_phase_begin
@@ -84,15 +90,17 @@ propolis$1:::migrate_phase_end
 dtrace:::END
 {
 	this->sync = "Sync";
+	this->rpush_pre = "RamPushPrePause";
 	this->pause = "Pause";
-	this->rpush = "RamPush";
+    this->rpush_post = "RamPushPostPause";
 	this->dev = "DeviceState";
 	this->rpull = "RamPull";
 	this->fin = "Finish";
 
 	this->d_sync = delta[this->sync];
+	this->d_rpush_pre = delta[this->rpush_pre];
 	this->d_pause = delta[this->pause];
-	this->d_rpush = delta[this->rpush];
+	this->d_rpush_post = delta[this->rpush_post];
 	this->d_dev = delta[this->dev];
 	this->d_rpull = delta[this->rpull];
 	this->d_fin = delta[this->fin];
@@ -107,27 +115,31 @@ dtrace:::END
 
 	/* Print the values of each phase, if they occurred */
 	if (this->d_sync != 0) {
-		printf("%-15s %30d\n", this->sync, this->d_sync / 1000);
+		printf("%-16s %29d\n", this->sync, this->d_sync / 1000);
 		this->total += this->d_sync;
 	}
+	if (this->d_rpush_pre != 0) {
+		printf("%-16s %29d\n", this->rpush_pre, this->d_rpush_pre / 1000);
+		this->total += this->d_rpush_pre;
+	}
 	if (this->d_pause != 0) {
-		printf("%-15s %30d\n", this->pause, this->d_pause / 1000);
+		printf("%-16s %29d\n", this->pause, this->d_pause / 1000);
 		this->total += this->d_pause;
 	}
-	if (this->d_rpush != 0) {
-		printf("%-15s %30d\n", this->rpush, this->d_rpush / 1000);
-		this->total += this->d_rpush;
+	if (this->d_rpush_post != 0) {
+		printf("%-16s %29d\n", this->rpush_post, this->d_rpush_post / 1000);
+		this->total += this->d_rpush_post;
 	}
 	if (this->d_dev != 0) {
-		printf("%-15s %30d\n", this->dev, this->d_dev / 1000);
+		printf("%-16s %29d\n", this->dev, this->d_dev / 1000);
 		this->total += this->d_dev;
 	}
 	if (this->d_rpull != 0) {
-		printf("%-15s %30d\n", this->rpull, this->d_rpull / 1000);
+		printf("%-16s %29d\n", this->rpull, this->d_rpull / 1000);
 		this->total += this->d_rpull;
 	}
 	if (this->d_fin != 0) {
-		printf("%-15s %30d\n", this->fin, this->d_fin / 1000);
+		printf("%-16s %29d\n", this->fin, this->d_fin / 1000);
 		this->total += this->d_fin;
 	}
 
@@ -137,13 +149,36 @@ dtrace:::END
 		printf("\n");
 	}
 
+	xfer_pages_total = xfer_pages[VM_PAUSED] + xfer_pages[VM_UNPAUSED];
+	xfer_bytes_total = xfer_bytes[VM_PAUSED] + xfer_bytes[VM_UNPAUSED];
+
 	/* Print summary of RAM pages transferred */
-	if ($$1 != "" && xfer_pages != 0) {
-		printf("%-15s %30d\n", "NPAGES XFERED", xfer_pages);
-		printf("%-15s %30d\n", "NBYTES XFERED", xfer_bytes);
-		if (this->d_rpush != 0) {
-			printf("%-15s %30d\n", "KiB/SEC",
-			    (xfer_bytes / 1024) / (this->d_rpush / 1000000000));
+	if ($$1 != "" && xfer_pages_total != 0) {
+		printf("%-25s %20d\n", "NPAGES XFERED (total)", xfer_pages_total);
+		printf("%-25s %20d\n", "NBYTES XFERED (total)", xfer_bytes_total);
+
+		printf("%-25s %20d\n",
+				"NPAGES XFERED (unpaused)",
+				xfer_pages[VM_UNPAUSED]);
+		printf("%-25s %20d\n",
+				"NBYTES XFERED (unpaused)",
+				xfer_bytes[VM_UNPAUSED]);
+		if (this->d_rpush_pre != 0 && xfer_bytes[VM_UNPAUSED] != 0) {
+			printf("%-25s %20d\n", "KiB/SEC (unpaused)",
+					((xfer_bytes[VM_UNPAUSED] * 1000000000) / 1024) /
+						this->d_rpush_pre);
+		}
+
+		printf("%-25s %20d\n",
+				"NPAGES XFERED (paused)",
+				xfer_pages[VM_PAUSED]);
+		printf("%-25s %20d\n",
+				"NBYTES XFERED (paused)",
+				xfer_bytes[VM_PAUSED]);
+		if (this->d_rpush_post != 0 && xfer_bytes[VM_PAUSED] != 0) {
+			printf("%-25s %20d\n", "KiB/SEC (paused)",
+					((xfer_bytes[VM_PAUSED] * 1000000000) / 1024) /
+						this->d_rpush_post);
 		}
 	}
 }

--- a/scripts/live-migration-times.d
+++ b/scripts/live-migration-times.d
@@ -21,14 +21,12 @@
  *   arugment into the migrate_phase_{begin,end} probes. We use the name as
  *   a key for tracking the phase deltas. If those names change, or phases are
  *   added/removed, this script will break.
- * - When calculating RAM transfer rates, the script assumes that the majority
- *   of the time Propolis spends in a RAM copy phase is spent actually copying
- *   guest memory and that the cost of other tasks in the phase (entering it,
- *   leaving it, logging messages, Propolis control flow, etc.) is negligible
- *   by comparison. If a RAM transfer phase copies very little memory (e.g.
- *   because the VM is mostly idle and there's nothing to copy in the post-
- *   pause phase), this assumption will not hold and the script will report
- *   unusually low transfer rates.
+ * - If a VM's guest is mostly idle, the post-pause RAM transfer phase will
+ *   copy very few pages, which can make the transfer rate abnormally low (the
+ *   cost of entering and leaving the phase becomes significant relative to the
+ *   cost of transferring RAM). If the post-pause transfer rate for some
+ *   migration seems abnormally low, check to make sure there were actually
+ *   some pages to transfer!
  */
 
 #pragma D option quiet


### PR DESCRIPTION
Send all pages from the source to the target once before pausing, then pause, then send only those pages that were modified after being sent the first time. This drastically reduces the number of pages that have to be sent while the VM is not running.

This change sends *all* pages in the pre-pause RAM transfer page, irrespective of whether they're dirty. This is a low-subtlety way of handling the following case:

1. Source reads its dirty page bitmap
2. Bhyve marks the previously-dirty pages as clean
3. Source sends the pages to the target
4. The target crashes and migration fails

To migrate correctly on a second attempt, the source needs to send the new target all the pages it sent in step 2 (in addition to any other modified pages). It'd be more efficient to remember exactly which pages need to be sent, but for now, this change just sends all guest pages once, since the set of required pages is guaranteed to be a subset of the set of all pages. Note that it's still important to query the dirty bitmap in this phase (so that the pages will only be transferred while paused if they were dirtied after being sent the first time).

Tested: PHD incl. migration variations; 200 migrations of a guest running a memory stress mix.