### PR TITLE
[propolis-client] implement Sink for InstanceSerialConsoleHelper

### DIFF
--- a/bin/propolis-cli/src/main.rs
+++ b/bin/propolis-cli/src/main.rs
@@ -9,7 +9,7 @@ use std::{
 
 use anyhow::{anyhow, Context};
 use clap::{Parser, Subcommand};
-use futures::future;
+use futures::{future, SinkExt};
 use propolis_client::handmade::{
     api::{
         DiskRequest, InstanceEnsureRequest, InstanceMigrateInitiateRequest,


### PR DESCRIPTION
This allows arbitrary `Sink` combinators, and in particular the
combinators in [`cancel-safe-futures`](https://github.com/oxidecomputer/cancel-safe-futures/),
to be used against `InstanceSerialConsoleHelper`.

This should not be disruptive to most users since the `send(item)` API removed here matches the `futures::SinkExt::send(item)` API exactly -- at most, they'll have to import `futures::SinkExt`.

This is required as part of the fix for https://github.com/oxidecomputer/omicron/issues/3356.