### PR TITLE
PHD: add Ubuntu 22.04 guest adapter

### DIFF
--- a/phd-tests/framework/src/guest_os/mod.rs
+++ b/phd-tests/framework/src/guest_os/mod.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 mod alpine;
 mod debian11_nocloud;
+mod ubuntu22_04;
 
 /// An entry in a sequence of interactions with the guest's command prompt.
 pub(super) enum CommandSequenceEntry {
@@ -37,6 +38,7 @@ pub(super) trait GuestOs {
 pub enum GuestOsKind {
     Alpine,
     Debian11NoCloud,
+    Ubuntu2204,
 }
 
 impl FromStr for GuestOsKind {
@@ -46,6 +48,7 @@ impl FromStr for GuestOsKind {
         match s {
             "alpine" => Ok(Self::Alpine),
             "debian11nocloud" => Ok(Self::Debian11NoCloud),
+            "ubuntu2204" => Ok(Self::Ubuntu2204),
             _ => Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 format!("Unrecognized guest OS kind {}", s),
@@ -60,5 +63,6 @@ pub(super) fn get_guest_os_adapter(kind: GuestOsKind) -> Box<dyn GuestOs> {
         GuestOsKind::Debian11NoCloud => {
             Box::new(debian11_nocloud::Debian11NoCloud)
         }
+        GuestOsKind::Ubuntu2204 => Box::new(ubuntu22_04::Ubuntu2204),
     }
 }

--- a/phd-tests/framework/src/guest_os/ubuntu22_04.rs
+++ b/phd-tests/framework/src/guest_os/ubuntu22_04.rs
@@ -1,0 +1,26 @@
+//! Guest OS adaptations for Ubuntu 22.04 images. These must be prepped with
+//! a cloud-init disk that is configured with the appropriate user and password.
+
+use super::{CommandSequence, CommandSequenceEntry, GuestOs};
+
+pub(super) struct Ubuntu2204;
+
+impl GuestOs for Ubuntu2204 {
+    fn get_login_sequence(&self) -> CommandSequence {
+        CommandSequence(vec![
+            CommandSequenceEntry::WaitFor("ubuntu login: "),
+            CommandSequenceEntry::WriteStr("ubuntu"),
+            CommandSequenceEntry::WaitFor("Password: "),
+            CommandSequenceEntry::WriteStr("1!Passw0rd"),
+            CommandSequenceEntry::WaitFor(self.get_shell_prompt()),
+        ])
+    }
+
+    fn get_shell_prompt(&self) -> &'static str {
+        "ubuntu@ubuntu:~$"
+    }
+
+    fn read_only_fs(&self) -> bool {
+        false
+    }
+}


### PR DESCRIPTION
This requires an Ubuntu 22.04 image that has been run through cloud-init such that the user/password combination in the adapter can be used to log in via the serial console. I've uploaded an image to catacomb that has this property.

Tested via a local run with the new guest OS type.