### PR TITLE
Begin making Accessor interface more robust

### DIFF
--- a/lib/propolis/src/accessors.rs
+++ b/lib/propolis/src/accessors.rs
@@ -2,6 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+//! Hierarchical access control for emulated resources
+//!
+//! Device emulation logic requires access to resources which may be
+//! subsequently moderated by intervening parts of the emulation.
+//!
+//! For example: A PCI device performs DMA to guest memory.  If bus-mastering is
+//! disabled on the device, or any parent bridge in its bus hierarchy, then its
+//! contained emulation should fail any DMA accesses.
+
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex, MutexGuard, Weak};
@@ -10,174 +19,414 @@ use crate::vmm::{MemCtx, VmmHdl};
 
 type AccId = usize;
 
+const ID_NULL: AccId = 0;
 const ID_ROOT: AccId = 1;
 
-type TreeBackref<T> = Arc<Mutex<Tree<T>>>;
-
+struct TreeNode<T> {
+    parent_id: AccId,
+    node_ref: Weak<Node<T>>,
+    children: Option<BTreeSet<AccId>>,
+    name: Option<String>,
+}
+impl<T> TreeNode<T> {
+    fn new(
+        parent_id: AccId,
+        node_ref: Weak<Node<T>>,
+        name: Option<String>,
+    ) -> Self {
+        Self { parent_id, node_ref, children: None, name }
+    }
+    fn children_mut(&mut self) -> &mut BTreeSet<AccId> {
+        if self.children.is_none() {
+            self.children = Some(BTreeSet::new());
+        }
+        self.children.as_mut().unwrap()
+    }
+}
 struct Tree<T> {
     resource_root: Option<Arc<T>>,
-    nodes: BTreeMap<AccId, Weak<NodeInner<T>>>,
-    children: BTreeMap<AccId, BTreeSet<AccId>>,
+    nodes: BTreeMap<AccId, TreeNode<T>>,
     next_id: AccId,
 }
 impl<T> Tree<T> {
-    fn adopt(
-        &mut self,
-        leaf: AccId,
-        child: &mut Tree<T>,
-        parent_ref: &TreeBackref<T>,
-        mut child_root: MutexGuard<NodeEntry<T>>,
-    ) {
-        assert!(
-            self.nodes.get(&leaf).and_then(Weak::upgrade).is_some(),
-            "leaf target for reparenting missing"
-        );
-
-        let mut queue = VecDeque::new();
-        queue.push_back((ID_ROOT, leaf));
-        while let Some((child_id, local_parent_id)) = queue.pop_front() {
-            if let Some(node) =
-                child.nodes.remove(&child_id).and_then(|n| Weak::upgrade(&n))
-            {
-                let new_child_id = self.next_id();
-
-                if child_id != ID_ROOT {
-                    let mut ent = node.ent.lock().unwrap();
-                    // Place the node in our tree
-                    debug_assert_eq!(ent.id, child_id);
-                    ent.id = new_child_id;
-                    ent.tree = Arc::clone(parent_ref);
-                    drop(ent);
-                } else {
-                    // Processing for the child root node is special, as we
-                    // already hold the lock on it.
-                    debug_assert_eq!(child_root.id, child_id);
-                    child_root.id = new_child_id;
-                    child_root.tree = Arc::clone(parent_ref);
-                }
-
-                self.nodes.insert(new_child_id, Arc::downgrade(&node));
-                self.add_child(local_parent_id, new_child_id);
-
-                // Associate any resource we have
-                if let Some(res) = self.resource_root.as_ref() {
-                    let mut local = node.local.lock().unwrap();
-                    local.resource = Some(res.clone());
-                }
-
-                // Note its children so they can be processed in turn
-                if let Some(cq) = child.children.remove(&child_id) {
-                    queue.extend(cq.into_iter().map(|cid| (cid, new_child_id)));
-                }
-            }
-        }
-        debug_assert!(child.nodes.is_empty());
-    }
-    fn add_child(&mut self, parent: AccId, child: AccId) {
-        debug_assert!(
-            self.nodes.get(&parent).is_some(),
-            "parent node must exist"
-        );
-        debug_assert!(
-            self.nodes.get(&child).is_some(),
-            "child node must exist"
-        );
-        if let Some(children) = self.children.get_mut(&parent) {
-            children.insert(child);
-        } else {
-            let mut children = BTreeSet::new();
-            children.insert(child);
-            self.children.insert(parent, children);
-        }
-    }
+    /// Get the next [AccId] for a node to be added into this tree.
     fn next_id(&mut self) -> AccId {
         let res = self.next_id;
         self.next_id += 1;
         res
     }
 
-    fn new(resource: Option<Arc<T>>) -> Node<T> {
-        let tree = Arc::new(Mutex::new(Tree {
-            resource_root: resource.clone(),
+    /// Record a node in the tree, given its ID and the ID of its parent.
+    fn add_child(
+        &mut self,
+        parent: AccId,
+        child: AccId,
+        child_node: &Arc<Node<T>>,
+        name: Option<String>,
+    ) {
+        let conflict = self.nodes.insert(
+            child,
+            TreeNode::new(parent, Arc::downgrade(&child_node), name),
+        );
+        assert!(
+            conflict.is_none(),
+            "new child should not conflict with existing node"
+        );
+
+        self.nodes
+            .get_mut(&parent)
+            .expect("parent node must exist")
+            .children_mut()
+            .insert(child);
+    }
+
+    fn adopt(
+        &mut self,
+        leaf_ent: &NodeEntry<T>,
+        adopt_tree: &mut Tree<T>,
+        mut adopt_root: MutexGuard<NodeEntry<T>>,
+    ) {
+        debug_assert!(
+            self.nodes
+                .get(&leaf_ent.id)
+                .and_then(|n| Weak::upgrade(&n.node_ref))
+                .is_some(),
+            "leaf target for re-parenting missing"
+        );
+        let tree_ref = &leaf_ent.tree;
+
+        let mut queue = VecDeque::new();
+        queue.push_back((ID_ROOT, leaf_ent.id));
+        while let Some((child_id, local_parent_id)) = queue.pop_front() {
+            if let Some(mut tnode) = adopt_tree.nodes.remove(&child_id) {
+                let node = match Weak::upgrade(&tnode.node_ref) {
+                    Some(nr) => nr,
+                    None => {
+                        continue;
+                    }
+                };
+
+                let new_child_id = self.next_id();
+
+                if child_id != ID_ROOT {
+                    let mut ent = node.0.lock().unwrap();
+                    // Place the node in our tree
+                    debug_assert_eq!(ent.id, child_id);
+                    ent.id = new_child_id;
+                    ent.tree = Arc::clone(tree_ref);
+                    ent.resource = self.resource_root.clone();
+                    drop(ent);
+                } else {
+                    // Processing for the child root node is special, as we
+                    // already hold the lock on it.
+                    debug_assert_eq!(adopt_root.id, child_id);
+                    adopt_root.id = new_child_id;
+                    adopt_root.tree = Arc::clone(tree_ref);
+                    adopt_root.resource = self.resource_root.clone();
+                }
+
+                self.add_child(
+                    local_parent_id,
+                    new_child_id,
+                    &node,
+                    tnode.name.take(),
+                );
+
+                // Note its children so they can be processed in turn
+                if let Some(cq) = tnode.children.take() {
+                    queue.extend(cq.into_iter().map(|cid| (cid, new_child_id)));
+                }
+            }
+        }
+        debug_assert!(adopt_tree.nodes.is_empty());
+    }
+
+    /// Remove traces of a node from the tree as it is dropped
+    fn remove_dead_node(&mut self, id: AccId) {
+        let mut tnode =
+            self.nodes.remove(&id).expect("tree node should be present");
+
+        if tnode.parent_id != ID_NULL {
+            let removed = self
+                .nodes
+                .get_mut(&tnode.parent_id)
+                .expect("parent for node exists")
+                .children_mut()
+                .remove(&id);
+            assert!(removed, "parent should list node as child");
+        } else {
+            assert_eq!(id, ID_ROOT);
+        }
+
+        // The node is (dropping) dead, so it should no longer be reachable via
+        // the Arc<> reference.
+        debug_assert_eq!(tnode.node_ref.strong_count(), 0);
+
+        // orphan any children of the node
+        if let Some(children) = tnode.children.take() {
+            for child in children {
+                self.orphan_node(child);
+            }
+        }
+    }
+
+    /// Remove a node from this Tree into a new empty tree, with all of its
+    /// descendants in tow.
+    fn orphan_node(&mut self, id: AccId) {
+        let mut tnode =
+            self.nodes.remove(&id).expect("node-to-orphan is present in tree");
+        let node =
+            tnode.node_ref.upgrade().expect("node-to-orphan is still live");
+
+        let tree = Self::new_empty(None);
+        let mut guard = node.0.lock().unwrap();
+        // This node now becomes the root of the orphaned tree
+        guard.id = ID_ROOT;
+        guard.tree = tree.clone();
+        guard.resource.take();
+        drop(guard);
+        let mut tguard = tree.lock().unwrap();
+        tguard.nodes.insert(
+            ID_ROOT,
+            TreeNode::new(ID_NULL, Arc::downgrade(&node), None),
+        );
+
+        let children = match tnode.children.take() {
+            None => return,
+            Some(c) => c,
+        };
+        drop(node);
+        drop(tnode);
+
+        let mut needs_fixup = VecDeque::new();
+        needs_fixup.extend(children);
+
+        while let Some(child) = needs_fixup.pop_front() {
+            let mut tnode =
+                self.nodes.remove(&child).expect("child tree node is present");
+
+            // Progeny of the orphaned node which are still "live" need to be
+            // associated with the new tree.  Anything which happens to be
+            // "dead" will clean itself from the existing tree and orphan its
+            // subsequent progeny when given access to the tree lock.
+            if let Some(node) = tnode.node_ref.upgrade() {
+                let new_parent_id = if tnode.parent_id == id {
+                    // Direct children of the now-root orphan node need their
+                    // parent_id updated.  Others can be left alone in that
+                    // sense, since only the root requires an updated ID.
+                    ID_ROOT
+                } else {
+                    tnode.parent_id
+                };
+
+                tguard.add_child(
+                    new_parent_id,
+                    child,
+                    &node,
+                    tnode.name.take(),
+                );
+                let mut ent = node.0.lock().unwrap();
+                ent.tree = tree.clone();
+                ent.resource = None;
+                drop(ent);
+
+                if let Some(grandchildren) = tnode.children.take() {
+                    needs_fixup.extend(grandchildren.into_iter())
+                }
+            }
+        }
+    }
+
+    fn rename_node(&mut self, id: AccId, name: Option<String>) {
+        if let Some(tnode) = self.nodes.get_mut(&id) {
+            tnode.name = name;
+        }
+    }
+
+    fn for_each(&self, start: AccId, mut f: impl FnMut(AccId, &TreeNode<T>)) {
+        let mut to_process = VecDeque::new();
+        to_process.push_back(start);
+        while let Some(id) = to_process.pop_front() {
+            if let Some(tnode) = self.nodes.get(&id) {
+                f(id, tnode);
+                if let Some(children) = tnode.children.as_ref() {
+                    to_process.extend(children);
+                }
+            }
+        }
+    }
+
+    /// Traverse tree in order conducive to printing, applying a provided
+    /// `print_fn` to each node.
+    fn print(&self, print_fn: impl Fn(PrintNode)) {
+        // Seed the root of the tree to be processed at depth 0
+        let mut initial = BTreeSet::new();
+        initial.insert(ID_ROOT);
+        let mut to_process = vec![(0, initial)];
+
+        while let Some((depth, mut children)) = to_process.pop() {
+            let id = match children.pop_first() {
+                Some(i) => {
+                    to_process.push((depth, children));
+                    i
+                }
+                None => continue,
+            };
+
+            if let Some(tnode) = self.nodes.get(&id) {
+                let pnode =
+                    PrintNode { depth, id, name: tnode.name.as_deref() };
+                print_fn(pnode);
+                if let Some(children) = tnode.children.clone() {
+                    to_process.push((depth + 1, children))
+                }
+            }
+        }
+    }
+
+    fn new_empty(resource: Option<Arc<T>>) -> Arc<Mutex<Tree<T>>> {
+        Arc::new(Mutex::new(Tree {
+            resource_root: resource,
             nodes: BTreeMap::new(),
-            children: BTreeMap::new(),
             next_id: ID_ROOT + 1,
-        }));
-        let node = Arc::new(NodeInner {
-            ent: Mutex::new(NodeEntry { id: ID_ROOT, tree: tree.clone() }),
-            local: Mutex::new(NodeLocal { resource }),
-        });
-        let mut guard = tree.lock().unwrap();
-        guard.nodes.insert(ID_ROOT, Arc::downgrade(&node));
+        }))
+    }
+    fn new(resource: Option<Arc<T>>) -> Arc<Node<T>> {
+        let tree = Self::new_empty(resource.clone());
+        let node = Node::new_root(tree.clone());
+        node.0.lock().unwrap().resource = resource;
+
+        let mut tguard = tree.lock().unwrap();
+        tguard.nodes.insert(
+            ID_ROOT,
+            TreeNode::new(ID_NULL, Arc::downgrade(&node), None),
+        );
 
         node
     }
 }
 
+/// Data provided to `print_fn` callback as part of [`Tree::print()`]
+pub struct PrintNode<'a> {
+    pub depth: usize,
+    pub id: AccId,
+    pub name: Option<&'a str>,
+}
+
+/// Build printing function for [`Tree::print()`] which outputs a list format.
+pub fn print_basic(match_node: Option<AccId>) -> impl Fn(PrintNode) {
+    move |node| {
+        let id = node.id;
+        let pad = "  ".repeat(node.depth);
+        let highlight = if Some(id) == match_node { " ***" } else { "" };
+        let namestr = match node.name {
+            None if id == ID_ROOT => "'ROOT'".to_string(),
+            None => "<unnamed>".to_string(),
+            Some(s) => format!("'{s}'"),
+        };
+
+        println!("{pad}- {{ id: {id}, name: {namestr} }}{highlight}");
+    }
+}
+
+type TreeBackref<T> = Arc<Mutex<Tree<T>>>;
+
 struct NodeEntry<T> {
     id: AccId,
     tree: TreeBackref<T>,
-}
-struct NodeLocal<T> {
     resource: Option<Arc<T>>,
-    // TODO: store local enable/disable state here for propagation
+    // TODO: store enable/disable state here for evaluation and propagation
 }
