### PR TITLE
9pfs: honor tread.size

### DIFF
--- a/lib/propolis/src/hw/virtio/p9fs.rs
+++ b/lib/propolis/src/hw/virtio/p9fs.rs
@@ -375,7 +375,9 @@ impl HostFSHandler {
             Ok(_) => {}
         }
 
-        let space_left = msize as usize
+        let read_count = u32::min(msize, msg.count);
+
+        let space_left = read_count as usize
             - size_of::<u32>()          // Rread.size
             - size_of::<MessageType>()  // Rread.typ
             - size_of::<u16>()          // Rread.tag


### PR DESCRIPTION
Previously, we were sending an `msize` buffer for rread payloads with trailing zeros independent of the tread count field. This is terrible for performance and makes some clients angry.