### PR TITLE
Clean up PCI device classes

### DIFF
--- a/lib/propolis/src/hw/chipset/i440fx.rs
+++ b/lib/propolis/src/hw/chipset/i440fx.rs
@@ -362,7 +362,8 @@ impl Piix4HostBridge {
             device_id: PIIX4_HB_DEV_ID,
             sub_vendor_id: VENDOR_OXIDE,
             sub_device_id: PIIX4_HB_SUB_DEV_ID,
-            class: 0x06,
+            class: pci::bits::CLASS_BRIDGE,
+            subclass: pci::bits::SUBCLASS_BRIDGE_HOST,
             ..Default::default()
         })
         .finish();
@@ -416,8 +417,8 @@ impl Piix3Lpc {
             device_id: PIIX3_ISA_DEV_ID,
             sub_vendor_id: VENDOR_OXIDE,
             sub_device_id: PIIX3_ISA_SUB_DEV_ID,
-            class: 0x06,
-            subclass: 0x01,
+            class: pci::bits::CLASS_BRIDGE,
+            subclass: pci::bits::SUBCLASS_BRIDGE_ISA,
             ..Default::default()
         })
         .add_custom_cfg(PIR_OFFSET as u8, PIR_LEN as u8)
@@ -758,8 +759,11 @@ impl Piix3PM {
             device_id: PIIX4_PM_DEV_ID,
             sub_vendor_id: VENDOR_OXIDE,
             sub_device_id: PIIX4_PM_SUB_DEV_ID,
-            class: 0x06,
-            subclass: 0x80,
+            class: pci::bits::CLASS_BRIDGE,
+            subclass: pci::bits::SUBCLASS_BRIDGE_OTHER,
+            // Linux will complain about the PM-timer being potentially slow if
+            // it detects the ACPI device exposing a revision prior to 0x3.
+            revision_id: 0x3,
             ..Default::default()
         })
         .add_custom_cfg(PMCFG_OFFSET as u8, PMCFG_LEN as u8)

--- a/lib/propolis/src/hw/nvme/mod.rs
+++ b/lib/propolis/src/hw/nvme/mod.rs
@@ -488,7 +488,7 @@ impl PciNvme {
             sub_vendor_id: VENDOR_OXIDE,
             sub_device_id: PROPOLIS_NVME_DEV_ID,
             class: pci::bits::CLASS_STORAGE,
-            subclass: pci::bits::SUBCLASS_NVM,
+            subclass: pci::bits::SUBCLASS_STORAGE_NVM,
             prog_if: pci::bits::PROGIF_ENTERPRISE_NVME,
             ..Default::default()
         });

--- a/lib/propolis/src/hw/pci/bits.rs
+++ b/lib/propolis/src/hw/pci/bits.rs
@@ -49,12 +49,19 @@ pub const CLASS_MULTIMEDIA: u8 = 4;
 pub const CLASS_MEMORY: u8 = 5;
 pub const CLASS_BRIDGE: u8 = 6;
 
+// Sub-classes under CLASS_STORAGE
+pub const SUBCLASS_STORAGE_NVM: u8 = 8;
+
+// Sub-classes under CLASS_BRIDGE
+pub const SUBCLASS_BRIDGE_HOST: u8 = 0;
+pub const SUBCLASS_BRIDGE_ISA: u8 = 1;
+pub const SUBCLASS_BRIDGE_OTHER: u8 = 0x80;
+
 pub const HEADER_TYPE_DEVICE: u8 = 0b0;
 pub const HEADER_TYPE_BRIDGE: u8 = 0b1;
 pub const HEADER_TYPE_MULTIFUNC: u8 = 0b1000_0000;
 
-pub const SUBCLASS_NVM: u8 = 8;
-
+// Programming Interfaces for SUBCLASS_STORAGE_NVM
 pub const PROGIF_ENTERPRISE_NVME: u8 = 2;
 
 pub(super) const MASK_FUNC: u8 = 0x07;


### PR DESCRIPTION
A few magic numbers were lingering in the PIIX4 device definitions, in addition to the PIIX3PM revision ID causing dmesg noise when interrogated by modern Linux kernels.