### PR TITLE
try reenabling PHD jobs

### DIFF
--- a/.github/buildomat/jobs/phd-build.sh
+++ b/.github/buildomat/jobs/phd-build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 #:
 #: name = "phd-build"
-#: enable = false
 #: variety = "basic"
 #: target = "helios-2.0"
 #: rust_toolchain = "stable"

--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 #:
 #: name = "phd-run"
-#: enable = false
 #: variety = "basic"
 #: target = "lab-2.0"
 #: output_rules = [
@@ -48,8 +47,6 @@ banner 'Tests'
 runner="$phddir/phd-runner"
 artifacts="$phddir/artifacts.toml"
 propolis="$phddir/propolis-server"
-
-# TODO: Leverage ZFS artifact support in PHD.
 
 ls $runner
 ls $artifacts

--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "phd-run"
 #: variety = "basic"
-#: target = "lab-2.0"
+#: target = "lab-2.0-opte-0.23"
 #: output_rules = [
 #:	"/tmp/phd-runner.log",
 #:	"/tmp/phd-tmp-files.tar.gz",


### PR DESCRIPTION
Switch the PHD run job to the `lab-2.0-opte-0.23` target per the discussion in oxidecomputer/meta#245 (this is the correct target to get a baremetal Helios 2.0 environment in the lab).