### PR TITLE
Update crucible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,7 +674,7 @@ dependencies = [
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=29d05bf35d5d2d31d55aacf9f87176a471e18a85#29d05bf35d5d2d31d55aacf9f87176a471e18a85"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2234dda06e653a36beda83831fbc39c432718a20#2234dda06e653a36beda83831fbc39c432718a20"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -690,6 +690,7 @@ dependencies = [
  "futures",
  "futures-core",
  "itertools 0.11.0",
+ "libc",
  "omicron-common",
  "oximeter",
  "oximeter-producer",
@@ -717,7 +718,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=29d05bf35d5d2d31d55aacf9f87176a471e18a85#29d05bf35d5d2d31d55aacf9f87176a471e18a85"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2234dda06e653a36beda83831fbc39c432718a20#2234dda06e653a36beda83831fbc39c432718a20"
 dependencies = [
  "base64 0.21.2",
  "schemars",
@@ -729,7 +730,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=29d05bf35d5d2d31d55aacf9f87176a471e18a85#29d05bf35d5d2d31d55aacf9f87176a471e18a85"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2234dda06e653a36beda83831fbc39c432718a20#2234dda06e653a36beda83831fbc39c432718a20"
 dependencies = [
  "anyhow",
  "atty",
@@ -756,7 +757,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=29d05bf35d5d2d31d55aacf9f87176a471e18a85#29d05bf35d5d2d31d55aacf9f87176a471e18a85"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2234dda06e653a36beda83831fbc39c432718a20#2234dda06e653a36beda83831fbc39c432718a20"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,8 @@ chrono = "0.4.19"
 clap = "4.2"
 const_format = "0.2"
 crossbeam-channel = "0.5"
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "29d05bf35d5d2d31d55aacf9f87176a471e18a85" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "29d05bf35d5d2d31d55aacf9f87176a471e18a85" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "2234dda06e653a36beda83831fbc39c432718a20" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "2234dda06e653a36beda83831fbc39c432718a20" }
 ctrlc = "3.2"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
 enum-iterator = "1.4.1"


### PR DESCRIPTION
Update crucible rev to include this lovely set of fixes, mostly performance related:

eliminate spurious metadb-related syncs (#881)
ACK the write after adding it to the work queue (#874) Use arc4random_buf or getrandom instead of ChaCha20Rng (#878) Fix crutest in README (#879)
Show client_id in panic messages (#843)
Reduce sqlite page cache size to 64KiB (#876)
Only flush extents that might actually be dirty. (#875)