### PR TITLE
Fix tungstenite buffering parameters for uart WS

### DIFF
--- a/bin/propolis-server/src/lib/mock_server.rs
+++ b/bin/propolis-server/src/lib/mock_server.rs
@@ -329,12 +329,7 @@ async fn instance_serial(
     query: Query<api::InstanceSerialConsoleStreamRequest>,
     websock: WebsocketConnection,
 ) -> dropshot::WebsocketChannelResult {
-    let config = WebSocketConfig {
-        // tune the buffer size limits down (compared to the defaults)
-        write_buffer_size: 4096,
-        max_write_buffer_size: 8192,
-        ..Default::default()
-    };
+    let config = WebSocketConfig::default();
     let mut ws_stream = WebSocketStream::from_raw_socket(
         websock.into_inner(),
         Role::Server,

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -831,13 +831,13 @@ async fn instance_serial(
     let vm = ctx.vm().await?;
     let serial = vm.com1().clone();
 
-    let config = WebSocketConfig {
-        // tune the buffer size limits down (compared to the defaults)
-        // TODO: tuning for this could be explored
-        write_buffer_size: 4096,
-        max_write_buffer_size: 8192,
-        ..Default::default()
-    };
+    // Use the default buffering paramters for the websocket configuration
+    //
+    // Because messages are written with [`StreamExt::send`], the buffer on the
+    // websocket is flushed for every message, preventing both unecessary delays
+    // of messages and the potential for the buffer to grow without bound.
+    let config = WebSocketConfig::default();
+
     let mut ws_stream = WebSocketStream::from_raw_socket(
         websock.into_inner(),
         Role::Server,


### PR DESCRIPTION
When tungstenite was updated to 0.20.x, the structure of the buffering parameters exposed by its websocket configuration changed significantly. The parameters chosen can cause `WriteBufferFull` errors if enough output accumulates in the history buffer to be sent in a message which exceeds the unnecessarily small `max_write_buffer_size`.

Using the configuration defaults, which feature an unbounded `max_write_buffer_size`, should provide acceptable behavior.

Fixes #540