### PR TITLE
Use correct register sizes for PIIX3 PM device

### DIFF
--- a/lib/propolis/src/hw/pci/bus.rs
+++ b/lib/propolis/src/hw/pci/bus.rs
@@ -247,15 +247,7 @@ impl Inner {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    fn prep() -> (Arc<PioBus>, Arc<MmioBus>, MemAccessor, MsiAccessor) {
-        (
-            Arc::new(PioBus::new()),
-            Arc::new(MmioBus::new(u32::MAX as usize)),
-            MemAccessor::new_orphan(),
-            MsiAccessor::new_orphan(),
-        )
-    }
+    use crate::hw::pci::test::Scaffold;
 
     #[derive(Default)]
     struct TestDev {
@@ -277,8 +269,8 @@ mod test {
 
     #[test]
     fn empty() {
-        let (pio, mmio, mem, msi) = prep();
-        let bus = Bus::new(&pio, &mmio, mem, msi);
+        let scaffold = Scaffold::new();
+        let bus = scaffold.create_bus();
 
         for slot in 0..31 {
             for func in 0..7 {
@@ -294,8 +286,8 @@ mod test {
 
     #[test]
     fn set_multifunc() {
-        let (pio, mmio, mem, msi) = prep();
-        let bus = Bus::new(&pio, &mmio, mem, msi);
+        let scaffold = Scaffold::new();
+        let bus = scaffold.create_bus();
 
         let first = Arc::new(TestDev::default());
         let other_slot = Arc::new(TestDev::default());

--- a/lib/propolis/src/hw/pci/mod.rs
+++ b/lib/propolis/src/hw/pci/mod.rs
@@ -19,8 +19,11 @@ pub mod bits;
 pub mod bridge;
 pub mod bus;
 mod cfgspace;
-mod device;
+pub(crate) mod device;
 pub mod topology;
+
+#[cfg(test)]
+pub(crate) mod test;
 
 pub use bus::Bus;
 pub use device::*;
@@ -349,101 +352,4 @@ impl PcieCfgDecoder {
 
 pub mod migrate {
     pub use super::device::migrate::*;
-}
-
-#[cfg(test)]
-mod test {
-    use crate::common::{RWOp, ReadOp, WriteOp};
-
-    use super::{bits, Bdf, PcieCfgDecoder};
-
-    #[test]
-    fn pcie_decoder() {
-        let pcie = PcieCfgDecoder::new(bits::PCIE_MAX_BUSES_PER_ECAM_REGION);
-        let mut buf = [0u8; 4];
-        let mut ro = ReadOp::from_buf(0, &mut buf);
-        pcie.service(RWOp::Read(&mut ro), |bdf, rwo| {
-            assert_eq!(*bdf, Bdf::new(0, 0, 0).unwrap());
-            assert!(matches!(rwo, RWOp::Read(_)));
-            assert_eq!(rwo.offset(), 0);
-            assert_eq!(rwo.len(), 4);
-            Some(())
-        });
-
-        let buf = [0u8; 16];
-        let mut wo = WriteOp::from_buf(0x400, &buf);
-        pcie.service(RWOp::Write(&mut wo), |bdf, rwo| {
-            assert_eq!(*bdf, Bdf::new(0, 0, 0).unwrap());
-            assert!(matches!(rwo, RWOp::Write(_)));
-            assert_eq!(rwo.offset(), 0x400);
-            assert_eq!(rwo.len(), 16);
-            Some(())
-        })
-    }
-
-    #[test]
-    fn pcie_decoder_multiple_bdfs() {
-        let pcie = PcieCfgDecoder::new(bits::PCIE_MAX_BUSES_PER_ECAM_REGION);
-        let mut buf = [0u8; 4];
-        let mut ro = ReadOp::from_buf(1_usize << 12, &mut buf);
-        pcie.service(RWOp::Read(&mut ro), |bdf, rwo| {
-            assert_eq!(*bdf, Bdf::new(0, 0, 1).unwrap());
-            assert_eq!(rwo.offset(), 0);
-            Some(())
-        });
-
-        let mut ro =
-            ReadOp::from_buf(4_usize << 15 | 3_usize << 12 | 0x123, &mut buf);
-        pcie.service(RWOp::Read(&mut ro), |bdf, rwo| {
-            assert_eq!(*bdf, Bdf::new(0, 4, 3).unwrap());
-            assert_eq!(rwo.offset(), 0x123);
-            Some(())
-        });
-
-        let mut ro = ReadOp::from_buf(
-            133_usize << 20 | 7_usize << 15 | 1_usize << 12 | 0x337,
-            &mut buf,
-        );
-        pcie.service(RWOp::Read(&mut ro), |bdf, rwo| {
-            assert_eq!(*bdf, Bdf::new(133, 7, 1).unwrap());
-            assert_eq!(rwo.offset(), 0x337);
-            Some(())
-        });
-    }
-
-    #[test]
-    fn pcie_decoder_min_buses() {
-        let pcie = PcieCfgDecoder::new(4);
-        let mut buf = [0u8; 4];
-        for seg_group in 0..4 {
-            for bus in 0..4 {
-                let mut ro =
-                    ReadOp::from_buf((seg_group * 4 + bus) << 20, &mut buf);
-                pcie.service(RWOp::Read(&mut ro), |bdf, rwo| {
-                    assert_eq!(
-                        *bdf,
-                        Bdf::new(bus as u8, 0, 0).unwrap(),
-                        "group {}, bus {}",
-                        seg_group,
-                        bus
-                    );
-                    assert_eq!(rwo.offset(), 0);
-                    Some(())
-                });
-            }
-        }
-    }
-
-    #[test]
-    fn pcie_decoder_access_spans_multiple_devs() {
-        let pcie = PcieCfgDecoder::new(bits::PCIE_MAX_BUSES_PER_ECAM_REGION);
-        let mut buf = [0u8; 8];
-        let mut ro = ReadOp::from_buf(0xffc, &mut buf);
-
-        // This access spans multiple functions, so the decoder can't
-        // meaningfully address a single BDF and should therefore not
-        // invoke the closure.
-        pcie.service(RWOp::Read(&mut ro), |_bdf, _rwo| panic!());
-        assert_eq!(buf, [0xffu8; 8]);
-    }
 }

--- a/lib/propolis/src/hw/pci/test.rs
+++ b/lib/propolis/src/hw/pci/test.rs
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::sync::Arc;
+
+use crate::accessors::*;
+use crate::common::{RWOp, ReadOp, WriteOp};
+use crate::mmio::MmioBus;
+use crate::pio::PioBus;
+
+use super::bus::Bus;
+use super::{bits, Bdf, PcieCfgDecoder};
+
+// Common test prep setup
+
+pub(crate) struct Scaffold {
+    pub bus_mmio: Arc<MmioBus>,
+    pub bus_pio: Arc<PioBus>,
+    pub acc_mem: MemAccessor,
+    pub acc_msi: MsiAccessor,
+}
+impl Scaffold {
+    pub(crate) fn new() -> Self {
+        Self {
+            bus_mmio: Arc::new(MmioBus::new(u32::MAX as usize)),
+            bus_pio: Arc::new(PioBus::new()),
+            acc_mem: MemAccessor::new_orphan(),
+            acc_msi: MsiAccessor::new_orphan(),
+        }
+    }
+
+    pub(crate) fn create_bus(&self) -> Bus {
+        Bus::new(
+            &self.bus_pio,
+            &self.bus_mmio,
+            self.acc_mem.child(),
+            self.acc_msi.child(),
+        )
+    }
+}
+
+// PCI-generic tests
+
+#[test]
+fn pcie_decoder() {
+    let pcie = PcieCfgDecoder::new(bits::PCIE_MAX_BUSES_PER_ECAM_REGION);
+    let mut buf = [0u8; 4];
+    let mut ro = ReadOp::from_buf(0, &mut buf);
+    pcie.service(RWOp::Read(&mut ro), |bdf, rwo| {
+        assert_eq!(*bdf, Bdf::new(0, 0, 0).unwrap());
+        assert!(matches!(rwo, RWOp::Read(_)));
+        assert_eq!(rwo.offset(), 0);
+        assert_eq!(rwo.len(), 4);
+        Some(())
+    });
+
+    let buf = [0u8; 16];
+    let mut wo = WriteOp::from_buf(0x400, &buf);
+    pcie.service(RWOp::Write(&mut wo), |bdf, rwo| {
+        assert_eq!(*bdf, Bdf::new(0, 0, 0).unwrap());
+        assert!(matches!(rwo, RWOp::Write(_)));
+        assert_eq!(rwo.offset(), 0x400);
+        assert_eq!(rwo.len(), 16);
+        Some(())
+    })
+}
+
+#[test]
+fn pcie_decoder_multiple_bdfs() {
+    let pcie = PcieCfgDecoder::new(bits::PCIE_MAX_BUSES_PER_ECAM_REGION);
+    let mut buf = [0u8; 4];
+    let mut ro = ReadOp::from_buf(1_usize << 12, &mut buf);
+    pcie.service(RWOp::Read(&mut ro), |bdf, rwo| {
+        assert_eq!(*bdf, Bdf::new(0, 0, 1).unwrap());
+        assert_eq!(rwo.offset(), 0);
+        Some(())
+    });
+
+    let mut ro =
+        ReadOp::from_buf(4_usize << 15 | 3_usize << 12 | 0x123, &mut buf);
+    pcie.service(RWOp::Read(&mut ro), |bdf, rwo| {
+        assert_eq!(*bdf, Bdf::new(0, 4, 3).unwrap());
+        assert_eq!(rwo.offset(), 0x123);
+        Some(())
+    });
+
+    let mut ro = ReadOp::from_buf(
+        133_usize << 20 | 7_usize << 15 | 1_usize << 12 | 0x337,
+        &mut buf,
+    );
+    pcie.service(RWOp::Read(&mut ro), |bdf, rwo| {
+        assert_eq!(*bdf, Bdf::new(133, 7, 1).unwrap());
+        assert_eq!(rwo.offset(), 0x337);
+        Some(())
+    });
+}
+
+#[test]
+fn pcie_decoder_min_buses() {
+    let pcie = PcieCfgDecoder::new(4);
+    let mut buf = [0u8; 4];
+    for seg_group in 0..4 {
+        for bus in 0..4 {
+            let mut ro =
+                ReadOp::from_buf((seg_group * 4 + bus) << 20, &mut buf);
+            pcie.service(RWOp::Read(&mut ro), |bdf, rwo| {
+                assert_eq!(
+                    *bdf,
+                    Bdf::new(bus as u8, 0, 0).unwrap(),
+                    "group {}, bus {}",
+                    seg_group,
+                    bus
+                );
+                assert_eq!(rwo.offset(), 0);
+                Some(())
+            });
+        }
+    }
+}
+
+#[test]
+fn pcie_decoder_access_spans_multiple_devs() {
+    let pcie = PcieCfgDecoder::new(bits::PCIE_MAX_BUSES_PER_ECAM_REGION);
+    let mut buf = [0u8; 8];
+    let mut ro = ReadOp::from_buf(0xffc, &mut buf);
+
+    // This access spans multiple functions, so the decoder can't
+    // meaningfully address a single BDF and should therefore not
+    // invoke the closure.
+    pcie.service(RWOp::Read(&mut ro), |_bdf, _rwo| panic!());
+    assert_eq!(buf, [0xffu8; 8]);
+}


### PR DESCRIPTION
DevResD and DevResG are both 2-byte registers.  The previous handler was trying to emit 4-byte values for them, resulting in a blown assertion.

Fixes #520
