### PR TITLE
Switch to building on heliosv2

### DIFF
--- a/.github/buildomat/jobs/falcon-build.sh
+++ b/.github/buildomat/jobs/falcon-build.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "falcon"
 #: variety = "basic"
-#: target = "helios-latest"
+#: target = "helios-2.0"
 #: rust_toolchain = "stable"
 #: output_rules = [
 #:   "/work/release/*",

--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "image"
 #: variety = "basic"
-#: target = "helios-latest"
+#: target = "helios-2.0"
 #: rust_toolchain = "stable"
 #: output_rules = [
 #:   "/out/*",

--- a/.github/buildomat/jobs/phd-build.sh
+++ b/.github/buildomat/jobs/phd-build.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "phd-build"
 #: variety = "basic"
-#: target = "helios-latest"
+#: target = "helios-2.0"
 #: rust_toolchain = "stable"
 #: output_rules = [
 #:   "/out/*",

--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "phd-run"
 #: variety = "basic"
-#: target = "lab"
+#: target = "lab-2.0"
 #: output_rules = [
 #:	"/tmp/phd-runner.log",
 #:	"/tmp/phd-tmp-files.tar.gz",


### PR DESCRIPTION
This is a pre-requisite for moving the rack software on top of heliosv2. Once this is integrated, we can point the omicron pins at the CI artefacts built with the newer helios version.

There is unfortunately no `lab-2.0` buildomat target yet, as @jordanhendricks has noted below; that should appear next week and the PHD tests will start running again.