### PR TITLE
propolis-server should use reservoir on prod gear

### DIFF
--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -27,7 +27,10 @@ cargo --version
 rustc --version
 
 banner build
-ptime -m cargo build --release --verbose -p propolis-server
+
+# Enable the "omicron-build" feature to indicate this is an artifact destined
+# for production use on an appropriately configured Oxide machine
+ptime -m cargo build --release --verbose -p propolis-server --features omicron-build
 
 banner image
 ptime -m cargo run -p propolis-package

--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -53,7 +53,7 @@ slog-async.workspace = true
 slog-bunyan.workspace = true
 slog-dtrace.workspace = true
 slog-term.workspace = true
-propolis.workspace = true
+propolis = { workspace = true, features = ["crucible-full", "oximeter"] }
 propolis-client = { workspace = true, features = ["generated"] }
 propolis-server-config.workspace = true
 rfb.workspace = true
@@ -71,8 +71,15 @@ expectorate.workspace = true
 mockall.workspace = true
 
 [features]
-default = ["propolis/crucible-full", "propolis/oximeter"]
-falcon = ["propolis/falcon", "propolis-client/falcon"]
+default = []
+
+# When building to be packaged for inclusion in the production ramdisk
+# (nominally an Omicron package), certain code is compiled in or out.
+omicron-build = []
+
 # If selected, only build a mock server which does not actually spawn instances
 # (i.e. to test with a facsimile of the API on unsupported platforms)
 mock-only = []
+
+# Falcon builds require corresponding bits turned on in the dependency libs
+falcon = ["propolis/falcon", "propolis-client/falcon"]

--- a/bin/propolis-server/src/lib/config.rs
+++ b/bin/propolis-server/src/lib/config.rs
@@ -64,10 +64,12 @@ fn blockdev_backend(
     }
 }
 
-// Automatically enable use of the memory reservoir (rather than transient
-// allocations) for guest memory if it meets some arbitrary size threshold.
-const RESERVOIR_THRESH_MB: usize = 512;
+#[cfg(not(feature = "omicron-build"))]
 pub fn reservoir_decide(log: &slog::Logger) -> bool {
+    // Automatically enable use of the memory reservoir (rather than transient
+    // allocations) for guest memory if it meets some arbitrary size threshold.
+    const RESERVOIR_THRESH_MB: usize = 512;
+
     match propolis::vmm::query_reservoir() {
         Err(e) => {
             slog::error!(log, "could not query reservoir {:?}", e);
@@ -93,4 +95,10 @@ pub fn reservoir_decide(log: &slog::Logger) -> bool {
             }
         }
     }
+}
+
+#[cfg(feature = "omicron-build")]
+pub fn reservoir_decide(_log: &slog::Logger) -> bool {
+    // Always use the reservoir in production
+    true
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -60,6 +60,10 @@ fn cmd_clippy(strict: bool) -> Result<()> {
     // Everything in the workspace (including tests, etc)
     failed |= run_clippy(&["--workspace", "--all-targets"])?;
 
+    // Check the server as it is built for production
+    failed |=
+        run_clippy(&["-p", "propolis-server", "--features", "omicron-build"])?;
+
     // Check the Falcon bits
     failed |= run_clippy(&["-p", "propolis-server", "--features", "falcon"])?;
 


### PR DESCRIPTION
Add "omicron-build" feature to propolis-server which compiles out the developer-friendly vmm-reservoir check, opting to use the reservoir unconditionally on the assumption that Oxide machines will be appropriately configured for such duty.

Fix #408