### PR TITLE
Update Crucible.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=6322a223c0e82a7731ff238416c11142c4c05c80#6322a223c0e82a7731ff238416c11142c4c05c80"
+source = "git+https://github.com/oxidecomputer/crucible?rev=b7a6856837faba76738282f9b45c2316ae1733dc#b7a6856837faba76738282f9b45c2316ae1733dc"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -735,7 +735,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=6322a223c0e82a7731ff238416c11142c4c05c80#6322a223c0e82a7731ff238416c11142c4c05c80"
+source = "git+https://github.com/oxidecomputer/crucible?rev=b7a6856837faba76738282f9b45c2316ae1733dc#b7a6856837faba76738282f9b45c2316ae1733dc"
 dependencies = [
  "base64 0.21.4",
  "crucible-workspace-hack",
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=6322a223c0e82a7731ff238416c11142c4c05c80#6322a223c0e82a7731ff238416c11142c4c05c80"
+source = "git+https://github.com/oxidecomputer/crucible?rev=b7a6856837faba76738282f9b45c2316ae1733dc#b7a6856837faba76738282f9b45c2316ae1733dc"
 dependencies = [
  "anyhow",
  "atty",
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=6322a223c0e82a7731ff238416c11142c4c05c80#6322a223c0e82a7731ff238416c11142c4c05c80"
+source = "git+https://github.com/oxidecomputer/crucible?rev=b7a6856837faba76738282f9b45c2316ae1733dc#b7a6856837faba76738282f9b45c2316ae1733dc"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,8 @@ oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch =
 oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 
 # Crucible
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "6322a223c0e82a7731ff238416c11142c4c05c80" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "6322a223c0e82a7731ff238416c11142c4c05c80" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "b7a6856837faba76738282f9b45c2316ae1733dc" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "b7a6856837faba76738282f9b45c2316ae1733dc" }
 
 # External dependencies
 anyhow = "1.0"


### PR DESCRIPTION
Crucible changes:
Don't unwrap when we can't create a dataset (#992) Fix tests and update log messages. (#995)
Better backpressure (#990)
Update Rust crate proptest to 1.3.1 (#977)
Read only downstairs can skip Live Repair (#984)
Update Rust crate expectorate to 1.1.0 (#975)
Add trait for `ExtentInner` (#982)
report backpressure in upstairs_info dtrace probe (#987) Support multiple downstairs operations in GtoS (#985)