### PR TITLE
vioblk: add flush support

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -358,7 +358,7 @@ impl<'a> MachineInitializer<'a> {
                       "len" => bytes.len());
 
                 let be = propolis::block::InMemoryBackend::create(
-                    bytes.clone(),
+                    bytes,
                     spec.readonly,
                     512,
                 )?;

--- a/bin/propolis-standalone/src/config.rs
+++ b/bin/propolis-standalone/src/config.rs
@@ -230,14 +230,9 @@ fn create_crucible_backend(
     };
     info!(log, "Creating Crucible disk from request {:?}", req);
     // QUESTION: is producer_registry: None correct here?
-    let be = block::CrucibleBackend::create(
-        req.clone(),
-        read_only,
-        None,
-        None,
-        log.clone(),
-    )
-    .unwrap();
+    let be =
+        block::CrucibleBackend::create(req, read_only, None, None, log.clone())
+            .unwrap();
     let creg =
         ChildRegister::new(&be, Some(be.get_uuid().unwrap().to_string()));
     (be, creg)

--- a/lib/propolis/src/block/crucible.rs
+++ b/lib/propolis/src/block/crucible.rs
@@ -310,7 +310,7 @@ async fn process_request(
             let offset = block.byte_offset_to_block(off as u64).await?;
             let _ = block.write(offset, crucible::Bytes::from(vec)).await?;
         }
-        block::Operation::Flush(_off, _len) => {
+        block::Operation::Flush => {
             // Send flush to crucible
             let _ = block.flush(None).await?;
         }

--- a/lib/propolis/src/block/file.rs
+++ b/lib/propolis/src/block/file.rs
@@ -103,7 +103,7 @@ impl FileBackend {
                     ));
                 }
             }
-            block::Operation::Flush(_off, _len) => {
+            block::Operation::Flush => {
                 self.fp.sync_data()?;
             }
         }

--- a/lib/propolis/src/block/in_memory.rs
+++ b/lib/propolis/src/block/in_memory.rs
@@ -99,7 +99,7 @@ impl InMemoryBackend {
                     &maps,
                 )?;
             }
-            block::Operation::Flush(_off, _len) => {
+            block::Operation::Flush => {
                 // nothing to do
             }
         }

--- a/lib/propolis/src/block/mem_async.rs
+++ b/lib/propolis/src/block/mem_async.rs
@@ -117,7 +117,7 @@ fn process_request(
                 };
             }
         }
-        block::Operation::Flush(_off, _len) => {
+        block::Operation::Flush => {
             // nothing to do
         }
     }

