### PR TITLE
Make the propolis zone self-assembling

### DIFF
--- a/packaging/package-manifest.toml
+++ b/packaging/package-manifest.toml
@@ -5,6 +5,7 @@ source.rust.binary_names = ["propolis-server"]
 source.rust.release = true
 source.paths = [
     { from = "packaging/smf/propolis-server", to = "/var/svc/manifest/site/propolis-server" },
+    { from = "packaging/smf/method_script.sh", to = "/opt/oxide/lib/svc/manifest/propolis/propolis.sh" },
 ]
 source.blobs = [ "alpine.iso" ]
 output.type = "zone"

--- a/packaging/smf/method_script.sh
+++ b/packaging/smf/method_script.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+. /lib/svc/share/smf_include.sh
+
+DATALINK="$(svcprop -c -p config/datalink "${SMF_FMRI}")"
+GATEWAY="$(svcprop -c -p config/gateway "${SMF_FMRI}")"
+LISTEN_ADDR="$(svcprop -c -p config/listen_addr "${SMF_FMRI}")"
+LISTEN_PORT="$(svcprop -c -p config/listen_port "${SMF_FMRI}")"
+METRIC_ADDR="$(svcprop -c -p config/metric_addr "${SMF_FMRI}")"
+
+if [[ $DATALINK == unknown ]] || [[ $GATEWAY == unknown ]]; then
+    printf 'ERROR: missing datalink or gateway' >&2
+    exit "$SMF_EXIT_ERR_CONFIG"
+fi
+
+ipadm show-addr "$DATALINK/ll" || ipadm create-addr -t -T addrconf "$DATALINK/ll"
+ipadm show-addr "$DATALINK/omicron6"  || ipadm create-addr -t -T static -a "$LISTEN_ADDR" "$DATALINK/omicron6"
+route get -inet6 default -inet6 "$GATEWAY" || route add -inet6 default -inet6 "$GATEWAY"
+
+args=(
+  'run'
+  '/var/svc/manifest/site/propolis-server/config.toml'
+  "[$LISTEN_ADDR]:$LISTEN_PORT"
+  '--metric-addr' "$METRIC_ADDR"
+)
+
+ctrun -l child -o noorphan,regent /opt/oxide/propolis-server/bin/propolis-server "${args[@]}" &

--- a/packaging/smf/method_script.sh
+++ b/packaging/smf/method_script.sh
@@ -17,6 +17,7 @@ if [[ $DATALINK == unknown ]] || [[ $GATEWAY == unknown ]]; then
     exit "$SMF_EXIT_ERR_CONFIG"
 fi
 
+ipadm delete-if "$DATALINK" || true
 ipadm show-addr "$DATALINK/ll" || ipadm create-addr -t -T addrconf "$DATALINK/ll"
 ipadm show-addr "$DATALINK/omicron6"  || ipadm create-addr -t -T static -a "$LISTEN_ADDR" "$DATALINK/omicron6"
 route get -inet6 default -inet6 "$GATEWAY" || route add -inet6 default -inet6 "$GATEWAY"

--- a/packaging/smf/propolis-server/manifest.xml
+++ b/packaging/smf/propolis-server/manifest.xml
@@ -4,6 +4,7 @@
 <service_bundle type='manifest' name='propolis-server'>
 
 <service name='system/illumos/propolis-server' type='service' version='1'>
+  <create_default_instance enabled='true' />
   <dependency name='network' grouping='require_all' restart_on='none'
     type='service'>
   <service_fmri value='svc:/milestone/network:default' />
@@ -23,7 +24,7 @@
     <propval name='datalink' type='astring' value='unknown' />
     <propval name='gateway' type='astring' value='unknown' />
     <propval name='listen_addr' type='astring' value='127.0.0.1' />
-    <propval name='listen_port' type='astring' value='17000' />
+    <propval name='listen_port' type='astring' value='12400' />
     <propval name='metric_addr' type='astring' value='127.0.0.1' />
   </property_group>
 

--- a/packaging/smf/propolis-server/manifest.xml
+++ b/packaging/smf/propolis-server/manifest.xml
@@ -4,6 +4,7 @@
 <service_bundle type='manifest' name='propolis-server'>
 
 <service name='system/illumos/propolis-server' type='service' version='1'>
+  <create_default_instance enabled='true' />
   <dependency name='network' grouping='require_all' restart_on='none'
     type='service'>
   <service_fmri value='svc:/milestone/network:default' />

--- a/packaging/smf/propolis-server/manifest.xml
+++ b/packaging/smf/propolis-server/manifest.xml
@@ -4,10 +4,13 @@
 <service_bundle type='manifest' name='propolis-server'>
 
 <service name='system/illumos/propolis-server' type='service' version='1'>
-  <create_default_instance enabled='true' />
   <dependency name='network' grouping='require_all' restart_on='none'
     type='service'>
   <service_fmri value='svc:/milestone/network:default' />
+  </dependency>
+  <dependency name='multi_user' grouping='require_all' restart_on='none'
+    type='service'>
+  <service_fmri value='svc:/milestone/multi-user:default' />
   </dependency>
 
   <method_context>

--- a/packaging/smf/propolis-server/manifest.xml
+++ b/packaging/smf/propolis-server/manifest.xml
@@ -15,16 +15,16 @@
     </method_environment>
   </method_context>
   <exec_method type='method' name='start'
-    exec='ctrun -l child -o noorphan,regent /opt/oxide/propolis-server/bin/propolis-server run /var/svc/manifest/site/propolis-server/config.toml %{config/server_addr} --metric-addr %{config/metric_addr} &amp;'
+    exec='/opt/oxide/lib/svc/manifest/propolis/propolis.sh'
     timeout_seconds='0' />
   <exec_method type='method' name='stop' exec=':kill' timeout_seconds='0' />
 
   <property_group name='config' type='application'>
-    <propval name='server_addr' type='astring' value='unknown' />
-  </property_group>
-
-  <property_group name='config' type='application'>
-    <propval name='metric_addr' type='astring' value='unknown' />
+    <propval name='datalink' type='astring' value='unknown' />
+    <propval name='gateway' type='astring' value='unknown' />
+    <propval name='listen_addr' type='astring' value='127.0.0.1' />
+    <propval name='listen_port' type='astring' value='17000' />
+    <propval name='metric_addr' type='astring' value='127.0.0.1' />
   </property_group>
 
   <property_group name='startd' type='framework'>


### PR DESCRIPTION
Uses a method script in the Propolis zone to make it self-assembling.

This should, along with a corresponding Omicron change, avoid the need to `zlogin` to the Propolis zone at any point.

Related to: https://github.com/oxidecomputer/omicron/pull/3456