### PR TITLE
Update Crucible to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,7 @@ dependencies = [
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=cd891a22234beecc77fce9351f0c492382adc54f#cd891a22234beecc77fce9351f0c492382adc54f"
+source = "git+https://github.com/oxidecomputer/crucible?rev=20273bcca1fd5834ebc3e67dfa7020f0e99ad681#20273bcca1fd5834ebc3e67dfa7020f0e99ad681"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=cd891a22234beecc77fce9351f0c492382adc54f#cd891a22234beecc77fce9351f0c492382adc54f"
+source = "git+https://github.com/oxidecomputer/crucible?rev=20273bcca1fd5834ebc3e67dfa7020f0e99ad681#20273bcca1fd5834ebc3e67dfa7020f0e99ad681"
 dependencies = [
  "base64 0.21.4",
  "schemars",
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=cd891a22234beecc77fce9351f0c492382adc54f#cd891a22234beecc77fce9351f0c492382adc54f"
+source = "git+https://github.com/oxidecomputer/crucible?rev=20273bcca1fd5834ebc3e67dfa7020f0e99ad681#20273bcca1fd5834ebc3e67dfa7020f0e99ad681"
 dependencies = [
  "anyhow",
  "atty",
@@ -806,7 +806,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=cd891a22234beecc77fce9351f0c492382adc54f#cd891a22234beecc77fce9351f0c492382adc54f"
+source = "git+https://github.com/oxidecomputer/crucible?rev=20273bcca1fd5834ebc3e67dfa7020f0e99ad681#20273bcca1fd5834ebc3e67dfa7020f0e99ad681"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5365,7 +5365,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=cd891a22234beecc77fce9351f0c492382adc54f#cd891a22234beecc77fce9351f0c492382adc54f"
+source = "git+https://github.com/oxidecomputer/crucible?rev=20273bcca1fd5834ebc3e67dfa7020f0e99ad681#20273bcca1fd5834ebc3e67dfa7020f0e99ad681"
 dependencies = [
  "bitflags 2.4.0",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
@@ -366,6 +377,9 @@ name = "bitflags"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitstruct"
@@ -706,7 +720,7 @@ dependencies = [
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=aeb69dda26c7e1a8b6eada425670cd4b83f91c07#aeb69dda26c7e1a8b6eada425670cd4b83f91c07"
+source = "git+https://github.com/oxidecomputer/crucible?rev=cd891a22234beecc77fce9351f0c492382adc54f#cd891a22234beecc77fce9351f0c492382adc54f"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -740,29 +754,31 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "toml 0.7.6",
+ "toml 0.8.1",
  "tracing",
  "usdt",
  "uuid",
  "version_check",
+ "workspace-hack",
 ]
 
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=aeb69dda26c7e1a8b6eada425670cd4b83f91c07#aeb69dda26c7e1a8b6eada425670cd4b83f91c07"
+source = "git+https://github.com/oxidecomputer/crucible?rev=cd891a22234beecc77fce9351f0c492382adc54f#cd891a22234beecc77fce9351f0c492382adc54f"
 dependencies = [
  "base64 0.21.4",
  "schemars",
  "serde",
  "serde_json",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=aeb69dda26c7e1a8b6eada425670cd4b83f91c07#aeb69dda26c7e1a8b6eada425670cd4b83f91c07"
+source = "git+https://github.com/oxidecomputer/crucible?rev=cd891a22234beecc77fce9351f0c492382adc54f#cd891a22234beecc77fce9351f0c492382adc54f"
 dependencies = [
  "anyhow",
  "atty",
@@ -780,25 +796,28 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio-rustls",
- "toml 0.7.6",
+ "toml 0.8.1",
  "twox-hash",
  "uuid",
  "vergen",
+ "workspace-hack",
 ]
 
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=aeb69dda26c7e1a8b6eada425670cd4b83f91c07#aeb69dda26c7e1a8b6eada425670cd4b83f91c07"
+source = "git+https://github.com/oxidecomputer/crucible?rev=cd891a22234beecc77fce9351f0c492382adc54f#cd891a22234beecc77fce9351f0c492382adc54f"
 dependencies = [
  "anyhow",
  "bincode",
  "bytes",
  "crucible-common",
  "num_enum 0.7.0",
+ "schemars",
  "serde",
  "tokio-util",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -1461,6 +1480,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.6",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1468,7 +1490,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash",
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -1477,7 +1499,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 dependencies = [
- "ahash",
+ "ahash 0.8.3",
  "allocator-api2",
 ]
 
@@ -1856,9 +1878,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libdlpi-sys"
@@ -1886,6 +1908,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2022,6 +2050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -2216,6 +2245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2908,7 +2938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.14",
 ]
 
 [[package]]
@@ -3464,9 +3494,9 @@ dependencies = [
 
 [[package]]
 name = "ringbuffer"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eba9638e96ac5a324654f8d47fb71c5e21abef0f072740ed9c1d4b0801faa37"
+checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "ron"
@@ -4486,7 +4516,19 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.14",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc1433177506450fe920e46a4f9812d0c211f5dd556da10e731a0a3dfa151f0"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.20.1",
 ]
 
 [[package]]
@@ -4503,6 +4545,19 @@ name = "toml_edit"
 version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca676d9ba1a322c1b64eb8045a5ec5c0cfb0c9d08e15e9ff622589ad5221c8fe"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -4558,7 +4613,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5c266b9ac83dedf0e0385ad78514949e6d89491269e7065bee51d2bb8ec7373"
 dependencies = [
- "ahash",
+ "ahash 0.8.3",
  "gethostname",
  "log",
  "serde",
@@ -5305,6 +5360,61 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "workspace-hack"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/crucible?rev=cd891a22234beecc77fce9351f0c492382adc54f#cd891a22234beecc77fce9351f0c492382adc54f"
+dependencies = [
+ "bitflags 2.4.0",
+ "bytes",
+ "cc",
+ "chrono",
+ "console",
+ "crossbeam-utils",
+ "crypto-common",
+ "digest",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-sink",
+ "futures-util",
+ "getrandom",
+ "hashbrown 0.12.3",
+ "hex",
+ "hyper",
+ "indexmap 1.9.3",
+ "libc",
+ "log",
+ "mio",
+ "num-traits",
+ "once_cell",
+ "openapiv3",
+ "parking_lot",
+ "phf_shared",
+ "rand",
+ "rand_chacha",
+ "rand_core",
+ "reqwest",
+ "rustls",
+ "schemars",
+ "semver 1.0.18",
+ "serde",
+ "slog",
+ "syn 1.0.109",
+ "syn 2.0.29",
+ "time 0.3.27",
+ "time-macros",
+ "tokio",
+ "tokio-util",
+ "toml_datetime",
+ "toml_edit 0.19.14",
+ "tracing",
+ "tracing-core",
+ "usdt",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,8 +96,8 @@ chrono = "0.4.19"
 clap = "4.2"
 const_format = "0.2"
 crossbeam-channel = "0.5"
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "aeb69dda26c7e1a8b6eada425670cd4b83f91c07" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "aeb69dda26c7e1a8b6eada425670cd4b83f91c07" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "cd891a22234beecc77fce9351f0c492382adc54f" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "cd891a22234beecc77fce9351f0c492382adc54f" }
 ctrlc = "3.2"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
 erased-serde = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,8 +96,8 @@ chrono = "0.4.19"
 clap = "4.2"
 const_format = "0.2"
 crossbeam-channel = "0.5"
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "cd891a22234beecc77fce9351f0c492382adc54f" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "cd891a22234beecc77fce9351f0c492382adc54f" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "20273bcca1fd5834ebc3e67dfa7020f0e99ad681" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "20273bcca1fd5834ebc3e67dfa7020f0e99ad681" }
 ctrlc = "3.2"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
 erased-serde = "0.3"


### PR DESCRIPTION
The following updates are part of this new Crucible version:

Log crucible opts on start, order crutest options (#974) Lock the Downstairs less (#966)
Cache dirty flag locally, reducing SQLite operations (#970) Make stats mutex synchronous (#961)
Optimize requeue during flow control conditions (#962) Update Rust crate base64 to 0.21.4 (#950)
Do less in control (#949)
Fix --flush-per-blocks (#959)
Fast dependency checking (#916)
Update actions/checkout action to v4 (#960)
Use `cargo hakari` for better workspace deps (#956) Update actions/checkout digest to 8ade135 (#939)
Cache block size in Guest (#947)
Update Rust crate ringbuffer to 0.15.0 (#954)
Update Rust crate toml to 0.8 (#955)
Update Rust crate reedline to 0.24.0 (#953)
Update Rust crate libc to 0.2.148 (#952)
Update Rust crate indicatif to 0.17.7 (#951)
Remove unused async (#943)
Use a synchronous mutex for bw/iop_tokens (#946)
Make flush ID non-locking (#945)
Use `oneshot` channels instead of `mpsc` for notification (#918) Use a strong type for upstairs negotiation (#941)
Add a "dynamometer" option to crucible-downstairs (#931) Get new work and active count in one lock (#938)
A bunch of misc test cleanup stuff (#937)
Wait for a snapshot to finish on all downstairs (#920) dsc and clippy cleanup. (#935)
No need to sort ackable_work (#934)
Use a strong type for repair ID (#928)
Keep new jobs sorted (#929)
Remove state_count function on Downstairs (#927)
Small cleanup to IOStateCount (#932)
let cmon and IOStateCount use ClientId (#930)
Fast return for zero length IOs (#926)
Use a strong type for client ID (#925)
A few Crucible Agent fixes (#922)
Use a newtype for `JobId` (#919)
Don't pass MutexGuard into functions (#917)
Crutest updates, rename tests, new options (#911)