### PR TITLE
Use hex formatting for unhandled MMIO/PIO/MSRs

### DIFF
--- a/bin/propolis-server/src/lib/vcpu_tasks.rs
+++ b/bin/propolis-server/src/lib/vcpu_tasks.rs
@@ -135,21 +135,21 @@ impl VcpuTasks {
             entry = vcpu.process_vmexit(&exit).unwrap_or_else(|| {
                 match exit.kind {
                     VmExitKind::Inout(pio) => {
-                        debug!(&log, "Unhandled pio {:?}", pio;
+                        debug!(&log, "Unhandled pio {:x?}", pio;
                                        "rip" => exit.rip);
                         VmEntry::InoutFulfill(exits::InoutRes::emulate_failed(
                             &pio,
                         ))
                     }
                     VmExitKind::Mmio(mmio) => {
-                        debug!(&log, "Unhandled mmio {:?}", mmio;
+                        debug!(&log, "Unhandled mmio {:x?}", mmio;
                                        "rip" => exit.rip);
                         VmEntry::MmioFulfill(exits::MmioRes::emulate_failed(
                             &mmio,
                         ))
                     }
                     VmExitKind::Rdmsr(msr) => {
-                        debug!(&log, "Unhandled rdmsr {:x}", msr;
+                        debug!(&log, "Unhandled rdmsr {:08x}", msr;
                                        "rip" => exit.rip);
                         let _ = vcpu.set_reg(
                             bhyve_api::vm_reg_name::VM_REG_GUEST_RAX,
@@ -162,8 +162,7 @@ impl VcpuTasks {
                         VmEntry::Run
                     }
                     VmExitKind::Wrmsr(msr, val) => {
-                        debug!(&log, "Unhandled wrmsr {:x}", msr;
-                                       "val" => val,
+                        debug!(&log, "Unhandled wrmsr {:08x} <- {:08x}", msr, val;
                                        "rip" => exit.rip);
                         VmEntry::Run
                     }

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -505,7 +505,7 @@ impl Instance {
                     VmExitKind::Inout(pio) => {
                         slog::error!(
                             &log,
-                            "Unhandled pio {:?}", pio; "rip" => exit.rip
+                            "Unhandled pio {:x?}", pio; "rip" => exit.rip
                         );
                         VmEntry::InoutFulfill(exits::InoutRes::emulate_failed(
                             &pio,
@@ -514,7 +514,7 @@ impl Instance {
                     VmExitKind::Mmio(mmio) => {
                         slog::error!(
                             &log,
-                            "Unhandled mmio {:?}", mmio; "rip" => exit.rip
+                            "Unhandled mmio {:x?}", mmio; "rip" => exit.rip
                         );
                         VmEntry::MmioFulfill(exits::MmioRes::emulate_failed(
                             &mmio,
@@ -523,7 +523,7 @@ impl Instance {
                     VmExitKind::Rdmsr(msr) => {
                         slog::error!(
                             &log,
-                            "Unhandled rdmsr {:x}", msr; "rip" => exit.rip
+                            "Unhandled rdmsr {:#08x}", msr; "rip" => exit.rip
                         );
                         let _ = vcpu.set_reg(
                             bhyve_api::vm_reg_name::VM_REG_GUEST_RAX,
@@ -538,8 +538,8 @@ impl Instance {
                     VmExitKind::Wrmsr(msr, val) => {
                         slog::error!(
                             &log,
-                            "Unhandled wrmsr {:x} <- {:x}", msr, val;
-                            "rip" => exit.rip
+                            "Unhandled wrmsr {:#08x} <- {:#08x}", msr, val;
+                            "rip" => #%exit.rip
                         );
                         VmEntry::Run
                     }


### PR DESCRIPTION
I got tired of doing radix conversion when examining the details of these unhandled exits.