### PR TITLE
Disable PHD test in buildomat until CI is fixed

### DIFF
--- a/.github/buildomat/jobs/phd-build.sh
+++ b/.github/buildomat/jobs/phd-build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #:
 #: name = "phd-build"
+#: enable = false
 #: variety = "basic"
 #: target = "helios-2.0"
 #: rust_toolchain = "stable"

--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #:
 #: name = "phd-run"
+#: enable = false
 #: variety = "basic"
 #: target = "lab-2.0"
 #: output_rules = [


### PR DESCRIPTION
Without buildomat hosts in the "lab-2.0" pool, the phd-run test will automatically fail.  Disable both phd-run and phd-build jobs until they have a chance at success.