### PR TITLE
Various NVMe emulation fixes

### DIFF
--- a/lib/propolis/src/hw/nvme/admin.rs
+++ b/lib/propolis/src/hw/nvme/admin.rs
@@ -258,11 +258,12 @@ impl NvmeCtrl {
                 // `ncqa`/`nsqa` are 0-based values so subtract 1
                 cmds::Completion::success_val((ncqa - 1) << 16 | (nsqa - 1))
             }
-            // NVMe 1.0e Figure 66 Identify - Identify Controller Data Structure
-            // "If a volatile write cache is present, then the host may ...
-            //  control whether it is enabled with Set Features specifying the
-            //  Volatile Write Cache feature identifier."
             cmds::FeatureIdent::VolatileWriteCache => {
+                // NVMe 1.0e Figure 66 Identify - Identify Controller Data
+                // Structure "If a volatile write cache [VWC] is present, then
+                // the host may ... control whether it is enabled with Set
+                // Features specifying the Volatile Write Cache feature
+                // identifier."
                 cmds::Completion::success()
             }
             cmds::FeatureIdent::Reserved

--- a/lib/propolis/src/hw/nvme/admin.rs
+++ b/lib/propolis/src/hw/nvme/admin.rs
@@ -258,13 +258,19 @@ impl NvmeCtrl {
                 // `ncqa`/`nsqa` are 0-based values so subtract 1
                 cmds::Completion::success_val((ncqa - 1) << 16 | (nsqa - 1))
             }
+            // NVMe 1.0e Figure 66 Identify - Identify Controller Data Structure
+            // "If a volatile write cache is present, then the host may ...
+            //  control whether it is enabled with Set Features specifying the
+            //  Volatile Write Cache feature identifier."
+            cmds::FeatureIdent::VolatileWriteCache => {
+                cmds::Completion::success()
+            }
             cmds::FeatureIdent::Reserved
             | cmds::FeatureIdent::Arbitration
             | cmds::FeatureIdent::PowerManagement
             | cmds::FeatureIdent::LbaRangeType
             | cmds::FeatureIdent::TemperatureThreshold
             | cmds::FeatureIdent::ErrorRecovery
-            | cmds::FeatureIdent::VolatileWriteCache
             | cmds::FeatureIdent::InterruptCoalescing
             | cmds::FeatureIdent::InterruptVectorConfiguration
             | cmds::FeatureIdent::WriteAtomicity

