### PR TITLE
add a probe for total bytes output to serial console

### DIFF
--- a/bin/propolis-server/src/lib/serial/history_buffer.rs
+++ b/bin/propolis-server/src/lib/serial/history_buffer.rs
@@ -118,6 +118,7 @@ impl HistoryBuffer {
             self.beginning.extend(drain);
         }
         self.total_bytes += data.len();
+        super::probes::serial_buffer_size!(|| self.total_bytes);
     }
 
     /// Returns a tuple containing:

--- a/bin/propolis-server/src/lib/serial/mod.rs
+++ b/bin/propolis-server/src/lib/serial/mod.rs
@@ -39,6 +39,7 @@ mod probes {
     fn serial_uart_read(n: usize) {}
     fn serial_inject_uart() {}
     fn serial_ws_recv() {}
+    fn serial_buffer_size(n: usize) {}
 }
 
 /// Errors which may occur during the course of a serial connection.


### PR DESCRIPTION
the running total of bytes written over the instance's entire life may be a useful stat to look at while investigating issues to do with serial output and/or history retrieval.