### PR TITLE
Bump crucible rev to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,9 +301,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bhyve_api"
@@ -453,13 +459,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "serde",
  "time 0.1.45",
@@ -674,13 +680,13 @@ dependencies = [
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=8757b3fb55a1763382ad7111144bc60ec72af23d#8757b3fb55a1763382ad7111144bc60ec72af23d"
+source = "git+https://github.com/oxidecomputer/crucible?rev=c7879bc8fbf68d977eb1c983cb0bab34b1b8b805#c7879bc8fbf68d977eb1c983cb0bab34b1b8b805"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
  "async-recursion 1.0.4",
  "async-trait",
- "base64 0.21.0",
+ "base64 0.21.2",
  "bytes",
  "chrono",
  "crucible-client-types",
@@ -707,29 +713,29 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.23.4",
  "tokio-util",
- "toml 0.7.3",
+ "toml 0.7.4",
  "tracing",
  "usdt",
- "uuid",
+ "uuid 1.3.3",
  "version_check",
 ]
 
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=8757b3fb55a1763382ad7111144bc60ec72af23d#8757b3fb55a1763382ad7111144bc60ec72af23d"
+source = "git+https://github.com/oxidecomputer/crucible?rev=c7879bc8fbf68d977eb1c983cb0bab34b1b8b805#c7879bc8fbf68d977eb1c983cb0bab34b1b8b805"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "schemars",
  "serde",
  "serde_json",