--- a/lib/propolis/src/block/mod.rs
+++ b/lib/propolis/src/block/mod.rs
@@ -48,7 +48,7 @@ pub enum Operation {
 
 #[derive(Copy, Clone, Debug)]
 pub enum Result {
-    Success,
+    Success = 0,
     Failure,
     Unsupported,
 }

--- a/lib/propolis/src/block/mod.rs
+++ b/lib/propolis/src/block/mod.rs
@@ -57,6 +57,9 @@ pub type BlockPayload = dyn Any + Send + Sync + 'static;
 
 /// Block device operation request
 pub struct Request {
+    /// A device specific value identifying this request.
+    id: u32,
+
     /// The type of operation requested by the block device
     op: Operation,
 
@@ -76,35 +79,44 @@ pub struct Request {
 }
 impl Request {
     pub fn new_read(
+        id: u32,
         off: usize,
         regions: Vec<GuestRegion>,
         payload: Box<BlockPayload>,
     ) -> Self {
         let op = Operation::Read(off);
-        Self { op, regions, payload: Some(payload), outstanding: None }
+        Self { id, op, regions, payload: Some(payload), outstanding: None }
     }
 
     pub fn new_write(
+        id: u32,
         off: usize,
         regions: Vec<GuestRegion>,
         payload: Box<BlockPayload>,
     ) -> Self {
         let op = Operation::Write(off);
-        Self { op, regions, payload: Some(payload), outstanding: None }
+        Self { id, op, regions, payload: Some(payload), outstanding: None }
     }
 
     pub fn new_flush(
+        id: u32,
         off: usize,
         len: usize,
         payload: Box<BlockPayload>,
     ) -> Self {
         let op = Operation::Flush(off, len);
         Self {
+            id,
             op,
             regions: Vec::new(),
             payload: Some(payload),
             outstanding: None,
         }
+    }
+
+    /// Device specific request ID.
+    pub fn id(&self) -> u32 {
+        self.id
     }
 
     /// Type of operation being issued.
@@ -142,7 +154,7 @@ impl Request {
     /// Indiciate disposition of completed request
     pub fn complete(mut self, res: Result, dev: &dyn Device) {
         let payload = self.payload.take().unwrap();
-        dev.complete(self.op, res, payload);
+        dev.complete(self.id, self.op, res, payload);
 
         // Update the outstanding I/O count
         self.outstanding
@@ -182,7 +194,13 @@ pub trait Device: Send + Sync + 'static {
     fn next(&self) -> Option<Request>;
 
     /// Complete processing of result
-    fn complete(&self, op: Operation, res: Result, payload: Box<BlockPayload>);
+    fn complete(
+        &self,
+        req_id: u32,
+        op: Operation,
+        res: Result,
+        payload: Box<BlockPayload>,
+    );
 
     /// Get an accessor to guest memory via the underlying device
     fn accessor_mem(&self) -> MemAccessor;

--- a/lib/propolis/src/block/mod.rs
+++ b/lib/propolis/src/block/mod.rs
@@ -42,8 +42,8 @@ pub enum Operation {
     Read(ByteOffset),
     /// Write to offset
     Write(ByteOffset),
-    /// Flush buffer(s) for [offset, offset + len)
-    Flush(ByteOffset, ByteLen),
+    /// Flush buffer(s)
+    Flush,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -93,12 +93,8 @@ impl Request {
         Self { op, regions, payload: Some(payload), outstanding: None }
     }
 
-    pub fn new_flush(
-        off: usize,
-        len: usize,
-        payload: Box<BlockPayload>,
-    ) -> Self {
-        let op = Operation::Flush(off, len);
+    pub fn new_flush(payload: Box<BlockPayload>) -> Self {
+        let op = Operation::Flush;
         Self {
             op,
             regions: Vec::new(),
@@ -125,7 +121,7 @@ impl Request {
             Operation::Write(_) => {
                 self.regions.iter().map(|r| mem.readable_region(r)).collect()
             }
-            Operation::Flush(_, _) => None,
+            Operation::Flush => None,
         }
     }
 
@@ -135,7 +131,7 @@ impl Request {
             Operation::Read(_) | Operation::Write(_) => {
                 self.regions.iter().map(|r| r.1).sum()
             }
-            Operation::Flush(_, len) => *len,
+            Operation::Flush => 0,
         }
     }
 

--- a/lib/propolis/src/hw/nvme/requests.rs
+++ b/lib/propolis/src/hw/nvme/requests.rs
@@ -135,11 +135,9 @@ impl PciNvme {
                     }
                     Ok(NvmCmd::Flush) => {
                         probes::nvme_flush_enqueue!(|| (qid, idx, cid));
-                        let req = Request::new_flush(
-                            0,
-                            0, // TODO: is 0 enough or do we pass total size?
-                            CompletionPayload::new(qid, cid, cqe_permit),
-                        );
+                        let req = Request::new_flush(CompletionPayload::new(
+                            qid, cid, cqe_permit,
+                        ));
                         return Some(req);
                     }
                     Ok(NvmCmd::Unknown(_)) | Err(_) => {
@@ -174,7 +172,7 @@ impl PciNvme {
             Operation::Write(..) => {
                 probes::nvme_write_complete!(|| (qid, cid, resnum));
             }
-            Operation::Flush(..) => {
+            Operation::Flush => {
                 probes::nvme_flush_complete!(|| (qid, cid, resnum));
             }
         }

--- a/lib/propolis/src/hw/virtio/block.rs
+++ b/lib/propolis/src/hw/virtio/block.rs
@@ -127,7 +127,7 @@ impl PciVirtioBlock {
                 if let Some(regions) = chain.writable_bufs(sz) {
                     let rid = self.next_req_id();
                     probes::vioblk_read_enqueue!(|| (
-                        rid as u16, off as u64, sz as u64
+                        rid, off as u64, sz as u64
                     ));
                     Ok(block::Request::new_read(
                         off,
@@ -146,7 +146,7 @@ impl PciVirtioBlock {
                 if let Some(regions) = chain.readable_bufs(sz) {
                     let rid = self.next_req_id();
                     probes::vioblk_write_enqueue!(|| (
-                        rid as u16, off as u64, sz as u64
+                        rid, off as u64, sz as u64
                     ));
                     Ok(block::Request::new_write(
                         off,
@@ -159,7 +159,7 @@ impl PciVirtioBlock {
             }
             VIRTIO_BLK_T_FLUSH => {
                 let rid = self.next_req_id();
-                probes::vioblk_flush_enqueue!(|| (rid as u16));
+                probes::vioblk_flush_enqueue!(|| (rid));
                 Ok(block::Request::new_flush(Box::new(CompletionPayload {
                     rid,
                     chain,

--- a/lib/propolis/src/hw/virtio/block.rs
+++ b/lib/propolis/src/hw/virtio/block.rs
@@ -160,11 +160,10 @@ impl PciVirtioBlock {
             VIRTIO_BLK_T_FLUSH => {
                 let rid = self.next_req_id();
                 probes::vioblk_flush_enqueue!(|| (rid as u16));
-                Ok(block::Request::new_flush(
-                    0,
-                    0,
-                    Box::new(CompletionPayload { rid, chain }),
-                ))
+                Ok(block::Request::new_flush(Box::new(CompletionPayload {
+                    rid,
+                    chain,
+                })))
             }
             _ => Err(chain),
         };
@@ -204,7 +203,7 @@ impl PciVirtioBlock {
                 block::Operation::Write(..) => {
                     probes::vioblk_write_complete!(|| (rid, resnum));
                 }
-                block::Operation::Flush(..) => {
+                block::Operation::Flush => {
                     probes::vioblk_flush_complete!(|| (rid, resnum));
                 }
             }

--- a/lib/propolis/src/hw/virtio/mod.rs
+++ b/lib/propolis/src/hw/virtio/mod.rs
@@ -60,6 +60,6 @@ pub enum VqIntr {
 #[usdt::provider(provider = "propolis")]
 mod probes {
     fn virtio_vq_notify(virtio_dev_addr: u64, virtqueue_id: u16) {}
-    fn virtio_vq_pop(cq_addr: u64, avail_idx: u16) {}
+    fn virtio_vq_pop(vq_addr: u64, desc_idx: u16, avail_idx: u16) {}
     fn virtio_vq_push(vq_addr: u64, used_idx: u16, used_len: u32) {}
 }

--- a/lib/propolis/src/hw/virtio/p9fs.rs
+++ b/lib/propolis/src/hw/virtio/p9fs.rs
@@ -209,7 +209,7 @@ pub trait P9Handler: Sync + Send + 'static {
         let mem = vq.acc_mem.access().unwrap();
 
         let mut chain = Chain::with_capacity(1);
-        let _clen = vq.pop_avail(&mut chain, &mem).unwrap() as usize;
+        let (_idx, _clen) = vq.pop_avail(&mut chain, &mem).unwrap();
 
         //TODO better as uninitialized?
         let mut data = Vec::new();

--- a/lib/propolis/src/hw/virtio/queue.rs
+++ b/lib/propolis/src/hw/virtio/queue.rs
@@ -63,8 +63,7 @@ impl VqAvail {
                 self.cur_avail_idx += Wrapping(1);
 
                 fence(Ordering::Acquire);
-                let addr = self.gpa_ring
-                    + (avail_idx as usize * mem::size_of::<u16>());
+                let addr = self.gpa_ring.offset::<u16>(avail_idx as usize);
                 return mem
                     .read(addr)
                     .map(|desc_idx| VqReq { desc_idx, avail_idx });
@@ -79,7 +78,7 @@ impl VqAvail {
         mem: &MemCtx,
     ) -> Option<VqdDesc> {
         assert!(id < rsize);
-        let addr = self.gpa_desc + (id as usize * mem::size_of::<VqdDesc>());
+        let addr = self.gpa_desc.offset::<VqdDesc>(id as usize);
         mem.read::<VqdDesc>(addr)
     }
     fn reset(&mut self) {
@@ -117,8 +116,7 @@ impl VqUsed {
 
         let idx = self.used_idx.0 & (rsize - 1);
         self.used_idx += Wrapping(1);
-        let desc_addr =
-            self.gpa_ring + (idx as usize * mem::size_of::<VqdUsed>());
+        let desc_addr = self.gpa_ring.offset::<VqdUsed>(idx as usize);
 
         let used = VqdUsed { id: id as u32, len };
         mem.write(desc_addr, &used);

--- a/lib/propolis/src/hw/virtio/queue.rs
+++ b/lib/propolis/src/hw/virtio/queue.rs
@@ -32,6 +32,12 @@ struct VqdUsed {
     len: u32,
 }
 
+#[derive(Copy, Clone, Debug)]
+pub struct VqReq {
+    desc_idx: u16,
+    avail_idx: u16,
+}
+
 pub struct VqAvail {
     /// Is populated with a valid physical address(es) for its contents
     valid: bool,
@@ -44,20 +50,24 @@ pub struct VqAvail {
     gpa_desc: GuestAddr,
 }
 impl VqAvail {
-    fn read_next_avail(&mut self, rsize: u16, mem: &MemCtx) -> Option<u16> {
+    /// If there's a request ready, pop it off the queue and return the
+    /// corresponding descriptor and available ring indicies.
+    fn read_next_avail(&mut self, rsize: u16, mem: &MemCtx) -> Option<VqReq> {
         if !self.valid {
             return None;
         }
         if let Some(idx) = mem.read::<u16>(self.gpa_idx) {
             let ndesc = Wrapping(idx) - self.cur_avail_idx;
             if ndesc.0 != 0 && ndesc.0 < rsize {
-                let read_idx = self.cur_avail_idx.0 & (rsize - 1);
+                let avail_idx = self.cur_avail_idx.0 & (rsize - 1);
                 self.cur_avail_idx += Wrapping(1);
 
                 fence(Ordering::Acquire);
-                let addr =
-                    self.gpa_ring + (read_idx as usize * mem::size_of::<u16>());
-                return mem.read(addr);
+                let addr = self.gpa_ring
+                    + (avail_idx as usize * mem::size_of::<u16>());
+                return mem
+                    .read(addr)
+                    .map(|desc_idx| VqReq { desc_idx, avail_idx });
             }
         }
         None
@@ -239,17 +249,25 @@ impl VirtQueue {
         avail.cur_avail_idx = Wrapping(info.avail_idx);
         used.used_idx = Wrapping(info.used_idx);
     }
-    pub fn pop_avail(&self, chain: &mut Chain, mem: &MemCtx) -> Option<u32> {
+    pub fn pop_avail(
+        &self,
+        chain: &mut Chain,
+        mem: &MemCtx,
+    ) -> Option<(u16, u32)> {
         assert!(chain.idx.is_none());
         let mut avail = self.avail.lock().unwrap();
-        let id = avail.read_next_avail(self.size, mem)?;
+        let req = avail.read_next_avail(self.size, mem)?;
 
-        let mut desc = avail.read_ring_descr(id, self.size, mem)?;
+        let mut desc = avail.read_ring_descr(req.desc_idx, self.size, mem)?;
         let mut flags = DescFlag::from_bits_truncate(desc.flags);
         let mut count = 0;
         let mut len = 0;
-        chain.idx = Some(id);
-        probes::virtio_vq_pop!(|| (self as *const VirtQueue as u64, id));
+        chain.idx = Some(req.desc_idx);
+        probes::virtio_vq_pop!(|| (
+            self as *const VirtQueue as u64,
+            req.desc_idx,
+            req.avail_idx,
+        ));
 
         // non-indirect descriptor(s)
         while !flags.contains(DescFlag::INDIRECT) {
@@ -273,10 +291,10 @@ impl VirtQueue {
                     desc = next;
                     flags = DescFlag::from_bits_truncate(desc.flags);
                 } else {
-                    return Some(len);
+                    return Some((req.avail_idx, len));
                 }
             } else {
-                return Some(len);
+                return Some((req.avail_idx, len));
             }
         }
         // XXX: skip indirect if not negotiated
@@ -313,7 +331,7 @@ impl VirtQueue {
                 }
             }
         }
-        Some(len)
+        Some((req.avail_idx, len))
     }
     pub fn push_used(&self, chain: &mut Chain, mem: &MemCtx) {
         assert!(chain.idx.is_some());

--- a/lib/propolis/src/hw/virtio/softnpu.rs
+++ b/lib/propolis/src/hw/virtio/softnpu.rs
@@ -320,9 +320,8 @@ impl PciVirtioSoftNpuPort {
             None => return,
         };
         let mut chain = Chain::with_capacity(1);
-        match vq.pop_avail(&mut chain, &mem) {
-            Some(val) => val as usize,
-            None => return,
+        let Some((_idx, _clen)) = vq.pop_avail(&mut chain, &mem) else {
+            return
         };
 
         // only vq.push_used if we actually read something


### PR DESCRIPTION
Partially addresses #492. Still need more work to support actually negotiating features and allowing reconfiguring block backends. But this bring us to par with the nvme device today.