### PR TITLE
Softnpu jumbo frames

### DIFF
--- a/lib/propolis/src/hw/virtio/p9fs.rs
+++ b/lib/propolis/src/hw/virtio/p9fs.rs
@@ -235,8 +235,6 @@ pub trait P9Handler: Sync + Send + 'static {
         let len = u32::from_le_bytes(buf[0..4].try_into().unwrap()) as usize;
         let typ = MessageType::try_from_primitive(buf[4]).unwrap();
 
-        println!("message: {:?}", typ);
-
         match typ {
             MessageType::Tversion => {
                 self.handle_version(&data[..len], &mut chain, &mem)

--- a/lib/propolis/src/hw/virtio/softnpu.rs
+++ b/lib/propolis/src/hw/virtio/softnpu.rs
@@ -42,8 +42,8 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 use slog::{error, info, warn, Logger};
 
-// TODO make configurable
-const MTU: usize = 1600;
+// Transit jumbo frames
+const MTU: usize = 9216;
 
 const SOFTNPU_CPU_AUX_PORT: u16 = 1000;
 

--- a/lib/propolis/src/hw/virtio/softnpu.rs
+++ b/lib/propolis/src/hw/virtio/softnpu.rs
@@ -773,8 +773,7 @@ impl ManagementMessageReader {
 
     fn read(&self) -> ManagementRequest {
         loop {
-            let mut buf = Vec::new();
-            buf.resize(10240, 0u8);
+            let mut buf = vec![0; 10240];
             let mut i = 0;
             let mut in_message = false;
             loop {


### PR DESCRIPTION
- Add enough headroom in softnpu frame buffers to support jumbo frames.
- Remove a very noisy p9fs print statement.
- Appease clippy.