### PR TITLE
Make storage backend config more flexible and consistent

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -304,7 +304,10 @@ impl<'a> MachineInitializer<'a> {
 
                 let be = propolis::block::CrucibleBackend::create(
                     vcr,
-                    spec.readonly,
+                    propolis::block::BackendOpts {
+                        read_only: Some(spec.readonly),
+                        ..Default::default()
+                    },
                     self.producer_registry.clone(),
                     nexus_client.clone(),
                     self.log.new(
@@ -327,7 +330,10 @@ impl<'a> MachineInitializer<'a> {
                 let nworkers = NonZeroUsize::new(8).unwrap();
                 let be = propolis::block::FileBackend::create(
                     &spec.path,
-                    spec.readonly,
+                    propolis::block::BackendOpts {
+                        read_only: Some(spec.readonly),
+                        ..Default::default()
+                    },
                     nworkers,
                     self.log.new(
                         slog::o!("component" => format!("file-{}", spec.path)),
@@ -359,8 +365,11 @@ impl<'a> MachineInitializer<'a> {
 
                 let be = propolis::block::InMemoryBackend::create(
                     bytes,
-                    spec.readonly,
-                    512,
+                    propolis::block::BackendOpts {
+                        block_size: Some(512),
+                        read_only: Some(spec.readonly),
+                        ..Default::default()
+                    },
                 )?;
 
                 let child = inventory::ChildRegister::new(

--- a/crates/propolis-server-config/src/lib.rs
+++ b/crates/propolis-server-config/src/lib.rs
@@ -105,10 +105,20 @@ impl Device {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct BlockOpts {
+    pub block_size: Option<u32>,
+    pub read_only: Option<bool>,
+    pub skip_flush: Option<bool>,
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct BlockDevice {
     #[serde(default, rename = "type")]
     pub bdtype: String,
+
+    #[serde(flatten)]
+    pub opts: BlockOpts,
 
     #[serde(flatten, default)]
     pub options: BTreeMap<String, toml::Value>,

--- a/crates/propolis-standalone-config/src/lib.rs
+++ b/crates/propolis-standalone-config/src/lib.rs
@@ -48,9 +48,19 @@ pub struct Device {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct BlockOpts {
+    pub block_size: Option<u32>,
+    pub read_only: Option<bool>,
+    pub skip_flush: Option<bool>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BlockDevice {
     #[serde(default, rename = "type")]
     pub bdtype: String,
+
+    #[serde(flatten)]
+    pub block_opts: BlockOpts,
 
     #[serde(flatten, default)]
     pub options: BTreeMap<String, toml::Value>,

--- a/lib/propolis/src/block/mod.rs
+++ b/lib/propolis/src/block/mod.rs
@@ -35,6 +35,10 @@ pub use mem_async::MemAsyncBackend;
 pub type ByteOffset = usize;
 pub type ByteLen = usize;
 
+/// When `block_size` is not specified in [BackendOpts], and the backend itself
+/// is not choosing a block size, a default of 512B is used.
+pub const DEFAULT_BLOCK_SIZE: u32 = 512;
+
 /// Type of operations which may be issued to a virtual block device.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Operation {
@@ -168,8 +172,26 @@ pub struct DeviceInfo {
     pub block_size: u32,
     /// Device size in blocks (see above)
     pub total_size: u64,
-    /// Is the device writable
-    pub writable: bool,
+    /// Is the device read-only
+    pub read_only: bool,
+}
+
+/// Options to control behavior of block backend.
+///
+/// Values for omitted fields will be determined by the backend, likely by
+/// querying the underlying resource.  If values provided conflict with said
+/// resource, the backend may fail its initialization with an error.
+#[derive(Default, Copy, Clone)]
+pub struct BackendOpts {
+    /// Size (in bytes) per block
+    pub block_size: Option<u32>,
+
+    /// Disallow writes (returning errors if attempted) and report a
+    /// non-writable device (if frontend is capable)
+    pub read_only: Option<bool>,
+
+    /// Force flush requests to be skipped (turned into no-op)
+    pub skip_flush: Option<bool>,
 }
 
 /// API to access a virtualized block device.

--- a/lib/propolis/src/hw/nvme/requests.rs
+++ b/lib/propolis/src/hw/nvme/requests.rs
@@ -87,7 +87,7 @@ impl PciNvme {
                 let cmd = NvmCmd::parse(sub);
 
                 match cmd {
-                    Ok(NvmCmd::Write(cmd)) if !state.binfo.writable => {
+                    Ok(NvmCmd::Write(cmd)) if state.binfo.read_only => {
                         let off = state.nlb_to_size(cmd.slba as usize) as u64;
                         let size = state.nlb_to_size(cmd.nlb as usize) as u64;
                         probes::nvme_write_enqueue!(|| (

--- a/lib/propolis/src/hw/virtio/block.rs
+++ b/lib/propolis/src/hw/virtio/block.rs
@@ -206,7 +206,7 @@ impl VirtioDevice for PciVirtioBlock {
         feat |= VIRTIO_BLK_F_SEG_MAX;
         feat |= VIRTIO_BLK_F_FLUSH;
 
-        if !self.info.writable {
+        if self.info.read_only {
             feat |= VIRTIO_BLK_F_RO;
         }
         feat


### PR DESCRIPTION
With the integration of #504, certain lab workloads exhibited pathological performance due to the added flushes.  It would be nice to be able to elide said flushes when desired.

Additionally, making handling of such general configuration items (block size, read-only status, flush elision) consistent across the backends would be a welcomed improvement.