--- a/lib/propolis/src/hw/nvme/bits.rs
+++ b/lib/propolis/src/hw/nvme/bits.rs
@@ -867,7 +867,7 @@ pub struct IdentifyController {
     /// See NVMe 1.0e Section 4.2, Figure 8 Command Format - Admin and NVM Vendor Specific Commands (Optional)
     pub avscc: u8,
     /// Reserved
-    pub _resv2: [u8; 246],
+    pub _resv2: [u8; 247],
 
     // bytes 512-2047 - NVM Command Set Attributes
     /// Submission Queue Entry Size (SQES)
@@ -988,7 +988,7 @@ impl Default for IdentifyController {
             vs: [0; 1024],
 
             _resv1: [0; 178],
-            _resv2: [0; 246],
+            _resv2: [0; 247],
             _resv3: [0; 2],
             _resv4: [0; 173],
             _resv5: [0; 1344],

--- a/lib/propolis/src/hw/nvme/bits.rs
+++ b/lib/propolis/src/hw/nvme/bits.rs
@@ -6,7 +6,7 @@ use bitstruct::bitstruct;
 ///
 /// See NVMe 1.0e Section 4.2 Submission Queue Entry - Command Format
 #[derive(Debug, Default, Copy, Clone)]
-#[repr(C)]
+#[repr(C, packed(1))]
 pub struct RawSubmission {
     /// Command Dword 0 (CDW0)
     ///
@@ -101,7 +101,7 @@ impl RawSubmission {
 ///
 /// See NVMe 1.0e Section 4.5 Completion Queue Entry
 #[derive(Debug, Default, Copy, Clone)]
-#[repr(C)]
+#[repr(C, packed(1))]
 pub struct RawCompletion {
     /// Dword 0 (DW0)
     ///
@@ -690,7 +690,7 @@ pub enum StatusCodeType {
 ///
 /// See NVMe 1.0e Section 5.11, Figure 67 Identify - Power State Descriptor Data Structure
 #[derive(Default, Copy, Clone)]
-#[repr(C)]
+#[repr(C, packed(1))]
 pub struct PowerStateDescriptor {
     /// Maximum Power
     ///
@@ -769,7 +769,7 @@ bitstruct! {
 ///
 /// See NVMe 1.0e Section 5.11, Figure 66 Identify - Identify Controller Data Structure
 #[derive(Copy, Clone)]
-#[repr(C)]
+#[repr(C, packed(1))]
 pub struct IdentifyController {
     // bytes 0-255 - Controller Capabilities and Features
     /// PCI Vendor ID (VID)
@@ -1001,7 +1001,7 @@ impl Default for IdentifyController {
 /// Describes a specific Logical Block Address (LBA) format.
 /// See NVMe 1.0e Section 5.11, Figure 69 Identify - LBA Format Data Structure, NVM Command Set Specific
 #[derive(Default, Copy, Clone)]
-#[repr(C)]
+#[repr(C, packed(1))]
 pub struct LbaFormat {
     /// Metadata Size (MS)
     ///
@@ -1030,7 +1030,7 @@ pub struct LbaFormat {
 ///
 /// See NVMe 1.0e Section 5.11, Figure 68 Identify - Identify Namespace Data Structure, NVM Command Set Specific
 #[derive(Copy, Clone)]
-#[repr(C)]
+#[repr(C, packed(1))]
 pub struct IdentifyNamespace {
     /// Namespace Size (NSZE)
     ///

--- a/lib/propolis/src/hw/nvme/cmds.rs
+++ b/lib/propolis/src/hw/nvme/cmds.rs
@@ -733,7 +733,7 @@ impl Completion {
             status: Self::status_field(
                 StatusCodeType::Generic,
                 bits::STS_SUCCESS,
-                0,
+                false,
             ),
         }
     }
@@ -745,7 +745,7 @@ impl Completion {
             status: Self::status_field(
                 StatusCodeType::Generic,
                 bits::STS_SUCCESS,
-                0,
+                false,
             ),
         }
     }
@@ -755,7 +755,7 @@ impl Completion {
         // success doesn't belong in an error
         assert_ne!(status, bits::STS_SUCCESS);
 
-        Self { dw0: 0, status: Self::status_field(sct, status, 0) }
+        Self { dw0: 0, status: Self::status_field(sct, status, false) }
     }
 
     /// Create a generic error Completion result with a specific status
@@ -765,7 +765,7 @@ impl Completion {
 
         Self {
             dw0: 0,
-            status: Self::status_field(StatusCodeType::Generic, status, 0),
+            status: Self::status_field(StatusCodeType::Generic, status, false),
         }
     }
 
@@ -777,12 +777,12 @@ impl Completion {
 
         Self {
             dw0: 0,
-            status: Self::status_field(StatusCodeType::Generic, status, 1),
+            status: Self::status_field(StatusCodeType::Generic, status, true),
         }
     }
 
     /// Helper method to combine StatusCodeType and status code
-    fn status_field(sct: StatusCodeType, sc: u8, dnr: u8) -> u16 {
+    fn status_field(sct: StatusCodeType, sc: u8, dnr: bool) -> u16 {
         (sc as u16) << 1 | ((sct as u8) as u16) << 9 | (dnr as u16) << 15
         // | (more as u16) << 14
     }

--- a/lib/propolis/src/hw/nvme/cmds.rs
+++ b/lib/propolis/src/hw/nvme/cmds.rs
@@ -733,6 +733,7 @@ impl Completion {
             status: Self::status_field(
                 StatusCodeType::Generic,
                 bits::STS_SUCCESS,
+                0,
             ),
         }
     }
@@ -744,6 +745,7 @@ impl Completion {
             status: Self::status_field(
                 StatusCodeType::Generic,
                 bits::STS_SUCCESS,
+                0,
             ),
         }
     }
@@ -753,7 +755,7 @@ impl Completion {
         // success doesn't belong in an error
         assert_ne!(status, bits::STS_SUCCESS);
 
-        Self { dw0: 0, status: Self::status_field(sct, status) }
+        Self { dw0: 0, status: Self::status_field(sct, status, 0) }
     }
 
     /// Create a generic error Completion result with a specific status
@@ -763,15 +765,26 @@ impl Completion {
 
         Self {
             dw0: 0,
-            status: Self::status_field(StatusCodeType::Generic, status),
+            status: Self::status_field(StatusCodeType::Generic, status, 0),
+        }
+    }
+
+    /// Create a generic error Completion result with a specific status
+    /// and the do-not-retry bit set.
+    pub fn generic_err_dnr(status: u8) -> Self {
+        // success doesn't belong in an error
+        assert_ne!(status, bits::STS_SUCCESS);
+
+        Self {
+            dw0: 0,
+            status: Self::status_field(StatusCodeType::Generic, status, 1),
         }
     }
 
     /// Helper method to combine StatusCodeType and status code
-    fn status_field(sct: StatusCodeType, sc: u8) -> u16 {
-        (sc as u16) << 1 | ((sct as u8) as u16) << 9
+    fn status_field(sct: StatusCodeType, sc: u8, dnr: u8) -> u16 {
+        (sc as u16) << 1 | ((sct as u8) as u16) << 9 | (dnr as u16) << 15
         // | (more as u16) << 14
-        // | (dnr as u16) << 15
     }
 }
 


### PR DESCRIPTION
With these fixes, and a separate change to the illumos nvme driver to make it happier at being under a PCI root complex, I can successfully boot an illumos guest under propolis with a working NVMe drive.

```
kayak-r151047# uname -a
SunOS unknown 5.11 omnios-master-42fe848aa52 i86pc i386 i86pc

kayak-r151047# diskinfo
TYPE    DISK                    VID      PID              SIZE          RMV SSD 
-       c5t0d0                  Virtio   Block Device        0.57 GiB   no  no  
NVME    c6t1d0                  NVMe     -                 300.00 GiB   no  yes

kayak-r151047# zpool create bob c6t1d0
kayak-r151047# zpool list
NAME   SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
bob    298G   146K   298G        -         -     0%     0%  1.00x    ONLINE  -
```
