### PR TITLE
only allow one request to reboot to be enqueued at a time

### DIFF
--- a/phd-tests/tests/src/server_state_machine.rs
+++ b/phd-tests/tests/src/server_state_machine.rs
@@ -47,16 +47,45 @@ fn instance_stop_causes_destroy_test(ctx: &TestContext) {
 }
 
 #[phd_testcase]
-fn instance_reset_returns_to_running_test(ctx: &TestContext) {
+fn instance_reset_test(ctx: &TestContext) {
     let mut vm = ctx.vm_factory.new_vm(
         "instance_reset_returns_to_running_test",
         ctx.default_vm_config(),
     )?;
 
+    assert!(vm.reset().is_err());
     vm.launch()?;
     vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
+
+    // Because "Rebooting" is not a steady state, the Propolis state worker may
+    // transition the instance from Running to Rebooting to Running before the
+    // test gets a chance to monitor its state any further. Thus, it's not safe
+    // to test that the Rebooting state was observed here.
     vm.reset()?;
+    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
+
+    // Queue multiple reset attempts. These should all succeed, even though
+    // Propolis will only allow one reboot to be enqueued at a time. Once again,
+    // the specific number of reboots that will be queued depends on factors
+    // outside of the test's control.
+    for _ in 0..10 {
+        vm.reset()?;
+    }
+
     vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
     vm.stop()?;
     vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))?;
+    assert!(vm.reset().is_err());
+}
+
+#[phd_testcase]
+fn instance_reset_requires_running_test(ctx: &TestContext) {
+    let mut vm = ctx.vm_factory.new_vm(
+        "instance_reset_requires_running_test",
+        ctx.default_vm_config(),
+    )?;
+
+    assert!(vm.reset().is_err());
+    vm.launch()?;
+    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
 }


### PR DESCRIPTION
Change the VM controller request queue so that requesting to reboot an instance causes subsequent requests to be ignored until a "Rebooted" state change arrives from the state driver.

Beef up the PHD reboot test a little bit--it can't check for idempotency explicitly because its Propolis may be able to reboot the VM as quickly as the test can issue new reboot requests, but the modified test provides at least a little bit of extra coverage. It also now checks that reboot requests are rejected before an instance has started and after it has stopped.

Fixes #363.