- "uuid",
+ "uuid 1.3.3",
 ]
 
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=8757b3fb55a1763382ad7111144bc60ec72af23d#8757b3fb55a1763382ad7111144bc60ec72af23d"
+source = "git+https://github.com/oxidecomputer/crucible?rev=c7879bc8fbf68d977eb1c983cb0bab34b1b8b805#c7879bc8fbf68d977eb1c983cb0bab34b1b8b805"
 dependencies = [
  "anyhow",
  "atty",
@@ -747,16 +753,16 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio-rustls 0.23.4",
- "toml 0.7.3",
+ "toml 0.7.4",
  "twox-hash",
- "uuid",
+ "uuid 1.3.3",
  "vergen",
 ]
 
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=8757b3fb55a1763382ad7111144bc60ec72af23d#8757b3fb55a1763382ad7111144bc60ec72af23d"
+source = "git+https://github.com/oxidecomputer/crucible?rev=c7879bc8fbf68d977eb1c983cb0bab34b1b8b805#c7879bc8fbf68d977eb1c983cb0bab34b1b8b805"
 dependencies = [
  "anyhow",
  "bincode",
@@ -765,7 +771,7 @@ dependencies = [
  "num_enum 0.6.1",
  "serde",
  "tokio-util",
- "uuid",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -982,7 +988,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "uuid",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -1004,11 +1010,11 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 [[package]]
 name = "dropshot"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#66aa7652f61e821171d632994040cd370234ca39"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#c719b41bc4ba46e3e9e5d85f6efffab694e0f0ff"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64 0.21.0",
+ "base64 0.21.2",
  "bytes",
  "camino",
  "chrono",
@@ -1023,7 +1029,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "proc-macro2",
- "rustls 0.21.0",
+ "rustls 0.21.1",
  "rustls-pemfile",
  "schemars",
  "serde",
@@ -1038,16 +1044,16 @@ dependencies = [
  "slog-term",
  "tokio",
  "tokio-rustls 0.24.0",
- "toml 0.7.3",
+ "toml 0.7.4",
  "usdt",
- "uuid",
+ "uuid 1.3.3",
  "version_check",
 ]
 
 [[package]]
 name = "dropshot_endpoint"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#66aa7652f61e821171d632994040cd370234ca39"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#c719b41bc4ba46e3e9e5d85f6efffab694e0f0ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1636,7 +1642,7 @@ checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.21.0",
+ "rustls 0.21.1",
  "tokio",
  "tokio-rustls 0.24.0",
 ]
@@ -1761,7 +1767,7 @@ dependencies = [
  "thiserror",
  "trust-dns-proto",
  "trust-dns-resolver",
- "uuid",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -2131,7 +2137,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "uuid",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -2353,8 +2359,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-postgres",
- "toml 0.7.3",
- "uuid",
+ "toml 0.7.4",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -2379,7 +2385,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml 0.7.3",
+ "toml 0.7.4",
  "walkdir",
 ]
 
@@ -2475,7 +2481,7 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
- "uuid",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -2505,7 +2511,7 @@ dependencies = [
  "slog-dtrace",
  "thiserror",
  "tokio",
- "uuid",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -2693,7 +2699,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "backoff",
- "base64 0.21.0",
+ "base64 0.21.2",
  "bhyve_api",
  "cfg-if",
  "crucible-client-types",
@@ -2717,7 +2723,7 @@ dependencies = [
  "tokio-tungstenite",
  "toml 0.5.11",
  "tracing",
- "uuid",
+ "uuid 1.3.3",
  "vte",
 ]
 
@@ -2734,7 +2740,7 @@ dependencies = [
  "tracing-appender",
  "tracing-bunyan-formatter",
  "tracing-subscriber",
- "uuid",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -2764,7 +2770,7 @@ dependencies = [
  "phd-testcase",
  "propolis-client",
  "tracing",
- "uuid",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -2849,7 +2855,7 @@ dependencies = [
  "chrono",
  "fallible-iterator",
  "postgres-protocol",
- "uuid",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -2931,9 +2937,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
@@ -3054,7 +3060,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "usdt",
- "uuid",
+ "uuid 1.3.3",
  "viona_api",
 ]
 
@@ -3063,7 +3069,7 @@ name = "propolis-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64 0.21.0",
+ "base64 0.21.2",
  "clap 4.3.0",
  "futures",
  "libc",
@@ -3076,14 +3082,14 @@ dependencies = [
  "slog-term",
  "tokio",
  "tokio-tungstenite",
- "uuid",
+ "uuid 1.3.3",
 ]
 
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "crucible-client-types",
  "futures",
  "progenitor",
@@ -3098,7 +3104,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-tungstenite",
- "uuid",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -3118,7 +3124,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "base64 0.21.0",
+ "base64 0.21.2",
  "bit_field",
  "bitvec",
  "bytes",
@@ -3163,7 +3169,7 @@ dependencies = [
  "tokio-util",
  "toml 0.5.11",
  "usdt",
- "uuid",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -3357,7 +3363,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3376,7 +3382,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.0",
+ "rustls 0.21.1",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -3531,9 +3537,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
 dependencies = [
  "log",
  "ring",
@@ -3547,7 +3553,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
 ]
 
 [[package]]
@@ -3602,7 +3608,8 @@ dependencies = [
  "schemars_derive",
  "serde",
  "serde_json",
- "uuid",
+ "uuid 0.8.2",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -3697,9 +3704,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -3715,9 +3722,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3777,9 +3784,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
  "serde",
 ]
@@ -4120,7 +4127,7 @@ dependencies = [
  "slog",
  "thiserror",
  "tokio",
- "uuid",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -4468,7 +4475,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
 dependencies = [
- "rustls 0.21.0",
+ "rustls 0.21.1",
  "tokio",
 ]
 
@@ -4509,9 +4516,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -4521,18 +4528,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
  "serde",
@@ -4933,9 +4940,15 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.2"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+
+[[package]]
+name = "uuid"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [
  "getrandom",
  "serde",
@@ -5336,9 +5349,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,3 @@ usdt = { version = "0.3.5", default-features = false }
 uuid = "1.3.2"
 vte = "0.10.1"
 
-#[patch."https://github.com/oxidecomputer/crucible"]
-#crucible = { path = "../crucible/upstairs" }
-#crucible-client-types = { path = "../crucible/crucible-client-types" }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,8 @@ chrono = "0.4.19"
 clap = "4.2"
 const_format = "0.2"
 crossbeam-channel = "0.5"
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "8757b3fb55a1763382ad7111144bc60ec72af23d" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "8757b3fb55a1763382ad7111144bc60ec72af23d" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "c7879bc8fbf68d977eb1c983cb0bab34b1b8b805" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "c7879bc8fbf68d977eb1c983cb0bab34b1b8b805" }
 ctrlc = "3.2"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
 enum-iterator = "1.4.1"
@@ -143,3 +143,8 @@ tracing-subscriber = "0.3.14"
 usdt = { version = "0.3.5", default-features = false }
 uuid = "1.3.2"
 vte = "0.10.1"
+
+#[patch."https://github.com/oxidecomputer/crucible"]
+#crucible = { path = "../crucible/upstairs" }
+#crucible-client-types = { path = "../crucible/crucible-client-types" }
+

--- a/bin/propolis-server/src/lib/stats.rs
+++ b/bin/propolis-server/src/lib/stats.rs
@@ -115,7 +115,6 @@ pub async fn start_oximeter_server(
     let dropshot_config = ConfigDropshot {
         bind_address: my_address,
         request_body_max_bytes: 2048,
-        tls: None,
     };
 
     let logging_config =

--- a/bin/propolis-server/src/main.rs
+++ b/bin/propolis-server/src/main.rs
@@ -185,7 +185,6 @@ async fn main() -> anyhow::Result<()> {
             let config_dropshot = ConfigDropshot {
                 bind_address: propolis_addr,
                 request_body_max_bytes: 1024 * 1024, // 1M for ISO bytes
-                ..Default::default()
             };
 
             let log = build_logger();


### PR DESCRIPTION
Pick up the following PRs:

- Accept a length for pantry validation requests
- use workspace dependencies
- Allow some jobs to remain behind
- Update the test_mem.sh test to show region sizes too.
- Test live repair using dummy downstairs
- test-live-repair is not finishing, disable for now
- New dtrace counters for upstairs state of downstairs connections
- Allow dsc more than three downstairs.
- Fix LR hang, polish dtrace, make CI test more
- Update all Omicron packages in Cargo.lock
- Fix double counting of repair jobs
- remove some &mut self for Downstairs
- Update Rust crate slog-term to 2.9
- Update Rust crate proptest to 1.2.0
- Update Rust crate uuid to 1.3.3
- Update Rust crate reedline to 0.19.1
- Update Rust crate libc to 0.2.144
- Update Rust crate base64 to 0.21.2

Also ran the following to deal with cargo conflicts:

    cargo update -p base64@0.21.0
    cargo update -p dropshot

Also adds commented out patch section for Crucible to Cargo.toml