### PR TITLE
Clippy checks

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,14 @@ jobs:
       run: cargo fmt -- --version
     - name: Check style
       run: cargo fmt -- --check
+  check-clippy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Report clippy version
+      run: cargo clippy -- --version
+    - name: Check clippy
+      run: cargo xtask clippy --strict
   build-docs:
     runs-on: ubuntu-latest
     steps:
@@ -26,11 +34,7 @@ jobs:
     - name: Test build documentation
       run: cargo doc
   build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-22.04 ]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5038,6 +5038,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtask"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap 4.2.4",
+ "serde_json",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "lib/*",
   "packaging/propolis-package",
   "phd-tests/*",
+  "xtask",
 ]
 
 default-members = [
@@ -16,6 +17,7 @@ default-members = [
   "bin/propolis-cli",
   "bin/propolis-server",
   "bin/propolis-standalone",
+  "xtask",
 ]
 
 exclude = [

--- a/bin/propolis-server/src/lib/migrate/codec.rs
+++ b/bin/propolis-server/src/lib/migrate/codec.rs
@@ -259,7 +259,7 @@ mod encoder_tests {
 
     fn encode(m: Message) -> Vec<u8> {
         if let tungstenite::Message::Binary(bytes) = m.try_into().unwrap() {
-            return bytes;
+            bytes
         } else {
             panic!();
         }

--- a/lib/propolis/src/vmm/time.rs
+++ b/lib/propolis/src/vmm/time.rs
@@ -485,7 +485,7 @@ mod test {
 
         // error case: migrate delta overflows i64
         // (i64::MAX + 1) sec - 0 sec
-        let dst_wc = Duration::from_nanos(((i64::MAX as u64) + 1) as u64);
+        let dst_wc = Duration::from_nanos((i64::MAX as u64) + 1);
         let res = adjust_time_data(base_time_data(), 0, dst_wc);
         assert!(res.is_err());
         assert!(matches!(
@@ -659,7 +659,7 @@ mod test {
         let dst_wc = Duration::from_nanos(300);
 
         // expect: 1 day, 1 min, 200 ns
-        let expect = ((1 * SEC_PER_DAY + 60) * NS_PER_SEC) as i64 + 200;
+        let expect = ((SEC_PER_DAY + 60) * NS_PER_SEC) as i64 + 200;
         let res = adjust_time_data(src_td, dst_hrt, dst_wc);
         assert!(res.is_ok());
         assert_eq!(res.unwrap().0.boot_hrtime, expect);
@@ -693,7 +693,7 @@ mod test {
         let dst_wc = Duration::new(65, 500);
 
         // expect: - (1 day, 1 min, 200 ns)
-        let expect: i64 = -(((1 * SEC_PER_DAY + 60) * NS_PER_SEC) as i64 + 200);
+        let expect: i64 = -(((SEC_PER_DAY + 60) * NS_PER_SEC) as i64 + 200);
         let res = adjust_time_data(src_td, dst_hrt, dst_wc);
         assert!(res.is_ok());
         assert_eq!(res.unwrap().0.boot_hrtime, expect);

--- a/packaging/propolis-package/src/main.rs
+++ b/packaging/propolis-package/src/main.rs
@@ -13,7 +13,7 @@ use std::fs::create_dir_all;
 use std::path::Path;
 use std::time::Duration;
 
-const PKG_NAME: &'static str = "propolis-server";
+const PKG_NAME: &str = "propolis-server";
 
 fn in_progress_style() -> ProgressStyle {
     ProgressStyle::default_bar()

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "xtask"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,84 @@
+use std::process::{Command, Stdio};
+
+use anyhow::{bail, Result};
+use clap::{Parser, Subcommand};
+use serde_json::{Map, Value};
+
+#[derive(Parser)]
+#[command(name = "cargo xtask", about = "Builder tasks for Propolis")]
+struct Args {
+    #[command(subcommand)]
+    cmd: Cmds,
+}
+
+#[derive(Subcommand)]
+enum Cmds {
+    /// Run suite of clippy checks
+    Clippy {
+        /// Treat warnings as errors
+        #[arg(short, long)]
+        strict: bool,
+    },
+}
+
+fn workspace_root() -> Result<String> {
+    let mut cmd = Command::new("cargo");
+    cmd.args(["metadata", "--format-version=1"])
+        .stdin(Stdio::null())
+        .stderr(Stdio::inherit());
+
+    let output = cmd.output()?;
+    if !output.status.success() {
+        bail!("failed to query cargo metadata");
+    }
+    let metadata: Map<String, Value> = serde_json::from_slice(&output.stdout)?;
+
+    if let Some(Value::String(root)) = metadata.get("workspace_root") {
+        Ok(root.clone())
+    } else {
+        bail!("could not location workspace root")
+    }
+}
+
+fn cmd_clippy(strict: bool) -> Result<()> {
+    let wroot = workspace_root()?;
+
+    let run_clippy = |args: &[&str]| -> Result<bool> {
+        let mut cmd = Command::new("cargo");
+        cmd.arg("clippy").arg("--no-deps").args(args).current_dir(&wroot);
+
+        if strict {
+            cmd.args(["--", "-Dwarnings"]);
+        }
+
+        let status = cmd.spawn()?.wait()?;
+        Ok(!status.success())
+    };
+
+    let mut failed = false;
+
+    // Everything in the workspace
+    failed |= run_clippy(&["--workspace"])?;
+
+    // And try with tests too
+    failed |= run_clippy(&["--workspace", "--tests"])?;
+
+    // Check the Falcon bits
+    failed |= run_clippy(&["-p", "propolis-server", "--features", "falcon"])?;
+
+    // Check the mock server
+    failed |=
+        run_clippy(&["-p", "propolis-server", "--features", "mock-only"])?;
+
+    if failed {
+        bail!("Clippy failures detected")
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    match Args::parse().cmd {
+        Cmds::Clippy { strict } => cmd_clippy(strict),
+    }
+}


### PR DESCRIPTION
With so many different components, some not build by default in the workspace, it has become easy to overlook problems which would otherwise be highlighted by Clippy.  Add an xtask to check the entire codebase and wire it into the GH Actions CI.