### PR TITLE
Clean up and restructure CQE handling in NVMe

### DIFF
--- a/lib/propolis/src/common.rs
+++ b/lib/propolis/src/common.rs
@@ -339,6 +339,12 @@ impl RWOp<'_, '_> {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct GuestAddr(pub u64);
 
+impl GuestAddr {
+    pub fn offset<T: Sized>(&self, count: usize) -> Self {
+        Self(self.0 + (count * std::mem::size_of::<T>()) as u64)
+    }
+}
+
 /// A region of memory within a guest VM.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct GuestRegion(pub GuestAddr, pub usize);


### PR DESCRIPTION
This attempts to consolidate some of the shared logic between NVMe completion queues and submission queues.  Additionally, addresses a theoretical issue in setting the correct phase bit in CQEs when threads race to push completions as the queue rolls over.

This is work I drafted while investigating #427.  It isn't especially high priority, but I wanted to get it cleaned up and posted, rather than stagnating in a branch.