### PR TITLE
Wire up bits for CPUID customization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpuid_profile_config"
+version = "0.0.0"
+dependencies = [
+ "propolis",
+ "serde",
+ "serde_derive",
+ "thiserror",
+ "toml 0.7.6",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3029,6 +3040,7 @@ dependencies = [
  "crucible-client-types",
  "dladm",
  "dlpi",
+ "enum-iterator",
  "erased-serde",
  "futures",
  "ispf",
@@ -3172,6 +3184,7 @@ dependencies = [
 name = "propolis-server-config"
 version = "0.0.0"
 dependencies = [
+ "cpuid_profile_config",
  "serde",
  "serde_derive",
  "thiserror",
@@ -3210,6 +3223,7 @@ dependencies = [
 name = "propolis-standalone-config"
 version = "0.0.0"
 dependencies = [
+ "cpuid_profile_config",
  "num_enum 0.5.11",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ panic = "abort"
 # Internal crates
 bhyve_api = { path = "crates/bhyve-api" }
 bhyve_api_sys = { path = "crates/bhyve-api/sys" }
+cpuid_profile_config = { path = "crates/cpuid-profile-config" }
 dladm = { path = "crates/dladm" }
 propolis-server-config = { path = "crates/propolis-server-config" }
 propolis-standalone-config = { path = "crates/propolis-standalone-config" }

--- a/bin/propolis-server/src/lib/spec.rs
+++ b/bin/propolis-server/src/lib/spec.rs
@@ -603,13 +603,11 @@ impl ServerSpecBuilder {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::BTreeMap, path::PathBuf};
-
     use crucible_client_types::VolumeConstructionRequest;
     use propolis_client::handmade::api::Slot;
     use uuid::Uuid;
 
-    use crate::config::{self, Config};
+    use crate::config::Config;
 
     use super::*;
 
@@ -625,13 +623,7 @@ mod test {
                 memory: 512,
                 vcpus: 4,
             },
-            &Config::new(
-                PathBuf::from_str("").unwrap(),
-                config::Chipset::default(),
-                BTreeMap::new(),
-                BTreeMap::new(),
-                Vec::new(),
-            ),
+            &Config::default(),
         )
     }
 

--- a/bin/propolis-utils/README.md
+++ b/bin/propolis-utils/README.md
@@ -7,7 +7,7 @@ development activities, but are otherwise not meant for general consumption.
 
 - `savex`:  Extract data fields from a `propolis-standalone` instance which was
   halted and saved with the `-s` flag.
-- `cpuid-gen`: Generated CPUID profile using the legacy emulated output from the
+- `cpuid-gen`: Generated `cpuid` profile using the legacy emulated output from the
   local host CPU, as filtered by the kernel VMM logic.
 - `rsrvrctl`: Manipulate the kernel VMM memory reservoir in the same manner
   offered by the utility shipped by the OS

--- a/bin/propolis-utils/src/bin/cpuid-gen.rs
+++ b/bin/propolis-utils/src/bin/cpuid-gen.rs
@@ -96,7 +96,7 @@ impl PartialOrd for CpuidKey {
     }
 }
 
-/// Query CPUID through bhyve-defined masks
+/// Query `cpuid` through bhyve-defined masks
 fn query_cpuid(vm: &VmmFd, eax: u32, ecx: u32) -> anyhow::Result<Cpuid> {
     let mut data = bhyve_api::vm_legacy_cpuid {
         vlc_eax: eax,
@@ -107,7 +107,7 @@ fn query_cpuid(vm: &VmmFd, eax: u32, ecx: u32) -> anyhow::Result<Cpuid> {
     Ok(Cpuid::from(&data))
 }
 
-/// Query CPUID directly from host CPU
+/// Query `cpuid` directly from host CPU
 fn query_raw_cpuid(eax: u32, ecx: u32) -> Cpuid {
     let mut res = Cpuid::default();
 

--- a/crates/bhyve-api/src/lib.rs
+++ b/crates/bhyve-api/src/lib.rs
@@ -578,7 +578,7 @@ pub enum ApiVersion {
     /// Made hlt-on-exit a required CPU feature, and enabled by default in vmm
     V6 = 6,
 
-    /// Adds ability to control CPUID results for guest vCPUs
+    /// Adds ability to control `cpuid` results for guest vCPUs
     V5 = 5,
 }
 impl ApiVersion {

--- a/crates/cpuid-profile-config/Cargo.toml
+++ b/crates/cpuid-profile-config/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "propolis-standalone-config"
+name = "cpuid_profile_config"
 version = "0.0.0"
 license = "MPL-2.0"
 edition = "2021"
@@ -9,8 +9,8 @@ test = false
 doctest = false
 
 [dependencies]
-cpuid_profile_config.workspace = true
-num_enum.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 toml.workspace = true
+propolis.workspace = true
+thiserror.workspace = true

--- a/crates/cpuid-profile-config/src/lib.rs
+++ b/crates/cpuid-profile-config/src/lib.rs
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Copy, Clone, Debug, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum CpuVendor {
+    Amd,
+    Intel,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct CpuidProfile {
+    pub vendor: CpuVendor,
+    #[serde(flatten, default)]
+    pub leaf: BTreeMap<String, toml::Value>,
+}
+
+/// `cpuid` entry parsed from a configured profile
+#[derive(Copy, Clone)]
+pub struct CpuidEntry {
+    /// Function (eax) to match for `cpuid` leaf
+    pub func: u32,
+    /// Index (ecx) to (optionally) match for `cpuid` leaf
+    pub idx: Option<u32>,
+
+    /// Values (eax, ebx, ecx, edx) for `cpuid` leaf
+    pub values: [u32; 4],
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CpuidParseError {
+    #[error("Unable to parse leaf {0}: {1}")]
+    Leaf(String, std::num::ParseIntError),
+    #[error("Unable to parse values: {0}")]
+    Values(&'static str),
+}
+
+impl TryFrom<&CpuidProfile> for Vec<CpuidEntry> {
+    type Error = CpuidParseError;
+
+    fn try_from(value: &CpuidProfile) -> Result<Self, Self::Error> {
+        let mut entries = Vec::with_capacity(value.leaf.len());
+
+        for (leaf, values) in value.leaf.iter() {
+            let (func, idx) = match leaf.split_once('-') {
+                None => (
+                    u32::from_str_radix(leaf, 16)
+                        .map_err(|e| CpuidParseError::Leaf(leaf.clone(), e))?,
+                    None,
+                ),
+                Some((func_part, idx_part)) => (
+                    u32::from_str_radix(func_part, 16)
+                        .map_err(|e| CpuidParseError::Leaf(leaf.clone(), e))?,
+                    Some(
+                        u32::from_str_radix(idx_part, 16).map_err(|e| {
+                            CpuidParseError::Leaf(leaf.clone(), e)
+                        })?,
+                    ),
+                ),
+            };
+            let raw_regs = values
+                .as_array()
+                .ok_or(CpuidParseError::Values("expected array of values"))?;
+            if raw_regs.len() != 4 {
+                return Err(CpuidParseError::Values("expected 4 cpuid values"));
+            }
+            let mut values = [0u32; 4];
+            for (v, raw) in values.iter_mut().zip(raw_regs.iter()) {
+                let num = raw.as_integer().ok_or(CpuidParseError::Values(
+                    "leaf values must be numeric",
+                ))?;
+                *v = u32::try_from(num).map_err(|_e| {
+                    CpuidParseError::Values("leaf values must be valid u32")
+                })?;
+            }
+            entries.push(CpuidEntry { func, idx, values });
+        }
+        Ok(entries)
+    }
+}

--- a/crates/propolis-server-config/Cargo.toml
+++ b/crates/propolis-server-config/Cargo.toml
@@ -9,6 +9,7 @@ test = false
 doctest = false
 
 [dependencies]
+cpuid_profile_config.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 toml.workspace = true

--- a/crates/propolis-standalone-config/src/lib.rs
+++ b/crates/propolis-standalone-config/src/lib.rs
@@ -7,6 +7,8 @@ use std::collections::BTreeMap;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
 
+pub use cpuid_profile_config::*;
+
 #[derive(TryFromPrimitive, IntoPrimitive, Eq, PartialEq)]
 #[repr(u8)]
 pub enum SnapshotTag {
@@ -26,6 +28,17 @@ pub struct Config {
 
     #[serde(default, rename = "block_dev")]
     pub block_devs: BTreeMap<String, BlockDevice>,
+
+    #[serde(default, rename = "cpuid")]
+    pub cpuid_profiles: BTreeMap<String, CpuidProfile>,
+}
+impl Config {
+    pub fn cpuid_profile(&self) -> Option<&CpuidProfile> {
+        match self.main.cpuid_profile.as_ref() {
+            Some(name) => self.cpuid_profiles.get(name),
+            None => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -35,6 +48,7 @@ pub struct Main {
     pub bootrom: String,
     pub memory: usize,
     pub use_reservoir: Option<bool>,
+    pub cpuid_profile: Option<String>,
 }
 
 /// A hard-coded device, either enabled by default or accessible locally

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -11,6 +11,7 @@ bitflags.workspace = true
 bitstruct.workspace = true
 byteorder.workspace = true
 lazy_static.workspace = true
+enum-iterator.workspace = true
 num_enum.workspace = true
 thiserror.workspace = true
 bhyve_api.workspace = true

--- a/lib/propolis/src/cpuid.rs
+++ b/lib/propolis/src/cpuid.rs
@@ -1,0 +1,454 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![allow(unused)]
+
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::num::NonZeroU8;
+use std::ops::Bound;
+
+use bhyve_api::vcpu_cpuid_entry;
+use enum_iterator::Sequence;
+
+/// Values for a cpuid leaf
+#[derive(Copy, Clone, Debug)]
+pub struct Entry {
+    pub eax: u32,
+    pub ebx: u32,
+    pub ecx: u32,
+    pub edx: u32,
+}
+impl Entry {
+    pub fn zero() -> Self {
+        Self { eax: 0, ebx: 0, ecx: 0, edx: 0 }
+    }
+}
+impl From<[u32; 4]> for Entry {
+    fn from(value: [u32; 4]) -> Self {
+        Self { eax: value[0], ebx: value[1], ecx: value[2], edx: value[3] }
+    }
+}
+
+/// Matching criteria for function (%eax) and sub-function (%ecx) to identify a
+/// specific leaf of cpuid information
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Debug)]
+pub struct Ident(
+    /// Function (%eax) value
+    pub u32,
+    /// Sub-function (%ecx) value, if any
+    pub Option<u32>,
+);
+
+/// Set of cpuid leafs
+#[derive(Clone)]
+pub struct Set {
+    map: BTreeMap<Ident, Entry>,
+    pub vendor: VendorKind,
+}
+
+impl Set {
+    pub fn new(vendor: VendorKind) -> Self {
+        Set { map: BTreeMap::new(), vendor }
+    }
+    pub fn new_host() -> Self {
+        let vendor = VendorKind::try_from(host_query(Ident(0, None)))
+            .expect("host CPU should be from recognized vendor");
+        Self::new(vendor)
+    }
+
+    pub fn insert(&mut self, ident: Ident, entry: Entry) -> Option<Entry> {
+        self.map.insert(ident, entry)
+    }
+    pub fn remove(&mut self, ident: Ident) -> Option<Entry> {
+        self.map.remove(&ident)
+    }
+    pub fn remove_all(&mut self, func: u32) {
+        self.map.retain(|ident, _val| ident.0 != func);
+    }
+    pub fn get(&self, ident: Ident) -> Option<&Entry> {
+        self.map.get(&ident)
+    }
+    pub fn get_mut(&mut self, ident: Ident) -> Option<&mut Entry> {
+        self.map.get_mut(&ident)
+    }
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    pub fn iter(&self) -> Iter {
+        Iter(self.map.iter())
+    }
+
+    pub fn for_regs(&self, eax: u32, ecx: u32) -> Option<Entry> {
+        if let Some(ent) = self.map.get(&Ident(eax, Some(ecx))) {
+            // Exact match
+            Some(*ent)
+        } else if let Some(ent) = self.map.get(&Ident(eax, None)) {
+            // Function-only match
+            Some(*ent)
+        } else {
+            None
+        }
+    }
+}
+impl From<Set> for Vec<bhyve_api::vcpu_cpuid_entry> {
+    fn from(value: Set) -> Self {
+        let mut out = Vec::with_capacity(value.map.len());
+        out.extend(value.map.iter().map(|(ident, leaf)| {
+            let vce_flags = match ident.1.as_ref() {
+                Some(_) => bhyve_api::VCE_FLAG_MATCH_INDEX,
+                None => 0,
+            };
+            bhyve_api::vcpu_cpuid_entry {
+                vce_function: ident.0,
+                vce_index: ident.1.unwrap_or(0),
+                vce_flags,
+                vce_eax: leaf.eax,
+                vce_ebx: leaf.ebx,
+                vce_ecx: leaf.ecx,
+                vce_edx: leaf.edx,
+                ..Default::default()
+            }
+        }));
+        out
+    }
+}
+
+/// Convert a [vcpu_cpuid_entry](bhyve_api::vcpu_cpuid_entry) into an ([Ident],
+/// [Entry]) tuple, suitable for insertion into a [Set].
+///
+/// This would be implemented as a [From] trait if rust let us.
+pub fn from_raw(value: bhyve_api::vcpu_cpuid_entry) -> (Ident, Entry) {
+    let idx = if value.vce_flags & bhyve_api::VCE_FLAG_MATCH_INDEX != 0 {
+        Some(value.vce_index)
+    } else {
+        None
+    };
+
+    (
+        Ident(value.vce_function, idx),
+        Entry {
+            eax: value.vce_eax,
+            ebx: value.vce_ebx,
+            ecx: value.vce_ecx,
+            edx: value.vce_edx,
+        },
+    )
+}
+
+pub struct Iter<'a>(std::collections::btree_map::Iter<'a, Ident, Entry>);
+impl<'a> Iterator for Iter<'a> {
+    type Item = (&'a Ident, &'a Entry);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SpecializeError {
+    #[error("unsupported cache level")]
+    UnsupportedCacheLevel,
+    #[error("missing vcpu count")]
+    MissingVcpuCount,
+}
+
+/// Specialize a set of cpuid leafs for provided attributes.
+///
+/// This includes things such as a CPU topology (cores/threads/etc), a given
+/// vCPU ID (APIC, core/thread ID, etc), or other info tidbits.
+#[derive(Default)]
+pub struct Specializer {
+    has_smt: bool,
+    num_vcpu: Option<NonZeroU8>,
+    vcpuid: Option<i32>,
+    vendor_kind: Option<VendorKind>,
+    cpu_topo_populate: BTreeSet<TopoKind>,
+    cpu_topo_clear: BTreeSet<TopoKind>,
+    do_cache_topo: bool,
+}
+impl Specializer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Specify number of vCPUs in instance, and if SMT is enabled
+    pub fn with_vcpu_count(self, count: NonZeroU8, has_smt: bool) -> Self {
+        Self { num_vcpu: Some(count), has_smt, ..self }
+    }
+
+    /// Specify vCPU ID to specialize for
+    pub fn with_vcpuid(self, vcpuid: i32) -> Self {
+        assert!((vcpuid as usize) < bhyve_api::VM_MAXCPU);
+        Self { vcpuid: Some(vcpuid), ..self }
+    }
+
+    /// Specify CPU vendor
+    pub fn with_vendor(self, vendor: VendorKind) -> Self {
+        Self { vendor_kind: Some(vendor), ..self }
+    }
+
+    /// Specify CPU topology types to render into the specialized [Set]
+    ///
+    /// Without basic information such as the number of vCPUs (set by
+    /// [`Self::with_vcpu_count()`]), population of the requested topology
+    /// information may be incomplete.
+    pub fn with_cpu_topo(
+        self,
+        populate: impl Iterator<Item = TopoKind>,
+    ) -> Self {
+        let mut cpu_topo_populate = BTreeSet::new();
+
+        for t in populate {
+            cpu_topo_populate.insert(t);
+        }
+
+        Self { cpu_topo_populate, ..self }
+    }
+
+    /// Specify CPU topology types to clear from the specialized [Set]
+    ///
+    /// Some leafs in the provided set may not match expectations for the given
+    /// CPU vendor.  Without populating it with generated data (via
+    /// [`Self::with_cpu_topo()`]), those leafs can be cleared out.
+    pub fn clear_cpu_topo(self, clear: impl Iterator<Item = TopoKind>) -> Self {
+        let mut cpu_topo_clear = BTreeSet::new();
+        for t in clear {
+            cpu_topo_clear.insert(t);
+        }
+
+        Self { cpu_topo_clear, ..self }
+    }
+
+    /// Update cache topology information for specified vCPU count and SMT
+    /// capabilities
+    pub fn with_cache_topo(self) -> Self {
+        Self { do_cache_topo: true, ..self }
+    }
+
+    /// Given the attributes and modifiers specified in this [Specializer],
+    /// render an updated [Set] reflecting those data.
+    pub fn execute(self, mut set: Set) -> Result<Set, SpecializeError> {
+        // Use vendor override if provided, or else the existing one
+        if let Some(vendor) = self.vendor_kind {
+            set.vendor = vendor;
+        }
+        match set.vendor {
+            VendorKind::Amd => {
+                if self.do_cache_topo && self.num_vcpu.is_some() {
+                    self.fix_amd_cache_topo(&mut set)?;
+                }
+            }
+            _ => {}
+        }
+
+        // apply any requested topo info fixups
+        self.fix_cpu_topo(&mut set)?;
+
+        // APIC ID based on vcpuid
+        if let Some(vcpuid) = self.vcpuid.as_ref() {
+            if let Some(ent) = set.get_mut(Ident(0x1, None)) {
+                // bits 31:24 contain initial APIC ID
+                ent.ebx &= !0xff000000;
+                ent.ebx |= ((*vcpuid as u32) & 0xff) << 24;
+            }
+        }
+
+        // logical CPU count (if SMT is enabled)
+        if let Some(num_vcpu) = self.num_vcpu.as_ref() {
+            if self.has_smt {
+                if let Some(ent) = set.get_mut(Ident(0x1, None)) {
+                    ent.edx |= (0x1 << 28);
+                    // bits 23:16 contain max IDs for logical CPUs in package
+                    ent.ebx &= !0xff0000;
+                    ent.ebx |= (num_vcpu.get() as u32) << 16;
+                }
+            }
+        }
+
+        Ok(set)
+    }
+
+    fn fix_amd_cache_topo(&self, set: &mut Set) -> Result<(), SpecializeError> {
+        assert!(self.do_cache_topo);
+        let num = self.num_vcpu.unwrap().get();
+        for ecx in 0..u32::MAX {
+            match set.get_mut(Ident(0x8000001d, Some(ecx))) {
+                None => break,
+                Some(vals) => {
+                    // bits 7:5 hold the cache level
+                    let visible_count = match (vals.eax & 0b11100000 >> 5) {
+                        0b001 | 0b010 => {
+                            // L1/L2 shared by SMT siblings
+                            if self.has_smt {
+                                2
+                            } else {
+                                1
+                            }
+                        }
+                        0b011 => {
+                            // L3 shared by all vCPUs
+                            // TODO: segregate by sockets, if configured
+                            num as u32
+                        }
+                        _ => {
+                            // unceremonious handling of unexpected cache levels
+                            return Err(SpecializeError::UnsupportedCacheLevel);
+                        }
+                    };
+                    // the number of logical CPUs (minus 1) sharing this cache
+                    // is stored in bits 25:14
+                    vals.eax &= !(0xfff << 14);
+                    vals.eax |= (visible_count - 1) << 14;
+                }
+            }
+        }
+        Ok(())
+    }
+    fn fix_cpu_topo(&self, set: &mut Set) -> Result<(), SpecializeError> {
+        for topo in self.cpu_topo_populate.union(&self.cpu_topo_clear) {
+            // Nuke any existing info in order to potentially override it
+            let leaf = *topo as u32;
+            set.remove_all(leaf);
+
+            if !self.cpu_topo_populate.contains(topo) {
+                continue;
+            }
+
+            let num_vcpu = self
+                .num_vcpu
+                .ok_or(SpecializeError::MissingVcpuCount)
+                .map(|n| n.get() as u32)?;
+
+            match topo {
+                TopoKind::StdB => {
+                    // Queries with invalid ecx will get all-zeroes
+                    set.insert(Ident(leaf, None), Entry::zero());
+                    if self.has_smt {
+                        set.insert(
+                            Ident(leaf, Some(0)),
+                            Entry {
+                                eax: 0x1,
+                                ebx: 0x2,
+                                ecx: 0x100,
+                                // TODO: populate with x2APIC ID
+                                edx: 0x0,
+                            },
+                        );
+                    } else {
+                        set.insert(
+                            Ident(leaf, Some(0)),
+                            Entry {
+                                eax: 0x0,
+                                ebx: 0x1,
+                                ecx: 0x100,
+                                // TODO: populate with x2APIC ID
+                                edx: 0x0,
+                            },
+                        );
+                    }
+                    set.insert(
+                        Ident(leaf, Some(1)),
+                        Entry {
+                            eax: 0x0,
+                            ebx: num_vcpu,
+                            ecx: 0x201,
+                            // TODO: populate with x2APIC ID
+                            edx: 0x0,
+                        },
+                    );
+                }
+                TopoKind::Std1F => {
+                    // TODO: add 0x1f topo info
+                }
+                TopoKind::Ext1E => {
+                    let id = self.vcpuid.unwrap_or(0) as u32;
+                    let mut ebx = id;
+                    if self.has_smt {
+                        // bits 15:8 hold the zero-based threads-per-compute-unit
+                        ebx |= 0x100;
+                    }
+                    set.insert(
+                        Ident(leaf, None),
+                        Entry {
+                            eax: id,
+                            ebx,
+                            // TODO: populate ecx info?
+                            ecx: 0,
+                            edx: 0,
+                        },
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Flavors of CPU topology information
+#[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Sequence)]
+pub enum TopoKind {
+    /// Leaf 0xB AMD (and legacy on Intel)
+    StdB = 0xb,
+    /// Leaf 0x1F (Intel)
+    Std1F = 0x1f,
+    /// LEAF 0x8000001E (AMD)
+    Ext1E = 0x8000001e,
+}
+impl TopoKind {
+    pub fn all() -> enum_iterator::All<Self> {
+        enum_iterator::all()
+    }
+}
+
+/// Flavors of CPU vendor for cpuid specialization
+#[derive(Clone, Copy)]
+pub enum VendorKind {
+    Amd,
+    Intel,
+}
+impl VendorKind {
+    pub fn is_intel(self) -> bool {
+        matches!(self, VendorKind::Intel)
+    }
+}
+impl TryFrom<Entry> for VendorKind {
+    type Error = &'static str;
+
+    fn try_from(value: Entry) -> Result<Self, Self::Error> {
+        match (value.ebx, value.ecx, value.edx) {
+            // AuthenticAmd
+            (0x68747541, 0x444d4163, 0x69746e65) => Ok(VendorKind::Amd),
+            // GenuineIntel
+            (0x756e6547, 0x6c65746e, 0x49656e69) => Ok(VendorKind::Intel),
+            _ => Err("unrecognized vendor"),
+        }
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub fn host_query(ident: Ident) -> Entry {
+    let mut res = Entry::zero();
+
+    unsafe {
+        std::arch::asm!(
+            "push rbx",
+            "cpuid",
+            "mov {0:e}, ebx",
+            "pop rbx",
+            out(reg) res.ebx,
+            // select cpuid 0, also specify eax as clobbered
+            inout("eax") ident.0 => res.eax,
+            inout("ecx") ident.1.unwrap_or(0) => res.ecx,
+            out("edx") res.edx,
+        );
+    }
+    res
+}
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+pub fn host_query(_ident: Ident) -> Entry {
+    panic!("this is not going to work on non-x86")
+}

--- a/lib/propolis/src/lib.rs
+++ b/lib/propolis/src/lib.rs
@@ -2,8 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#![allow(clippy::style)]
-#![allow(clippy::drop_non_drop)]
+#![allow(
+    clippy::style,
+
+    // Propolis will only ever be built as 64-bit, so wider enums are acceptable
+    clippy::enum_clike_unportable_variant
+)]
 
 pub extern crate bhyve_api;
 pub extern crate usdt;
@@ -15,6 +19,7 @@ pub mod api_version;
 pub mod block;
 pub mod chardev;
 pub mod common;
+pub mod cpuid;
 pub mod exits;
 pub mod hw;
 pub mod instance;

--- a/phd-tests/framework/src/test_vm/vm_config.rs
+++ b/phd-tests/framework/src/test_vm/vm_config.rs
@@ -5,7 +5,6 @@
 //! Structures that express how a VM should be configured.
 
 use std::{
-    collections::BTreeMap,
     io::Write,
     path::{Path, PathBuf},
     sync::Arc,
@@ -175,13 +174,10 @@ impl ConfigRequest {
     }
 
     fn write_config_toml(&self, toml_path: &Path) -> anyhow::Result<()> {
-        let config = config::Config::new(
-            self.bootrom_path.clone(),
-            config::Chipset { options: BTreeMap::default() },
-            BTreeMap::new(),
-            BTreeMap::new(),
-            Vec::new(),
-        );
+        let config = config::Config {
+            bootrom: self.bootrom_path.clone(),
+            ..Default::default()
+        };
 
         let serialized = toml::ser::to_string(&config).unwrap();
         let mut cfg_file = std::fs::OpenOptions::new()


### PR DESCRIPTION
This is a first cut at making CPUID information customizable, rather than using the in-kernel vmm logic which applies limited transformations to the data exposed by the host CPU.  Basic plumbing in propolis-lib is provided, which is wired into propolis-standalone.  The same configuration syntax is defined for propolis-server, but it is going unused for now until some internal structure is hammered out.