### PR TITLE
Make qemu debug port output configurable

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -267,6 +267,7 @@ impl<'a> MachineInitializer<'a> {
     }
 
     pub fn initialize_qemu_debug_port(&self) -> Result<(), Error> {
+        // TODO: Make the output file configurable
         let dbg = QemuDebugPort::create(&self.machine.bus_pio);
         let debug_file = std::fs::File::create("debug.out")?;
         let poller = chardev::BlockingFileOutput::new(debug_file);

--- a/bin/propolis-standalone/README.md
+++ b/bin/propolis-standalone/README.md
@@ -16,6 +16,8 @@ name = "testvm"
 cpus = 4
 bootrom = "/path/to/bootrom/OVMF_CODE.fd"
 memory = 1024
+# File path to store qemu debug port output (optional)
+# qemu_debug_file = "/path/to/output"
 
 [block_dev.alpine_iso]
 type = "file"

--- a/crates/propolis-standalone-config/src/lib.rs
+++ b/crates/propolis-standalone-config/src/lib.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 use strum::FromRepr;
@@ -50,6 +51,7 @@ pub struct Main {
     pub bootrom: String,
     pub memory: usize,
     pub use_reservoir: Option<bool>,
+    pub qemu_debug_file: Option<PathBuf>,
     pub cpuid_profile: Option<String>,
 }
 

--- a/lib/propolis/src/chardev/mod.rs
+++ b/lib/propolis/src/chardev/mod.rs
@@ -105,3 +105,10 @@ impl ConsumerCell {
         }
     }
 }
+
+/// Build a [`BlockingSourceConsumer`] which silently consumes any output bytes
+pub fn null_blocking_consumer() -> BlockingSourceConsumer {
+    Box::new(|_buf| {
+        // Simply do nothing with the buffer
+    })
+}


### PR DESCRIPTION
The default of dumping `debug.out` files everywhere that propolis-standalone is run is a bit unnecessary if that output isn't desired.