### PR TITLE
Improve error message when /dev/vmmctl not present

### DIFF
--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -938,6 +938,10 @@ fn setup_instance(
 fn api_version_checks(log: &slog::Logger) -> std::io::Result<()> {
     match api_version::check() {
         Err(api_version::Error::Io(e)) => {
+            if e.kind() == ErrorKind::NotFound {
+                slog::error!(log, "Failed to open /dev/vmmctl");
+            }
+
             // IO errors _are_ fatal
             Err(e)
         }


### PR DESCRIPTION
When `/dev/vmmctl` is not present both `propolis-standalone` and `propolis-server` exit during the API version check without providing the user much context as to why. This diff logs the fact that the device node is not there so the user has a pointer where to start looking for the problem. The resulting output looks as follows:
```
arjen@helios:~/propolis/bin/propolis-server$ cargo run -- run server.cfg 127.0.0.1:3000
Aug 23 22:45:55.319 ERRO Failed to open /dev/vmmctl
Error: API version checks

Caused by:
    0: IO Error
    1: No such file or directory (os error 2)
```
```
arjen@helios:...opolis/bin/propolis-standalone$ cargo run -- vm.cfg
Aug 23 22:45:24.783 ERRO Failed to open /dev/vmmctl
Error: API version checks

Caused by:
    No such file or directory (os error 2)
```
The logging with context and nested types make this less clean than I was shooting for, but it's functional. Happy to take a different approach though.

Fixes #505.