### PR TITLE
fix softnpu port order

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -547,8 +547,12 @@ impl<'a> MachineInitializer<'a> {
             return Ok(());
         }
 
-        let ports: Vec<&instance_spec::components::devices::SoftNpuPort> =
+        let mut ports: Vec<&instance_spec::components::devices::SoftNpuPort> =
             self.spec.devices.softnpu_ports.values().collect();
+
+        // SoftNpu ports are named <topology>_<node>_vnic<N> by falcon, where
+        // <N> indicates the intended order.
+        ports.sort_by_key(|p| &p.name);
 
         let mut data_links: Vec<String> = Vec::new();
         for x in &ports {


### PR DESCRIPTION
When Falcon creates SoftNpu ports, it does so with the following naming scheme:

```
<topology-name>_<node-name>_vnic<N>
````

The `<N>` indicates the order in which the programmer ordered the ports in the Falcon topology and must be preserved.

This commit performs a sort on SoftNpu ports according to this naming scheme before they are passed into the SoftNpu constructor to preserve the intended order.