### PR TITLE
Allow 64-vCPU instances on Helios (stlouis)

### DIFF
--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -76,7 +76,7 @@ default = []
 
 # When building to be packaged for inclusion in the production ramdisk
 # (nominally an Omicron package), certain code is compiled in or out.
-omicron-build = []
+omicron-build = ["propolis/omicron-build"]
 
 # If selected, only build a mock server which does not actually spawn instances
 # (i.e. to test with a facsimile of the API on unsupported platforms)

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -52,3 +52,4 @@ rand.workspace = true
 default = []
 crucible-full = ["crucible", "crucible-client-types", "oximeter", "nexus-client"]
 falcon = ["libloading", "p9ds", "dlpi", "ispf", "rand", "softnpu-lib"]
+omicron-build = []

--- a/lib/propolis/src/vcpu.rs
+++ b/lib/propolis/src/vcpu.rs
@@ -22,6 +22,13 @@ mod probes {
     fn vm_exit(vcpuid: u32, rip: u64, code: u32) {}
 }
 
+#[cfg(not(feature = "omicron-build"))]
+pub const MAXCPU: usize = bhyve_api::VM_MAXCPU;
+
+// Helios (stlouis) is built with an expanded limit of 64
+#[cfg(feature = "omicron-build")]
+pub const MAXCPU: usize = 64;
+
 /// A handle to a virtual CPU.
 pub struct Vcpu {
     hdl: Arc<VmmHdl>,

--- a/lib/propolis/src/vmm/machine.rs
+++ b/lib/propolis/src/vmm/machine.rs
@@ -12,7 +12,7 @@ use crate::accessors::*;
 use crate::hw;
 use crate::mmio::MmioBus;
 use crate::pio::PioBus;
-use crate::vcpu::Vcpu;
+use crate::vcpu::{Vcpu, MAXCPU};
 use crate::vmm::{create_vm, CreateOpts, PhysMap, VmmHdl};
 
 /// Arbitrary limit for the top of the physical memory map.
@@ -249,7 +249,7 @@ impl Builder {
     }
     /// Sets the maximum number of CPUs for the machine.
     pub fn max_cpus(mut self, max: u8) -> Result<Self> {
-        if max == 0 || max > bhyve_api::VM_MAXCPU as u8 {
+        if max == 0 || max > MAXCPU as u8 {
             Err(Error::new(ErrorKind::InvalidInput, "maxcpu out of range"))
         } else {
             self.max_cpu = max;


### PR DESCRIPTION
With VM_MAXCPU expanded from 32 to 64 on the stlouis build of Helios, so too can the limit used for the checks in the Propolis library when constructing instance VMM resources.

Fixes #474