### PR TITLE
nvme: don't fail on abort cmd

### DIFF
--- a/lib/propolis/src/hw/nvme/cmds.rs
+++ b/lib/propolis/src/hw/nvme/cmds.rs
@@ -45,7 +45,7 @@ pub enum AdminCmd {
     /// Identify Command
     Identify(IdentifyCmd),
     /// Abort Command
-    Abort,
+    Abort(AbortCmd),
     /// Set Features Command
     SetFeatures(SetFeaturesCmd),
     /// Get Features Command
@@ -110,7 +110,10 @@ impl AdminCmd {
                 prp1: raw.prp1,
                 prp2: raw.prp2,
             }),
-            bits::ADMIN_OPC_ABORT => AdminCmd::Abort,
+            bits::ADMIN_OPC_ABORT => AdminCmd::Abort(AbortCmd {
+                cid: (raw.cdw10 >> 16) as u16,
+                sqid: raw.cdw10 as u16,
+            }),
             bits::ADMIN_OPC_SET_FEATURES => {
                 AdminCmd::SetFeatures(SetFeaturesCmd {
                     fid: FeatureIdent::from((raw.cdw10 as u8, raw.cdw11)),
@@ -327,6 +330,17 @@ impl IdentifyCmd {
     pub fn data<'a>(&self, mem: &'a MemCtx) -> PrpIter<'a> {
         PrpIter::new(PAGE_SIZE as u64, self.prp1, self.prp2, mem)
     }
+}
+
+/// Abort Command Parameters
+#[derive(Debug)]
+pub struct AbortCmd {
+    /// The command identifier of the command to be aborted.
+    pub cid: u16,
+
+    /// The ID of the Submission Queue asssociated with the command to be
+    /// aborted.
+    pub sqid: u16,
 }
 
 /// Set Features Command Parameters

--- a/lib/propolis/src/hw/nvme/mod.rs
+++ b/lib/propolis/src/hw/nvme/mod.rs
@@ -885,6 +885,7 @@ impl PciNvme {
                 AdminCmd::Unknown(sub)
             });
             let comp = match cmd {
+                AdminCmd::Abort(cmd) => state.acmd_abort(&cmd),
                 AdminCmd::CreateIOCompQ(cmd) => {
                     state.acmd_create_io_cq(&cmd, &mem)
                 }
@@ -910,9 +911,7 @@ impl PciNvme {
                     // this can detect it and stop posting async events.
                     cmds::Completion::generic_err_dnr(bits::STS_INVAL_OPC)
                 }
-                AdminCmd::Abort
-                | AdminCmd::GetFeatures
-                | AdminCmd::Unknown(_) => {
+                AdminCmd::GetFeatures | AdminCmd::Unknown(_) => {
                     cmds::Completion::generic_err(bits::STS_INTERNAL_ERR)
                 }
             };

--- a/lib/propolis/src/hw/nvme/mod.rs
+++ b/lib/propolis/src/hw/nvme/mod.rs
@@ -618,6 +618,8 @@ impl PciNvme {
 
         let cur = state.ctrl.cc;
         if new.enabled() && !cur.enabled() {
+            slog::info!(self.log, "Enabling controller");
+
             let mem = self.mem_access();
             let mem = mem.ok_or(NvmeError::MemoryInaccessible)?;
 
@@ -633,6 +635,8 @@ impl PciNvme {
                 state.ctrl.csts.set_ready(true);
             }
         } else if !new.enabled() && cur.enabled() {
+            slog::info!(self.log, "Disabling controller");
+
             // Reset controller state which will set CC.EN=0 and CSTS.RDY=0
             state.reset();
         }


### PR DESCRIPTION
`Abort` is a mandatory NVMe command and we were previously just returning `STS_INTERNAL_ERR` (`06h - Internal Device Error` ). Even without fully supporting aborting commands we can do better than that since it's a best effort command.

This change just adds some validation and immediately completes an abort request indicating the command in question _wasn't_ aborted.