### PR TITLE
Bump Crucible revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 dependencies = [
  "backtrace",
 ]
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=3a3e806bfc2eea3519cfc0ec14ec4e745f275cd6#3a3e806bfc2eea3519cfc0ec14ec4e745f275cd6"
+source = "git+https://github.com/oxidecomputer/crucible?rev=9f69deab230079a5bae4a10a099d7fc1f3d29df7#9f69deab230079a5bae4a10a099d7fc1f3d29df7"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=3a3e806bfc2eea3519cfc0ec14ec4e745f275cd6#3a3e806bfc2eea3519cfc0ec14ec4e745f275cd6"
+source = "git+https://github.com/oxidecomputer/crucible?rev=9f69deab230079a5bae4a10a099d7fc1f3d29df7#9f69deab230079a5bae4a10a099d7fc1f3d29df7"
 dependencies = [
  "base64 0.21.0",
  "schemars",
@@ -723,13 +723,14 @@ dependencies = [
 
 [[package]]
 name = "crucible-common"
-version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=3a3e806bfc2eea3519cfc0ec14ec4e745f275cd6#3a3e806bfc2eea3519cfc0ec14ec4e745f275cd6"
+version = "0.0.1"
+source = "git+https://github.com/oxidecomputer/crucible?rev=9f69deab230079a5bae4a10a099d7fc1f3d29df7#9f69deab230079a5bae4a10a099d7fc1f3d29df7"
 dependencies = [
  "anyhow",
  "nix",
  "rusqlite",
  "rustls-pemfile",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
@@ -738,17 +739,19 @@ dependencies = [
  "toml 0.7.3",
  "twox-hash",
  "uuid",
+ "vergen",
 ]
 
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=3a3e806bfc2eea3519cfc0ec14ec4e745f275cd6#3a3e806bfc2eea3519cfc0ec14ec4e745f275cd6"
+source = "git+https://github.com/oxidecomputer/crucible?rev=9f69deab230079a5bae4a10a099d7fc1f3d29df7#9f69deab230079a5bae4a10a099d7fc1f3d29df7"
 dependencies = [
  "anyhow",
  "bincode",
  "bytes",
  "crucible-common",
+ "num_enum",
  "serde",
  "tokio-util",
  "uuid",
@@ -1989,7 +1992,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.1.7",
 ]
 
 [[package]]
@@ -3259,9 +3262,9 @@ dependencies = [
 
 [[package]]
 name = "ringbuffer"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1973f95452ec56a4b2c683f5eabc15617e38f4faf2776ed4a0011d5070ecb37e"
+checksum = "b6e4fbb37fd18bd949f42583141d650fcdce49dbf759264e4dd3a5df0bc15dc6"
 
 [[package]]
 name = "ron"
@@ -3301,6 +3304,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 dependencies = [
  "semver 0.1.20",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.17",
 ]
 
 [[package]]
@@ -3602,7 +3614,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.17",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -3729,7 +3741,7 @@ dependencies = [
  "hostname",
  "slog",
  "slog-json",
- "time 0.3.17",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -3770,7 +3782,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "time 0.3.17",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -3805,7 +3817,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.17",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -4083,9 +4095,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
  "libc",
@@ -4097,15 +4109,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -4308,7 +4320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.17",
+ "time 0.3.21",
  "tracing-subscriber",
 ]
 
@@ -4334,7 +4346,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "time 0.3.17",
+ "time 0.3.21",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -4674,9 +4686,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
 dependencies = [
  "getrandom",
  "serde",
@@ -4693,6 +4705,19 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b86a8af1dedf089b1c78338678e4c7492b6045649042d94faf19690499d236"
+dependencies = [
+ "anyhow",
+ "git2",
+ "rustc_version 0.4.0",
+ "rustversion",
+ "time 0.3.21",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ tracing-appender = "0.2.2"
 tracing-bunyan-formatter = "0.3.3"
 tracing-subscriber = "0.3.14"
 usdt = { version = "0.3.2", default-features = false }
-uuid = "1.0.0"
+uuid = "1.3.2"
 version_check = "0.9"
 viona_api = { path = "crates/viona-api" }
 viona_api_sys = { path = "crates/viona-api/sys" }
@@ -135,8 +135,8 @@ vte = "0.10.1"
 
 [workspace.dependencies.crucible-client-types]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "3a3e806bfc2eea3519cfc0ec14ec4e745f275cd6"
+rev = "9f69deab230079a5bae4a10a099d7fc1f3d29df7"
 
 [workspace.dependencies.crucible]
 git = "https://github.com/oxidecomputer/crucible"
-rev = "3a3e806bfc2eea3519cfc0ec14ec4e745f275cd6"
+rev = "9f69deab230079a5bae4a10a099d7fc1f3d29df7"


### PR DESCRIPTION
Picks up:

    * 9f69dea - Actually provision read-only downstairs! (#728)
    * 92ae012 - crutest use SIGUSR1 to stop tests (#699)
    * 47f3569 - Add build info and version commands (#709)
    * 07f0a9e - Give up on a downstairs (#725)
    * 9985a4c - Slightly better versioning between upstairs and downstairs (#705)
    * 0b34a53 - Fix paths in method scripts (#703)
    * 12b65eb - [smf] Allow Crucible Zones to be self-assembling (#498)

Also updates uuid dep to 1.3.2.