### PR TITLE
Bump crucible rev to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=ae135d3d9920c1a8f5d7b2ecb9437c43e1176664#ae135d3d9920c1a8f5d7b2ecb9437c43e1176664"
+source = "git+https://github.com/oxidecomputer/crucible?rev=f78832dc7ca48bce53f23de00d557bc9320a933f#f78832dc7ca48bce53f23de00d557bc9320a933f"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=ae135d3d9920c1a8f5d7b2ecb9437c43e1176664#ae135d3d9920c1a8f5d7b2ecb9437c43e1176664"
+source = "git+https://github.com/oxidecomputer/crucible?rev=f78832dc7ca48bce53f23de00d557bc9320a933f#f78832dc7ca48bce53f23de00d557bc9320a933f"
 dependencies = [
  "base64 0.21.2",
  "schemars",
@@ -741,7 +741,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=ae135d3d9920c1a8f5d7b2ecb9437c43e1176664#ae135d3d9920c1a8f5d7b2ecb9437c43e1176664"
+source = "git+https://github.com/oxidecomputer/crucible?rev=f78832dc7ca48bce53f23de00d557bc9320a933f#f78832dc7ca48bce53f23de00d557bc9320a933f"
 dependencies = [
  "anyhow",
  "atty",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=ae135d3d9920c1a8f5d7b2ecb9437c43e1176664#ae135d3d9920c1a8f5d7b2ecb9437c43e1176664"
+source = "git+https://github.com/oxidecomputer/crucible?rev=f78832dc7ca48bce53f23de00d557bc9320a933f#f78832dc7ca48bce53f23de00d557bc9320a933f"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,8 @@ chrono = "0.4.19"
 clap = "4.2"
 const_format = "0.2"
 crossbeam-channel = "0.5"
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "ae135d3d9920c1a8f5d7b2ecb9437c43e1176664" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "ae135d3d9920c1a8f5d7b2ecb9437c43e1176664" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "f78832dc7ca48bce53f23de00d557bc9320a933f" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "f78832dc7ca48bce53f23de00d557bc9320a933f" }
 ctrlc = "3.2"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
 enum-iterator = "1.4.1"

--- a/lib/propolis/src/block/crucible.rs
+++ b/lib/propolis/src/block/crucible.rs
@@ -57,7 +57,9 @@ impl CrucibleBackend {
         log: slog::Logger,
     ) -> Result<Arc<Self>, crucible::CrucibleError> {
         // Construct the volume.
-        let volume = Volume::construct(request, producer_registry).await?;
+        let volume =
+            Volume::construct(request, producer_registry, Some(log.clone()))
+                .await?;
 
         // Decide if we need to scrub this volume or not.
         if volume.has_read_only_parent() {


### PR DESCRIPTION
Pick up the following PRs:

- fix build break caused by merging #801
- Issue extent flushes in parallel
- Add Logger Option to Volume construct method
- Update Rust crate libc to 0.2.147
- Update Rust crate percent-encoding to 2.3
- Retry jobs until they succeed
- Reorder select arms so pings can't be starved out
- Treat a skipped IO like an error IO for ACK results.
- Retry pantry requests
- Remove panics and asserts in dummy tests
- Update Rust crate csv to 1.2.2
- Update Rust crate reedline to 0.21.0

Also updated Volume::construct to take a (new) log parameter, so Crucible logs will no longer output over Propolis logs.