-struct NodeInner<T> {
-    ent: Mutex<NodeEntry<T>>,
-    local: Mutex<NodeLocal<T>>,
-}
-impl<T> NodeInner<T> {
-    fn tree(&self) -> Arc<Mutex<Tree<T>>> {
-        let guard = self.ent.lock().unwrap();
-        guard.tree.clone()
+struct Node<T>(Mutex<NodeEntry<T>>);
+impl<T> Node<T> {
+    /// Lock tree and entry (in that order, as required), and check if the tree
+    /// we locked is the one this node is associated with.
+    ///
+    /// If the tree references match, the two guards are returned. If not, the
+    /// tree to which we are now associated is returned instead.
+    ///
+    /// This is purely a helper function to make lifetimes clearer for
+    /// [`Self::lock_tree()`]
+    #[allow(clippy::type_complexity)]
+    fn try_lock_tree<'a>(
+        &'a self,
+        tree_ref: &'a TreeBackref<T>,
+    ) -> Result<
+        (MutexGuard<'a, Tree<T>>, MutexGuard<'a, NodeEntry<T>>),
+        TreeBackref<T>,
+    > {
+        let tguard = tree_ref.lock().unwrap();
+        let guard = self.0.lock().unwrap();
+        if Arc::ptr_eq(tree_ref, &guard.tree) {
+            Ok((tguard, guard))
+        } else {
+            Err(guard.tree.clone())
+        }
     }
 
-    fn set_parent(&self, parent: &NodeInner<T>) {
+    /// Safely acquire the lock to this entry, as well as the containing tree,
+    /// respecting the ordering requirements.
+    fn lock_tree<R>(
+        &self,
+        f: impl FnOnce(MutexGuard<'_, Tree<T>>, MutexGuard<'_, NodeEntry<T>>) -> R,
+    ) -> R {
+        let mut tree = self.0.lock().unwrap().tree.clone();
+        let (tguard, ent) = loop {
+            let new_tree = match self.try_lock_tree(&tree) {
+                Ok((tg, g)) => break (tg, g),
+                Err(nt) => nt,
+            };
+            let _ = std::mem::replace(&mut tree, new_tree);
+        };
+        f(tguard, ent)
+    }
+
+    fn adopt(&self, child: &Node<T>, name: Option<String>) {
         assert_ne!(
-            self as *const NodeInner<_>, parent as *const NodeInner<_>,
-            "cannot adopt to self"
+            self as *const Node<_>, child as *const Node<_>,
+            "cannot adopt self"
         );
 
-        let child_tree = self.tree();
-        let mut child_guard = child_tree.lock().unwrap();
-        let child_ent = self.ent.lock().unwrap();
-        assert_eq!(child_ent.id, ID_ROOT, "adopting of non-roots not allowed");
-
-        let parent_tree = parent.tree();
-        let mut parent_guard = parent_tree.lock().unwrap();
-        let parent_ent = parent.ent.lock().unwrap();
-        parent_guard.adopt(
-            parent_ent.id,
-            &mut child_guard,
-            &parent_ent.tree,
-            child_ent,
-        );
+        self.lock_tree(|mut parent_tguard, parent_ent| {
+            child.lock_tree(|mut child_tguard, child_ent| {
+                if child_ent.id != ID_ROOT {
+                    drop(child_tguard);
+                    drop(child_ent);
+                    drop(parent_tguard);
+                    drop(parent_ent);
+                    panic!("adopting of non-roots not allowed");
+                }
+                // Apply the chosen name to the root prior to its adoption
+                child_tguard.rename_node(ID_ROOT, name);
+                parent_tguard.adopt(&parent_ent, &mut child_tguard, child_ent);
+            });
+        });
     }
 
-    fn new_child(&self) -> Arc<NodeInner<T>> {
-        let tree = self.tree();
-        let mut guard = tree.lock().unwrap();
-        let parent = self.ent.lock().unwrap();
-
-        let child_id = guard.next_id();
-        let child = Arc::new(NodeInner {
-            ent: Mutex::new(NodeEntry {
+    fn new_root(tree: Arc<Mutex<Tree<T>>>) -> Arc<Node<T>> {
+        Arc::new(Node(Mutex::new(NodeEntry {
+            id: ID_ROOT,
+            tree,
+            resource: None,
+        })))
+    }
+    fn new_child(&self, name: Option<String>) -> Arc<Node<T>> {
+        self.lock_tree(|mut tguard, parent| {
+            let child_id = tguard.next_id();
+            let child = Arc::new(Node(Mutex::new(NodeEntry {
                 id: child_id,
                 tree: parent.tree.clone(),
-            }),
-            local: Mutex::new(NodeLocal {
-                resource: guard.resource_root.clone(),
-            }),
-        });
+                resource: tguard.resource_root.clone(),
+            })));
 
-        guard.nodes.insert(child_id, Arc::downgrade(&child));
-        guard.add_child(parent.id, child_id);
+            tguard.add_child(parent.id, child_id, &child, name);
 
-        child
+            child
+        })
     }
 
     fn guard(&self) -> Option<Guard<'_, T>> {
-        let local = self.local.lock().unwrap();
+        let local = self.0.lock().unwrap();
         local
             .resource
             .as_ref()
@@ -185,14 +434,38 @@ impl<T> NodeInner<T> {
     }
 
     fn poison(&self) -> Option<Arc<T>> {
-        let tree = self.tree();
-        let mut tree_guard = tree.lock().unwrap();
-        let ent = self.ent.lock().unwrap();
-        assert_eq!(ent.id, ID_ROOT, "tree poisoning only allowed at root");
-        tree_guard.resource_root.take()
+        self.lock_tree(|mut tguard, ent| {
+            let id = ent.id;
+            drop(ent);
+            if id != ID_ROOT {
+                drop(tguard);
+                panic!("tree poisoning only allowed at root");
+            }
+
+            // Remove the resource from the tree...
+            let top_res = tguard.resource_root.take();
+            // ... and poison all nodes too
+            if top_res.is_some() {
+                tguard.for_each(ID_ROOT, |_id, tnode| {
+                    if let Some(node) = tnode.node_ref.upgrade() {
+                        node.0.lock().unwrap().resource.take();
+                    }
+                });
+            }
+
+            top_res
+        })
     }
 }
-type Node<T> = Arc<NodeInner<T>>;
+impl<T> Drop for Node<T> {
+    fn drop(&mut self) {
+        let ent = self.0.get_mut().unwrap();
+        // drop any lingering access to the resource immediately
+        let _ = ent.resource.take();
+        // and remove us from the tree
+        ent.tree.lock().unwrap().remove_dead_node(ent.id);
+    }
+}
 
 pub struct Guard<'a, T> {
     inner: Arc<T>,
@@ -209,31 +482,58 @@ impl<T> std::ops::Deref for Guard<'_, T> {
         &self.inner
     }
 }
-pub fn opt_guard<'a, T>(val: &'a Option<Guard<'_, T>>) -> Option<&'a T> {
-    val.as_ref().map(std::ops::Deref::deref)
-}
 
-pub struct Accessor<T>(Node<T>);
+pub struct Accessor<T>(Arc<Node<T>>);
 impl<T> Accessor<T> {
-    pub(crate) fn new(res: Arc<T>) -> Self {
-        Self(Tree::new(Some(res)))
+    /// Create a new accessor hierarchy, mediating access to `resource`.
+    pub fn new(resource: Arc<T>) -> Self {
+        Self(Tree::new(Some(resource)))
     }
+
+    /// Create a new orphaned accessor hierarchy, bearing no existing resource.
+    /// The hierarchy can gain access to a valid resource by being
+    /// [adopted][`Self::adopt()`].
     pub fn new_orphan() -> Self {
         Self(Tree::new(None))
     }
 
-    pub fn child(&self) -> Self {
-        Self(self.0.new_child())
+    /// Create a child of this node.
+    pub fn child(&self, name: Option<String>) -> Self {
+        Self(self.0.new_child(name))
     }
-    pub fn set_parent(&self, parent: &Self) {
-        self.0.set_parent(&parent.0);
+
+    /// Adopt an orphan node and its descendants.
+    ///
+    /// # Panics
+    ///
+    /// If the node to be adopted is not the root of an orphan tree.
+    pub fn adopt(&self, child: &Self, name: Option<String>) {
+        self.0.adopt(&child.0, name);
     }
+
+    /// Poison (remove the underlying resource) from the root node of a
+    /// hierarchy.
+    ///
+    /// # Panics
+    ///
+    /// If this is called on a non-root node.
     pub fn poison(&self) -> Option<Arc<T>> {
         self.0.poison()
     }
 
+    /// Attempt to gain access to the underlying resource.
+    ///
+    /// Will return [None] if any ancestor node disables access, or if the node
+    /// is not attached to a hierarchy containing a valid resource.
     pub fn access(&self) -> Option<Guard<T>> {
         self.0.guard()
+    }
+
+    /// Print the hierarchy that this node is a member of
+    pub fn print(&self, highlight_self: bool) {
+        self.0.lock_tree(|tree, ent| {
+            tree.print(print_basic(highlight_self.then_some(ent.id)));
+        });
     }
 }
 
@@ -242,21 +542,30 @@ pub type MemAccessor = Accessor<MemCtx>;
 // Keep the rest of VmmHdl hidden for the MSI accessor
 pub struct MsiAccessor(Accessor<VmmHdl>);
 impl MsiAccessor {
-    pub fn new(res: Arc<VmmHdl>) -> Self {
-        Self(Accessor::new(res))
+    /// See: [`Accessor::new()`]
+    pub fn new(resource: Arc<VmmHdl>) -> Self {
+        Self(Accessor::new(resource))
     }
+    /// See: [`Accessor::new_orphan()`]
     pub fn new_orphan() -> Self {
         Self(Accessor::new_orphan())
     }
-    pub fn child(&self) -> Self {
-        Self(self.0.child())
+    /// See: [`Accessor::child()`]
+    pub fn child(&self, name: Option<String>) -> Self {
+        Self(self.0.child(name))
     }
-    pub fn set_parent(&self, parent: &Self) {
-        self.0.set_parent(&parent.0)
+    /// See: [`Accessor::adopt()`]
+    pub fn adopt(&self, child: &Self, name: Option<String>) {
+        self.0.adopt(&child.0, name)
     }
+    /// See: [`Accessor::poison()`]
     pub fn poison(&self) -> Option<Arc<VmmHdl>> {
         self.0.poison()
     }
+
+    /// Attempt to send an MSI with the resource held by this accessor
+    /// hierarchy.  Returns [`Ok`] if valid access to the resource exists,
+    /// otherwise [`Err`].
     pub fn send(&self, addr: u64, msg: u64) -> Result<(), ()> {
         if let Some(guard) = self.0.access() {
             guard.lapic_msi(addr, msg).expect("lapic_msi() should succeed");
@@ -269,5 +578,186 @@ impl MsiAccessor {
 impl std::fmt::Debug for MsiAccessor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MsiAccessor").finish()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    //! Note regarding unwinding for `should_panic` tests:
+    //!
+    //! If any mutexes are held when the code under test panics, the poisoned
+    //! mutex will prevent the unwinder from functioning properly when the
+    //! [MutexGuard]s are dropped.  You will see several checks in the above
+    //! logic which eschew [assert_eq] for a manual check which drops any held
+    //! mutexes before issuing a [panic].
+
+    use super::*;
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    // Helpers:
+
+    fn new_root() -> Accessor<AtomicUsize> {
+        Accessor::new(Arc::new(AtomicUsize::new(0)))
+    }
+    fn new_orphan() -> Accessor<AtomicUsize> {
+        Accessor::new_orphan()
+    }
+    fn new_depth(
+        depth: usize,
+    ) -> (Accessor<AtomicUsize>, Vec<Accessor<AtomicUsize>>) {
+        let root = new_root();
+        let mut children: Vec<Accessor<AtomicUsize>> =
+            Vec::with_capacity(depth);
+
+        for idx in 0..depth {
+            let next_child = match idx {
+                0 => root.child(None),
+                n => children[n - 1].child(None),
+            };
+            children.push(next_child);
+        }
+        (root, children)
+    }
+
+    #[test]
+    fn tree_root() {
+        let root = new_root();
+
+        let guard = root.access();
+        assert!(guard.is_some());
+        let guard = guard.unwrap();
+        drop(guard);
+
+        let res = root.poison();
+        assert!(res.is_some());
+
+        assert!(root.access().is_none())
+    }
+
+    #[test]
+    fn simple_orphan() {
+        let root = new_root();
+        let orphan = new_orphan();
+
+        assert!(root.access().is_some());
+        assert!(orphan.access().is_none());
+
+        root.adopt(&orphan, None);
+        assert!(orphan.access().is_some());
+    }
+
+    #[test]
+    #[should_panic]
+    fn only_root_can_poison() {
+        let root = new_root();
+        let child = root.child(None);
+
+        assert!(root.access().is_some());
+        assert!(child.access().is_some());
+
+        child.poison();
+    }
+
+    #[test]
+    #[should_panic]
+    fn adopt_self() {
+        let root = new_root();
+        root.adopt(&root, None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn adopt_nonroot() {
+        let root = new_root();
+        let child = new_orphan();
+        let grandchild = child.child(None);
+
+        root.adopt(&grandchild, None);
+    }
+
+    #[test]
+    fn simple_depth() {
+        let depth = 4;
+        let (root, children) = new_depth(depth);
+
+        // update the inner resource, checking that it's the same at all depths
+        let tval = 1;
+        root.access().unwrap().store(tval, Ordering::Relaxed);
+        for child in children.iter() {
+            assert_eq!(child.access().unwrap().load(Ordering::Relaxed), tval);
+        }
+
+        root.poison();
+        for node in children.iter() {
+            assert!(node.access().is_none());
+        }
+    }
+
+    #[test]
+    fn orphan_split() {
+        let (root, children) = new_depth(5);
+
+        // Wrap the children in Option, so we can drop one from the middle to
+        // orphan its descendants
+        let mut children =
+            children.into_iter().map(|c| Some(c)).collect::<Vec<Option<_>>>();
+
+        // Drop the middle node, causing its children to become orphaned
+        children[2] = None;
+
+        // Children above the "split" should be fine
+        for child in children[0..2].iter().map(|c| c.as_ref().unwrap()) {
+            assert!(child.access().is_some());
+        }
+
+        // Those below should be orphaned, with no access to the resource
+        for child in children[3..].iter().map(|c| c.as_ref().unwrap()) {
+            assert!(child.access().is_none());
+        }
+
+        let tval = 1;
+        root.access().unwrap().store(tval, Ordering::Relaxed);
+
+        // Closest available child will adopt the orphan chain
+        children[1]
+            .as_ref()
+            .unwrap()
+            .adopt(children[3].as_ref().unwrap(), None);
+
+        // The adopted nodes should have access (and see the updated val)
+        for child in children[3..].iter().map(|c| c.as_ref().unwrap()) {
+            let guard = child.access().expect("resource is accessible");
+            assert_eq!(guard.load(Ordering::Relaxed), tval);
+        }
+    }
+
+    #[test]
+    fn print_names() {
+        let root = new_root();
+
+        // build up an arbitrary hierarchy to print out
+        let left = root.child(Some("left".to_string()));
+        let right = root.child(Some("right".to_string()));
+        let mut sub = Vec::new();
+        for n in 0..4 {
+            let lsub = left.child(Some(format!("sub {n}")));
+            let rsub = right.child(Some(format!("sub {n}")));
+
+            match n {
+                3 => {
+                    sub.push(lsub.child(Some("deep".to_string())));
+                }
+                2 => {
+                    sub.push(rsub.child(Some("deep".to_string())));
+                }
+                _ => {}
+            }
+            sub.push(lsub);
+            sub.push(rsub);
+        }
+
+        right.print(true);
     }
 }

--- a/lib/propolis/src/hw/nvme/queue.rs
+++ b/lib/propolis/src/hw/nvme/queue.rs
@@ -894,7 +894,7 @@ mod tests {
         let read_base = GuestAddr(0);
         let write_base = GuestAddr(1024 * 1024);
 
-        let acc_mem = instance.lock().machine().acc_mem.child();
+        let acc_mem = instance.lock().machine().acc_mem.child(None);
         let mem = acc_mem.access().unwrap();
 
         // Admin queues must be less than 4K
@@ -947,7 +947,7 @@ mod tests {
         let read_base = GuestAddr(0);
         let write_base = GuestAddr(1024 * 1024);
 
-        let acc_mem = instance.lock().machine().acc_mem.child();
+        let acc_mem = instance.lock().machine().acc_mem.child(None);
         let mem = acc_mem.access().unwrap();
 
         // Create corresponding CQs
@@ -1024,7 +1024,7 @@ mod tests {
         let read_base = GuestAddr(0);
         let write_base = GuestAddr(1024 * 1024);
 
-        let acc_mem = instance.lock().machine().acc_mem.child();
+        let acc_mem = instance.lock().machine().acc_mem.child(None);
         let mem = acc_mem.access().unwrap();
 
         // Create our queues
@@ -1090,7 +1090,7 @@ mod tests {
         let read_base = GuestAddr(0);
         let write_base = GuestAddr(1024 * 1024);
 
-        let acc_mem = instance.lock().machine().acc_mem.child();
+        let acc_mem = instance.lock().machine().acc_mem.child(None);
         let mem = acc_mem.access().unwrap();
 
         // Create our queues
@@ -1144,7 +1144,7 @@ mod tests {
         let read_base = GuestAddr(0);
         let write_base = GuestAddr(1024 * 1024);
 
-        let acc_mem = instance.lock().machine().acc_mem.child();
+        let acc_mem = instance.lock().machine().acc_mem.child(None);
         let mem = acc_mem.access().unwrap();
 
         // Create a pair of Completion and Submission Queues
@@ -1223,7 +1223,7 @@ mod tests {
                 let worker_sq = sq.clone();
                 let worker_comp_tx = comp_tx.clone();
 
-                let child_acc = acc_mem.child();
+                let child_acc = acc_mem.child(None);
 
                 spawn(move || {
                     let mut submissions = 0;

--- a/lib/propolis/src/hw/nvme/requests.rs
+++ b/lib/propolis/src/hw/nvme/requests.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::{
-    accessors::{opt_guard, MemAccessor},
+    accessors::MemAccessor,
     block::{self, BlockPayload, Operation, Request, Result as BlockResult},
     hw::nvme::{bits, cmds::Completion},
 };
@@ -50,7 +50,7 @@ impl block::Device for PciNvme {
     }
 
     fn accessor_mem(&self) -> MemAccessor {
-        self.pci_state.acc_mem.child()
+        self.pci_state.acc_mem.child(Some("block backend".to_string()))
     }
 
     fn set_notifier(&self, f: Option<Box<block::NotifierFn>>) {
@@ -172,7 +172,7 @@ impl PciNvme {
             }
         }
 
-        let mem = self.mem_access();
-        permit.complete(Completion::from(res), opt_guard(&mem));
+        let guard = self.mem_access();
+        permit.complete(Completion::from(res), guard.as_deref());
     }
 }

--- a/lib/propolis/src/hw/pci/bus.rs
+++ b/lib/propolis/src/hw/pci/bus.rs
@@ -173,7 +173,17 @@ impl Inner {
     ) -> (Arc<SlotState>, MsiAccessor, MemAccessor) {
         let slot_state =
             self.slots[location.dev.get() as usize].attach(location, dev);
-        (slot_state, self.acc_msi.child(), self.acc_mem.child())
+
+        let acc_name = format!(
+            "PCI dev:{} func:{}",
+            location.dev.get(),
+            location.func.get()
+        );
+        (
+            slot_state,
+            self.acc_msi.child(Some(acc_name.clone())),
+            self.acc_mem.child(Some(acc_name)),
+        )
     }
     fn bar_register(
         &mut self,

--- a/lib/propolis/src/hw/pci/device.rs
+++ b/lib/propolis/src/hw/pci/device.rs
@@ -562,8 +562,8 @@ impl DeviceState {
         let _old = state.attach.replace(attachment);
         assert!(_old.is_none());
         let attach = state.attach.as_ref().unwrap();
-        self.acc_mem.set_parent(&attach.acc_mem);
-        self.acc_msi.set_parent(&attach.acc_msi);
+        attach.acc_mem.adopt(&self.acc_mem, None);
+        attach.acc_msi.adopt(&self.acc_msi, None);
     }
 
     pub fn lintr_pin(&self) -> Option<Arc<dyn IntrPin>> {
@@ -998,7 +998,7 @@ impl MsixCfg {
     fn attach(&self, msi_acc: &MsiAccessor) {
         for entry in self.entries.iter() {
             let mut guard = entry.lock().unwrap();
-            guard.acc_msi = Some(msi_acc.child());
+            guard.acc_msi = Some(msi_acc.child(None));
         }
     }
     fn export(&self) -> migrate::MsixStateV1 {

--- a/lib/propolis/src/hw/pci/test.rs
+++ b/lib/propolis/src/hw/pci/test.rs
@@ -34,8 +34,8 @@ impl Scaffold {
         Bus::new(
             &self.bus_pio,
             &self.bus_mmio,
-            self.acc_mem.child(),
-            self.acc_msi.child(),
+            self.acc_mem.child(None),
+            self.acc_msi.child(None),
         )
     }
 }

--- a/lib/propolis/src/hw/pci/topology.rs
+++ b/lib/propolis/src/hw/pci/topology.rs
@@ -267,30 +267,29 @@ impl Builder {
 
         let pio_bus = &machine.bus_pio;
         let mmio_bus = &machine.bus_mmio;
-        let acc_mem = machine.acc_mem.child();
-        let acc_msi = machine.acc_msi.child();
 
         // Bus 0 is always present and always routes to itself.
         buses.push(Bus::new(
             pio_bus,
             mmio_bus,
-            acc_mem.child(),
-            acc_msi.child(),
+            machine.acc_mem.child(Some("PCI bus 0".to_string())),
+            machine.acc_msi.child(Some("PCI bus 0".to_string())),
         ));
         logical_buses.insert(LogicalBusId(0), BusIndex(0));
         inner.routed_buses.insert(RoutedBusId(0), BusIndex(0));
 
         for bridge in &self.bridges {
+            let idx = buses.len();
             logical_buses.insert(
                 LogicalBusId(bridge.downstream_bus_id.0),
-                BusIndex(buses.len()),
+                BusIndex(idx),
             );
             // TODO: wire up accessors to mirror actual bus topology
             buses.push(Bus::new(
                 &pio_bus,
                 &mmio_bus,
-                acc_mem.child(),
-                acc_msi.child(),
+                machine.acc_mem.child(Some(format!("PCI bus {idx}"))),
+                machine.acc_msi.child(Some(format!("PCI bus {idx}"))),
             ));
         }
 

--- a/lib/propolis/src/hw/qemu/fwcfg.rs
+++ b/lib/propolis/src/hw/qemu/fwcfg.rs
@@ -388,7 +388,7 @@ impl FwCfg {
     }
 
     pub fn attach(self: &Arc<Self>, pio: &PioBus, acc_mem: &MemAccessor) {
-        self.acc_mem.set_parent(acc_mem);
+        acc_mem.adopt(&self.acc_mem, Some("fw_cfg".to_string()));
         let ports = [
             (FW_CFG_IOP_SELECTOR, 1),
             (FW_CFG_IOP_DATA, 1),

--- a/lib/propolis/src/hw/qemu/ramfb.rs
+++ b/lib/propolis/src/hw/qemu/ramfb.rs
@@ -115,7 +115,7 @@ impl RamFb {
         builder: &mut FwCfgBuilder,
         acc_mem: &MemAccessor,
     ) {
-        self.acc_mem.set_parent(acc_mem);
+        acc_mem.adopt(&self.acc_mem, Some("ramfb".to_string()));
         builder
             .add_named("etc/ramfb", Arc::clone(self) as Arc<dyn Item>)
             .unwrap();

--- a/lib/propolis/src/hw/virtio/block.rs
+++ b/lib/propolis/src/hw/virtio/block.rs
@@ -245,7 +245,7 @@ impl block::Device for PciVirtioBlock {
     }
 
     fn accessor_mem(&self) -> MemAccessor {
-        self.pci_state.acc_mem.child()
+        self.pci_state.acc_mem.child(Some("block backend".to_string()))
     }
 
     fn set_notifier(&self, val: Option<Box<block::NotifierFn>>) {

--- a/lib/propolis/src/hw/virtio/pci.rs
+++ b/lib/propolis/src/hw/virtio/pci.rs
@@ -235,7 +235,9 @@ impl PciVirtioState {
 
         for queue in this.queues.iter() {
             queue.set_intr(IsrIntr::new(&this.isr_state));
-            queue.acc_mem.set_parent(&pci_state.acc_mem);
+            pci_state
+                .acc_mem
+                .adopt(&queue.acc_mem, Some(format!("VQ {}", queue.id)));
         }
 
         (this, pci_state)


### PR DESCRIPTION
This fixes leaky (and broken) behavior for when nodes are dropped an should be removed from the hierarchy.  A small base of tests have been added to cover a few of those cases.

The ability to disable access for swaths of the hierarchy is still missing, but this should lay the groundwork for more easily adding that in the future.

FYI: The coming overhaul of the block IO interfaces depends on this work.