### PR TITLE
Guarantee Tokio access for Entity methods

### DIFF
--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -929,6 +929,7 @@ impl StateDriverVmController for VmController {
     }
 
     fn reset_entities_and_machine(&self) {
+        let _rtguard = self.runtime_hdl.enter();
         self.for_each_entity(|ent, rec| {
             info!(self.log, "Sending reset request to {}", rec.name());
             ent.reset();
@@ -940,6 +941,7 @@ impl StateDriverVmController for VmController {
     }
 
     fn start_entities(&self) -> anyhow::Result<()> {
+        let _rtguard = self.runtime_hdl.enter();
         self.for_each_entity(|ent, rec| {
             info!(self.log, "Sending startup complete to {}", rec.name());
             let res = ent.start();
@@ -951,6 +953,7 @@ impl StateDriverVmController for VmController {
     }
 
     fn pause_entities(&self) {
+        let _rtguard = self.runtime_hdl.enter();
         self.for_each_entity(|ent, rec| {
             info!(self.log, "Sending pause request to {}", rec.name());
             ent.pause();
@@ -984,6 +987,7 @@ impl StateDriverVmController for VmController {
     }
 
     fn resume_entities(&self) {
+        let _rtguard = self.runtime_hdl.enter();
         self.for_each_entity(|ent, rec| {
             info!(self.log, "Sending resume request to {}", rec.name());
             ent.resume();
@@ -993,6 +997,7 @@ impl StateDriverVmController for VmController {
     }
 
     fn halt_entities(&self) {
+        let _rtguard = self.runtime_hdl.enter();
         self.for_each_entity(|ent, rec| {
             info!(self.log, "Sending halt request to {}", rec.name());
             ent.halt();

--- a/lib/propolis/src/inventory.rs
+++ b/lib/propolis/src/inventory.rs
@@ -571,11 +571,30 @@ impl Record {
     }
 }
 
+/// General trait for emulated devices in the system.
+///
+/// As the VM goes through its lifecycle, the emulated devices which it contains
+/// are so driven through those phases via various event functions (`start`,
+/// `pause`, `resume`, etc).
+///
+/// A collection of these [Entity] implementing trait objects are held in an
+/// [Inventory] for the software driving the VM instance to interact with.
+///
+/// Note: Calling any of these lifecycle methods on an [Entity] should be done
+/// from a context with access to a [Tokio runtime](tokio::runtime::Runtime):
+/// - [Entity::start]
+/// - [Entity::pause]
+/// - [Entity::resume]
+/// - [Entity::paused]
+/// - [Entity::reset]
+/// - [Entity::halt]
+/// - [Entity::migrate]
 pub trait Entity: Send + Sync + 'static {
     /// Unique name for entities for a given type
+    ///
+    /// Intended to be `const` once stabilized for trait functions.
     fn type_name(&self) -> &'static str;
 
-    #[allow(unused_variables)]
     fn child_register(&self) -> Option<Vec<ChildRegister>> {
         None
     }


### PR DESCRIPTION
Device emulation may need access to a Tokio runtime for spawning tasks or running futures to completion as part of the methods exposed by the Entity trait.  This should be clearly documented by Entity, and propolis-server should meet those requirements.