### PR TITLE
Make Oximeter producer endpoint registration best effort

### DIFF
--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -465,8 +465,6 @@ async fn instance_ensure_common(
     let producer_registry = if let Some(cfg) =
         server_context.static_config.metrics.as_ref()
     {
-        let producer_registry =
-            if let Some(cfg) = server_context.static_config.metrics.as_ref() {
                 // TODO: Any errors in creating and registering the oximeter
                 // server here are swallowed, and we continue on without being
                 // able to serve metrics for this instance. It's a challenge
@@ -488,9 +486,6 @@ async fn instance_ensure_common(
             } else {
                 None
             };
-    } else {
-        None
-    };
 
     let (stop_ch, stop_recv) = oneshot::channel();
 

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -465,27 +465,22 @@ async fn instance_ensure_common(
     let producer_registry = if let Some(cfg) =
         server_context.static_config.metrics.as_ref()
     {
-                // TODO: Any errors in creating and registering the oximeter
-                // server here are swallowed, and we continue on without being
-                // able to serve metrics for this instance. It's a challenge
-                // today to separate the creation of the producer registry from
-                // the registering of its server endpoint with the oximeter
-                // consumer, and in reality, the only error path here is if we
-                // could not contact the oximeter consumer (e.g., it is down for
-                // some reason).
-                //
-                // See omicron#3956 for tracking the longer term fix.
-                register_oximeter(
-                    server_context,
-                    cfg,
-                    properties.id,
-                    rqctx.log.clone(),
-                )
-                .await
-                .ok()
-            } else {
-                None
-            };
+        // TODO: Any errors in creating and registering the oximeter
+        // server here are swallowed, and we continue on without being
+        // able to serve metrics for this instance. It's a challenge
+        // today to separate the creation of the producer registry from
+        // the registering of its server endpoint with the oximeter
+        // consumer, and in reality, the only error path here is if we
+        // could not contact the oximeter consumer (e.g., it is down for
+        // some reason).
+        //
+        // See omicron#3956 for tracking the longer term fix.
+        register_oximeter(server_context, cfg, properties.id, rqctx.log.clone())
+            .await
+            .ok()
+    } else {
+        None
+    };
 
     let (stop_ch, stop_recv) = oneshot::channel();
 

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -465,16 +465,14 @@ async fn instance_ensure_common(
     let producer_registry = if let Some(cfg) =
         server_context.static_config.metrics.as_ref()
     {
-        // TODO: Any errors in creating and registering the oximeter
+        // TODO(#513): Any errors in creating and registering the oximeter
         // server here are swallowed, and we continue on without being
         // able to serve metrics for this instance. It's a challenge
         // today to separate the creation of the producer registry from
-        // the registering of its server endpoint with the oximeter
+        // the registration of its server endpoint with the oximeter
         // consumer, and in reality, the only error path here is if we
         // could not contact the oximeter consumer (e.g., it is down for
         // some reason).
-        //
-        // See omicron#3956 for tracking the longer term fix.
         register_oximeter(server_context, cfg, properties.id, rqctx.log.clone())
             .await
             .ok()

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -460,26 +460,16 @@ async fn instance_ensure_common(
         }));
     }
 
-    let producer_registry =
-        if let Some(cfg) = server_context.static_config.metrics.as_ref() {
-            Some(
-                register_oximeter(
-                    server_context,
-                    cfg,
-                    properties.id,
-                    rqctx.log.clone(),
-                )
-                .await
-                .map_err(|e| {
-                    HttpError::for_internal_error(format!(
-                        "failed to register to produce metrics: {}",
-                        e
-                    ))
-                })?,
-            )
-        } else {
-            None
-        };
+    let producer_registry = if let Some(cfg) =
+        server_context.static_config.metrics.as_ref()
+    {
+        // TODO: issue ##
+        register_oximeter(server_context, cfg, properties.id, rqctx.log.clone())
+            .await
+            .ok()
+    } else {
+        None
+    };
 
     let (stop_ch, stop_recv) = oneshot::channel();
 

--- a/bin/propolis-server/src/lib/stats.rs
+++ b/bin/propolis-server/src/lib/stats.rs
@@ -156,7 +156,7 @@ pub async fn start_oximeter_server(
                 warn!(
                     log,
                     "Could not connect to oximeter (retrying in {}s):\n{}",
-                    RETRY_WAIT_SEC
+                    RETRY_WAIT_SEC,
                     e,
                 );
 

--- a/bin/propolis-server/src/lib/stats.rs
+++ b/bin/propolis-server/src/lib/stats.rs
@@ -156,8 +156,8 @@ pub async fn start_oximeter_server(
                 warn!(
                     log,
                     "Could not connect to oximeter (retrying in {}s):\n{}",
-                    e,
                     RETRY_WAIT_SEC
+                    e,
                 );
 
                 tokio::time::sleep(tokio::time::Duration::from_secs(

--- a/bin/propolis-server/src/lib/stats.rs
+++ b/bin/propolis-server/src/lib/stats.rs
@@ -138,9 +138,9 @@ pub async fn start_oximeter_server(
         logging_config,
     };
 
-    const N_RETRY: u8 = 2;
+    const N_ATTEMPTS: u8 = 2;
     const RETRY_WAIT_SEC: u64 = 1;
-    for _ in 0..N_RETRY {
+    for _ in 0..N_ATTEMPTS {
         let server = Server::start(&config).await;
         match server {
             Ok(server) => {
@@ -167,7 +167,7 @@ pub async fn start_oximeter_server(
             }
         }
     }
-    error!(log, "Could not connect to oximeter after {} retries", N_RETRY);
+    error!(log, "Could not connect to oximeter after {} attempts", N_ATTEMPTS);
 
     None
 }

--- a/bin/propolis-server/src/main.rs
+++ b/bin/propolis-server/src/main.rs
@@ -40,7 +40,7 @@ enum Args {
         #[clap(name = "PROPOLIS_IP:PORT", action)]
         propolis_addr: SocketAddr,
 
-        /// IP:Port for the Oximeter register address, which is Nexus.
+        /// IP:Port for the Oximeter register address
         #[clap(long, action)]
         metric_addr: Option<SocketAddr>,
 


### PR DESCRIPTION
The easy fix for #497, moving on if propolis-server couldn't connect to oximeter after a couple of retries. The better fixes are tracked in #513 and oxidecomputer/omicron#3956.

**Testing: Cannot connect to oximeter**
I tested out the error case with the convenient propolis-server `--metric-addr` option (pointing it at an IP/port that isn't running anything), then ensured I could create and run a VM.

Before, this experiment would hang as seen in #497:
```
jordan@rodman:~/src/propolis$ pfexec ./target/release/propolis-server run confs/helios.conf --metric-addr 127.0.0.1:9000 127.0.0.1:8000
Aug 26 12:42:58.921 INFO reservoir too small (0MiB) to use for guest memory
Aug 26 12:42:58.921 INFO Metrics server will use MetricsEndpointConfig { propolis_addr: 127.0.0.1:8000, metric_addr: 127.0.0.1:9000 }
Aug 26 12:42:58.921 INFO Starting server...
Aug 26 12:42:58.921 INFO listening, local_addr: 127.0.0.1:8000
Aug 26 12:43:04.913 INFO accepted connection, remote_addr: 127.0.0.1:42015, local_addr: 127.0.0.1:8000
Aug 26 12:43:04.914 INFO Attempt to register 127.0.0.1:0 with Nexus/Oximeter at 127.0.0.1:9000, uri: /instance, method: PUT, req_id: ad0b9a76-3de3-4e12-8f8b-d211a5131e15, remote_addr: 127.0.0.1:42015, local_addr: 127.0.0.1:8000
Aug 26 12:43:04.960 ERRO Can't connect to oximeter server:
Error registering as metric producer: Communication Error: error sending request for url (http://127.0.0.1:9000/metrics/producers): error trying to connect: tcp connect error: Connection refused (os error 146)
```

With this change, some warnings/errors print in the logs, but then it moves on (the messages are hard to read because of #512):
```
jordan@rodman:~/src/propolis$ pfexec ./target/release/propolis-server run confs/helios.conf --metric-addr 127.0.0.1:9000 127.0.0.1:8000                   
Aug 26 12:17:22.123 INFO reservoir too small (0MiB) to use for guest memory                                                                               
Aug 26 12:17:22.123 INFO Metrics server will use MetricsEndpointConfig { propolis_addr: 127.0.0.1:8000, metric_addr: 127.0.0.1:9000 }                     
Aug 26 12:17:22.123 INFO Starting server...                                                                                                               
Aug 26 12:17:22.123 INFO listening, local_addr: 127.0.0.1:8000                                                                                            
Aug 26 12:17:27.083 INFO accepted connection, remote_addr: 127.0.0.1:61485, local_addr: 127.0.0.1:8000                                                    
Aug 26 12:17:27.083 INFO Attempt to register 127.0.0.1:0 with Nexus/Oximeter at 127.0.0.1:9000, uri: /instance, method: PUT, req_id: a696b50a-a424-4c94-bb
05-12a10f65cece, remote_addr: 127.0.0.1:61485, local_addr: 127.0.0.1:8000                                                                                 
Aug 26 12:17:27.084 INFO listening, local_addr: 127.0.0.1:49861, component: dropshot                                                                      
Aug 26 12:17:27.115 WARN Aug 26 12:17:27.115Could not connect to oximeter (retrying in 1s):                                                               
Error registering as metric producer: Communication Error: error sending request for url (http://127.0.0.1:9000/metrics/producers): error trying to connec
t: tcp connect error: Connection refused (os error 146) , INFOuri :received request to begin graceful shutdown , /instancelocal_addr, :method :127 .0PUT.0
, .1req_id:49861:,  componenta696b50a-a424-4c94-bb05-12a10f65cece:,  remote_addrdropshot:                                                                 
 127.0.0.1:61485, local_addr: 127.0.0.1:8000                                                                                                              
Aug 26 12:17:28.117 INFO listening, local_addr: 127.0.0.1:37062, component: dropshot                                                                      
Aug 26 12:17:28.146 Aug 26 12:17:28.146WARN  INFOCould not connect to oximeter (retrying in 1s):                                                          
Error registering as metric producer: Communication Error: error sending request for url (http://127.0.0.1:9000/metrics/producers): error trying to connec
t: tcp connect error: Connection refused (os error 146) , received request to begin graceful shutdownuri, :local_addr :/instance , 127.method0.:0. 1:PUT37062, , req_idcomponent::  a696b50a-a424-4c94-bb05-12a10f65cecedropshot,                                                                                   
remote_addr: 127.0.0.1:61485, local_addr: 127.0.0.1:8000                                                                                                  
Aug 26 12:17:29.148 ERRO Could not connect to oximeter after 2 retries, uri: /instance, method: PUT, req_id: a696b50a-a424-4c94-bb05-12a10f65cece, remote_
addr: 127.0.0.1:61485, local_addr: 127.0.0.1:8000                                                                                                         
Aug 26 12:17:29.148 WARN Unable to determine Nexus endpoint for IPv4 addresses, uri: /instance, method: PUT, req_id: a696b50a-a424-4c94-bb05-12a10f65cece,
 remote_addr: 127.0.0.1:61485, local_addr: 127.0.0.1:8000   
 Aug 26 12:17:29.148 INFO initializing new VM, bootrom: /home/jordan/src/propolis/ovmf/OVMF_CODE.fd, use_reservoir: false, properties: InstanceProperties {
    id: 6d11c12c-0b89-4c77-a64e-700b6326aea8,                                                                                                             
    name: "vm0",                                                                                                                                          
    description: "propolis-cli generated instance",                                                                                                       
    image_id: 00000000-0000-0000-0000-000000000000,                                                                                                       
    bootrom_id: 00000000-0000-0000-0000-000000000000,                                                                                                     
    memory: 1024,                                                                                                                                         
    vcpus: 4,                                                                                                                                             
}, spec: V0(                                                                                                                                              
    InstanceSpecV0 {                
...
```