### PR TITLE
Reorganize and update cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,25 +496,25 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.4"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
- "clap_derive 4.2.0",
+ "clap_derive 4.3.0",
  "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.4"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
  "anstream",
  "anstyle",
  "bitflags 1.3.2",
- "clap_lex 0.4.1",
+ "clap_lex 0.5.0",
  "strsim",
 ]
 
@@ -533,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "codespan-reporting"
@@ -1446,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",
@@ -1600,9 +1600,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1866,9 +1866,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libdlpi-sys"
@@ -2484,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "p4rs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=main#112315db527ffe5a5c314a6368bc4109bef86041"
+source = "git+https://github.com/oxidecomputer/p4?rev=d59491f86668e15e92f35ffe3f94504ff4241c64#d59491f86668e15e92f35ffe3f94504ff4241c64"
 dependencies = [
  "bitvec",
  "colored",
@@ -2700,7 +2700,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "backtrace",
- "clap 4.2.4",
+ "clap 4.3.0",
  "phd-framework",
  "phd-tests",
  "tracing",
@@ -2918,7 +2918,7 @@ source = "git+https://github.com/oxidecomputer/progenitor?branch=main#4c16647cac
 dependencies = [
  "anyhow",
  "built",
- "clap 4.2.4",
+ "clap 4.3.0",
  "openapiv3",
  "progenitor-client",
  "progenitor-impl",
@@ -3012,7 +3012,6 @@ dependencies = [
  "num_enum",
  "once_cell",
  "oximeter",
- "p4rs",
  "p9ds 0.1.0 (git+https://github.com/oxidecomputer/p9fs)",
  "propolis_types",
  "rand",
@@ -3038,7 +3037,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
- "clap 4.2.4",
+ "clap 4.3.0",
  "futures",
  "libc",
  "propolis-client",
@@ -3098,7 +3097,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "chrono",
- "clap 4.2.4",
+ "clap 4.3.0",
  "const_format",
  "dropshot",
  "enum-iterator",
@@ -3157,7 +3156,7 @@ dependencies = [
  "anyhow",
  "atty",
  "bhyve_api",
- "clap 4.2.4",
+ "clap 4.3.0",
  "ctrlc",
  "erased-serde",
  "futures",
@@ -3192,7 +3191,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bhyve_api",
- "clap 4.2.4",
+ "clap 4.3.0",
  "libc",
  "propolis",
  "propolis-standalone-config",
@@ -4040,10 +4039,11 @@ dependencies = [
 [[package]]
 name = "softnpu"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/softnpu?branch=main#5091054d4fbb95ef752a43fef7e4fcf4f967692d"
+source = "git+https://github.com/oxidecomputer/softnpu?rev=88f5f1334364e5580fe778c44ac0746a35927351#88f5f1334364e5580fe778c44ac0746a35927351"
 dependencies = [
+ "anstyle",
  "anyhow",
- "clap 4.2.4",
+ "clap 4.3.0",
  "devinfo 0.1.0 (git+https://github.com/oxidecomputer/devinfo-sys?branch=main)",
  "dlpi",
  "indicatif",
@@ -5348,7 +5348,7 @@ name = "xtask"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "clap 4.2.4",
+ "clap 4.3.0",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,14 +38,48 @@ inherits = "dev"
 panic = "unwind"
 
 [workspace.dependencies]
+# Internal crates
+bhyve_api = { path = "crates/bhyve-api" }
+bhyve_api_sys = { path = "crates/bhyve-api/sys" }
+dladm = { path = "crates/dladm" }
+propolis-server-config = { path = "crates/propolis-server-config" }
+propolis-standalone-config = { path = "crates/propolis-standalone-config" }
+propolis_types = { path = "crates/propolis-types" }
+viona_api = { path = "crates/viona-api" }
+viona_api_sys = { path = "crates/viona-api/sys" }
+
+# PHD testing framework
+phd-framework = { path = "phd-tests/framework" }
+phd-testcase = { path = "phd-tests/testcase" }
+phd-testcase-macros = { path = "phd-tests/testcase_macro" }
+phd-tests = { path = "phd-tests/tests" }
+
+# Public library crates
+propolis = { path = "lib/propolis", default-features = false }
+propolis-client = { path = "lib/propolis-client" }
+
+# Propolis cfg(feature = "falcon")
+dlpi = { git = "https://github.com/oxidecomputer/dlpi-sys", branch = "main" }
+ispf = { git = "https://github.com/oxidecomputer/ispf" }
+libloading = "0.7"
+p9ds = { git = "https://github.com/oxidecomputer/p9fs" }
+softnpu-lib = { git = "https://github.com/oxidecomputer/softnpu", rev = "88f5f1334364e5580fe778c44ac0746a35927351", package = "softnpu" }
+
+# Omicron-related
+internal-dns = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
+nexus-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
+omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
+omicron-zone-package = "0.9.0"
+oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
+oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
+
+# External dependencies
 anyhow = "1.0"
 async-trait = "0.1.53"
 atty = "0.2.14"
 backoff = "0.4.0"
 backtrace = "0.3.66"
 base64 = "0.21"
-bhyve_api = { path = "crates/bhyve-api" }
-bhyve_api_sys = { path = "crates/bhyve-api/sys" }
 bit_field = "0.10.1"
 bitflags = "1.3"
 bitstruct = "0.1"
@@ -58,10 +92,9 @@ chrono = "0.4.19"
 clap = "4.2"
 const_format = "0.2"
 crossbeam-channel = "0.5"
-ctest2 = "0.4.3"
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "9f69deab230079a5bae4a10a099d7fc1f3d29df7" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "9f69deab230079a5bae4a10a099d7fc1f3d29df7" }
 ctrlc = "3.2"
-dladm = { path = "crates/dladm" }
-dlpi = { git = "https://github.com/oxidecomputer/dlpi-sys", branch = "main" }
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
 enum-iterator = "1.4.1"
 erased-serde = "0.3"
@@ -71,33 +104,14 @@ futures = "0.3"
 hex = "0.4.3"
 hyper = "0.14"
 indicatif = "0.17.3"
-internal-dns = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 inventory = "0.3.0"
-ispf = { git = "https://github.com/oxidecomputer/ispf" }
 lazy_static = "1.4"
 libc = "0.2"
-libloading = "0.7"
 mockall = "0.11"
-nexus-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 num_enum = "0.5"
-omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-omicron-zone-package = "0.9.0"
 once_cell = "1.13"
-oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-p4rs = { git = "https://github.com/oxidecomputer/p4", branch = "main" }
-p9ds = { git = "https://github.com/oxidecomputer/p9fs" }
-phd-framework = { path = "phd-tests/framework" }
-phd-testcase = { path = "phd-tests/testcase" }
-phd-testcase-macros = { path = "phd-tests/testcase_macro" }
-phd-tests = { path = "phd-tests/tests" }
 proc-macro2 = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
-propolis = { path = "lib/propolis", default-features = false }
-propolis-client = { path = "lib/propolis-client" }
-propolis-server-config = { path = "crates/propolis-server-config" }
-propolis-standalone-config = { path = "crates/propolis-standalone-config" }
-propolis_types = { path = "crates/propolis-types" }
 quote = "1.0"
 rand = "0.8"
 reqwest = { version = "0.11.12", default-features = false }
@@ -115,7 +129,6 @@ slog-async = "2.7"
 slog-bunyan = "2.4.0"
 slog-dtrace = "0.2.3"
 slog-term = "2.8"
-softnpu-lib = { git = "https://github.com/oxidecomputer/softnpu", branch = "main", package = "softnpu" }
 syn = "1.0"
 tempfile = "3.2"
 thiserror = "1.0"
@@ -129,14 +142,4 @@ tracing-bunyan-formatter = "0.3.3"
 tracing-subscriber = "0.3.14"
 usdt = { version = "0.3.5", default-features = false }
 uuid = "1.3.2"
-viona_api = { path = "crates/viona-api" }
-viona_api_sys = { path = "crates/viona-api/sys" }
 vte = "0.10.1"
-
-[workspace.dependencies.crucible-client-types]
-git = "https://github.com/oxidecomputer/crucible"
-rev = "9f69deab230079a5bae4a10a099d7fc1f3d29df7"
-
-[workspace.dependencies.crucible]
-git = "https://github.com/oxidecomputer/crucible"
-rev = "9f69deab230079a5bae4a10a099d7fc1f3d29df7"

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -40,7 +40,6 @@ libloading = { workspace = true, optional = true }
 p9ds = { workspace = true, optional = true }
 ispf = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
-p4rs = { workspace = true, optional = true } 
 softnpu-lib = { workspace = true, optional = true }
 dlpi = { workspace = true, optional = true }
 
@@ -54,4 +53,4 @@ rand.workspace = true
 [features]
 default = []
 crucible-full = ["crucible", "crucible-client-types", "oximeter", "nexus-client"]
-falcon = ["libloading", "p9ds", "dlpi", "p4rs", "ispf", "rand", "softnpu-lib"]
+falcon = ["libloading", "p9ds", "dlpi", "ispf", "rand", "softnpu-lib"]

--- a/lib/propolis/src/hw/virtio/softnpu.rs
+++ b/lib/propolis/src/hw/virtio/softnpu.rs
@@ -25,8 +25,8 @@ use super::{
     VirtioDevice,
 };
 
-use p4rs::{packet_in, packet_out, Pipeline};
 use softnpu_lib::mgmt::ManagementRequest;
+use softnpu_lib::p4rs::{self, packet_in, packet_out, Pipeline};
 
 use crate::hw::virtio::p9fs::{write_error, P9Handler, PciVirtio9pfs};
 use dlpi::sys::dlpi_recvinfo_t;


### PR DESCRIPTION
- Workspace deps in Cargo.toml organized by category
- h2 & hyper deps bumped to cross CVE-2023-26964
- softnpu deps reworked to unify p4rs access