### PR TITLE
add QEMU pvpanic ISA device

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -282,7 +282,7 @@ impl<'a> MachineInitializer<'a> {
         uuid: uuid::Uuid,
     ) -> Result<(), anyhow::Error> {
         if let Some(ref spec) = self.spec.devices.qemu_pvpanic {
-            if spec.enable_isa {
+            if spec.enable_mmio {
                 let pvpanic = QemuPvpanic::create(
                     self.log.new(slog::o!("dev" => "qemu-pvpanic")),
                 );

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -35,7 +35,7 @@ use crate::serial::Serial;
 use crate::server::CrucibleBackendMap;
 pub use nexus_client::Client as NexusClient;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 // Arbitrary ROM limit for now
 const MAX_ROM_SIZE: usize = 0x20_0000;
@@ -292,11 +292,9 @@ impl<'a> MachineInitializer<'a> {
                 if let Some(ref registry) = self.producer_registry {
                     let producer =
                         crate::stats::PvpanicProducer::new(uuid, pvpanic);
-                    registry.register_producer(producer).map_err(|error| {
-                        anyhow::anyhow!(
-                            "failed to register PVPANIC Oximeter producer: {error}"
-                        )
-                    })?;
+                    registry.register_producer(producer).context(
+                        "failed to register PVPANIC Oximeter producer",
+                    )?;
                 }
             }
         }

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -282,7 +282,7 @@ impl<'a> MachineInitializer<'a> {
         uuid: uuid::Uuid,
     ) -> Result<(), anyhow::Error> {
         if let Some(ref spec) = self.spec.devices.qemu_pvpanic {
-            if spec.enable_mmio {
+            if spec.enable_isa {
                 let pvpanic = QemuPvpanic::create(
                     self.log.new(slog::o!("dev" => "qemu-pvpanic")),
                 );

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -283,7 +283,9 @@ impl<'a> MachineInitializer<'a> {
     ) -> Result<(), anyhow::Error> {
         if let Some(ref spec) = self.spec.devices.qemu_pvpanic {
             if spec.enable_isa {
-                let pvpanic = QemuPvpanic::create();
+                let pvpanic = QemuPvpanic::create(
+                    self.log.new(slog::o!("dev" => "qemu-pvpanic")),
+                );
                 pvpanic.attach_pio(&self.machine.bus_pio);
                 self.inv.register(&pvpanic)?;
 

--- a/bin/propolis-server/src/lib/spec.rs
+++ b/bin/propolis-server/src/lib/spec.rs
@@ -222,8 +222,12 @@ impl ServerSpecBuilder {
                 },
             )?;
 
-        let builder =
+        let mut builder =
             SpecBuilder::new(properties.vcpus, properties.memory, enable_pcie);
+
+        builder.add_pvpanic_device(components::devices::QemuPvpanic {
+            enable_isa: true,
+        })?;
 
         Ok(Self { builder })
     }

--- a/bin/propolis-server/src/lib/stats.rs
+++ b/bin/propolis-server/src/lib/stats.rs
@@ -42,6 +42,19 @@ struct Reset {
     pub count: Cumulative<i64>,
 }
 
+/// An Oximeter `Metric` that specifies the number of times an instance's guest
+/// reported a kernel panic using the QEMU `pvpanic` device.
+#[derive(Debug, Default, Copy, Clone, Metric)]
+struct PvPanic {
+    /// The number of times this instance's guest handled a kernel panic.
+    #[datum]
+    pub handled: Cumulative<i64>,
+
+    /// The number of times this instance's guest reported an unhandled panic.
+    #[datum]
+    pub unhandled: Cumulative<i64>,
+}
+
 /// The full set of server-level metrics, collated by
 /// [`ServerStatsOuter::produce`] into the types needed to relay these
 /// statistics to Oximeter.
@@ -53,6 +66,9 @@ struct ServerStats {
 
     /// The reset count for the relevant instance.
     run_count: Reset,
+
+    /// `pvpanic` device panic count for the relevant instance.
+    pvpanic_count: PvPanic,
 }
 
 impl ServerStats {
@@ -60,6 +76,7 @@ impl ServerStats {
         ServerStats {
             stat_name: InstanceUuid { uuid },
             run_count: Default::default(),
+            pvpanic_count: Default::default(),
         }
     }
 }

--- a/bin/propolis-server/src/lib/stats.rs
+++ b/bin/propolis-server/src/lib/stats.rs
@@ -14,7 +14,7 @@ use oximeter::{
     Metric, MetricsError, Producer, Target,
 };
 use oximeter_producer::{Config, Server};
-use propolis::hw::qemu::pvpanic;
+use propolis::hw::qemu::pvpanic::QemuPvpanic;
 use slog::{error, info, warn, Logger};
 
 use std::net::SocketAddr;
@@ -99,7 +99,7 @@ pub struct PvpanicProducer {
     host_handled_panics: PvPanicHostHandled,
     guest_handled_panics: PvPanicGuestHandled,
 
-    counts: Arc<pvpanic::PanicCounts>,
+    counts: Arc<QemuPvpanic>,
 }
 
 impl ServerStatsOuter {
@@ -123,7 +123,7 @@ impl Producer for ServerStatsOuter {
 }
 
 impl PvpanicProducer {
-    pub fn new(id: Uuid, counts: Arc<pvpanic::PanicCounts>) -> Self {
+    pub fn new(id: Uuid, counts: Arc<QemuPvpanic>) -> Self {
         PvpanicProducer {
             stat_name: InstanceUuid { uuid: id },
             host_handled_panics: Default::default(),

--- a/bin/propolis-server/src/lib/stats.rs
+++ b/bin/propolis-server/src/lib/stats.rs
@@ -14,7 +14,6 @@ use oximeter::{
     Metric, MetricsError, Producer, Target,
 };
 use oximeter_producer::{Config, Server};
-use propolis::hw::qemu::pvpanic::QemuPvpanic;
 use slog::{error, info, warn, Logger};
 
 use std::net::SocketAddr;
@@ -22,6 +21,9 @@ use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
 use crate::server::MetricsEndpointConfig;
+
+mod pvpanic;
+pub use self::pvpanic::PvpanicProducer;
 
 const OXIMETER_STAT_INTERVAL: tokio::time::Duration =
     tokio::time::Duration::from_secs(30);
@@ -39,24 +41,6 @@ struct InstanceUuid {
 #[derive(Debug, Default, Copy, Clone, Metric)]
 struct Reset {
     /// The number of times this instance was reset via the API.
-    #[datum]
-    pub count: Cumulative<i64>,
-}
-
-/// An Oximeter `Metric` that specifies the number of times an instance's guest
-/// reported a guest-handled kernel panic using the QEMU `pvpanic` device.
-#[derive(Debug, Default, Copy, Clone, Metric)]
-struct PvPanicGuestHandled {
-    /// The number of times this instance's guest handled a kernel panic.
-    #[datum]
-    pub count: Cumulative<i64>,
-}
-
-/// An Oximeter `Metric` that specifies the number of times an instance's guest
-/// reported a host-handled kernel panic using the QEMU `pvpanic` device.
-#[derive(Debug, Default, Copy, Clone, Metric)]
-struct PvPanicHostHandled {
-    /// The number of times this instance's reported a host-handled kernel panic.
     #[datum]
     pub count: Cumulative<i64>,
 }
@@ -89,19 +73,6 @@ pub struct ServerStatsOuter {
     server_stats_wrapped: Arc<Mutex<ServerStats>>,
 }
 
-#[derive(Clone, Debug)]
-pub struct PvpanicProducer {
-    /// The name to use as the Oximeter target, i.e. the identifier of the
-    /// source of these metrics.
-    stat_name: InstanceUuid,
-
-    /// Kernel panic counts for the relevant instance.
-    host_handled_panics: PvPanicHostHandled,
-    guest_handled_panics: PvPanicGuestHandled,
-
-    counts: Arc<QemuPvpanic>,
-}
-
 impl ServerStatsOuter {
     /// Increments the number of times the instance was reset.
     pub fn count_reset(&self) {
@@ -118,36 +89,6 @@ impl Producer for ServerStatsOuter {
         let inner = self.server_stats_wrapped.lock().unwrap();
         let name = inner.stat_name;
         let data = vec![Sample::new(&name, &inner.run_count)?];
-        Ok(Box::new(data.into_iter()))
-    }
-}
-
-impl PvpanicProducer {
-    pub fn new(id: Uuid, counts: Arc<QemuPvpanic>) -> Self {
-        PvpanicProducer {
-            stat_name: InstanceUuid { uuid: id },
-            host_handled_panics: Default::default(),
-            guest_handled_panics: Default::default(),
-            counts,
-        }
-    }
-}
-
-impl Producer for PvpanicProducer {
-    fn produce(
-        &mut self,
-    ) -> Result<Box<dyn Iterator<Item = Sample> + 'static>, MetricsError> {
-        self.host_handled_panics
-            .datum_mut()
-            .set(self.counts.host_handled_count() as i64);
-        self.guest_handled_panics
-            .datum_mut()
-            .set(self.counts.guest_handled_count() as i64);
-        let data = vec![
-            Sample::new(&self.stat_name, &self.guest_handled_panics)?,
-            Sample::new(&self.stat_name, &self.host_handled_panics)?,
-        ];
-
         Ok(Box::new(data.into_iter()))
     }
 }

--- a/bin/propolis-server/src/lib/stats/pvpanic.rs
+++ b/bin/propolis-server/src/lib/stats/pvpanic.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use super::InstanceUuid;
 use oximeter::{
     types::{Cumulative, Sample},

--- a/bin/propolis-server/src/lib/stats/pvpanic.rs
+++ b/bin/propolis-server/src/lib/stats/pvpanic.rs
@@ -62,6 +62,7 @@ impl Producer for PvpanicProducer {
 
         self.host_handled_panics.datum_mut().set(host_handled as i64);
         self.guest_handled_panics.datum_mut().set(guest_handled as i64);
+
         let data = vec![
             Sample::new(&self.stat_name, &self.guest_handled_panics)?,
             Sample::new(&self.stat_name, &self.host_handled_panics)?,

--- a/bin/propolis-server/src/lib/stats/pvpanic.rs
+++ b/bin/propolis-server/src/lib/stats/pvpanic.rs
@@ -1,0 +1,69 @@
+use super::InstanceUuid;
+use oximeter::{
+    types::{Cumulative, Sample},
+    Metric, MetricsError, Producer,
+};
+use propolis::hw::qemu::pvpanic::QemuPvpanic;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Clone, Debug)]
+pub struct PvpanicProducer {
+    /// The name to use as the Oximeter target, i.e. the identifier of the
+    /// source of these metrics.
+    stat_name: InstanceUuid,
+
+    /// Kernel panic counts for the relevant instance.
+    host_handled_panics: PvPanicHostHandled,
+    guest_handled_panics: PvPanicGuestHandled,
+
+    counts: Arc<QemuPvpanic>,
+}
+
+/// An Oximeter `Metric` that specifies the number of times an instance's guest
+/// reported a guest-handled kernel panic using the QEMU `pvpanic` device.
+#[derive(Debug, Default, Copy, Clone, Metric)]
+struct PvPanicGuestHandled {
+    /// The number of times this instance's guest handled a kernel panic.
+    #[datum]
+    pub count: Cumulative<i64>,
+}
+
+/// An Oximeter `Metric` that specifies the number of times an instance's guest
+/// reported a host-handled kernel panic using the QEMU `pvpanic` device.
+#[derive(Debug, Default, Copy, Clone, Metric)]
+struct PvPanicHostHandled {
+    /// The number of times this instance's reported a host-handled kernel panic.
+    #[datum]
+    pub count: Cumulative<i64>,
+}
+
+impl PvpanicProducer {
+    pub fn new(id: Uuid, counts: Arc<QemuPvpanic>) -> Self {
+        PvpanicProducer {
+            stat_name: InstanceUuid { uuid: id },
+            host_handled_panics: Default::default(),
+            guest_handled_panics: Default::default(),
+            counts,
+        }
+    }
+}
+
+impl Producer for PvpanicProducer {
+    fn produce(
+        &mut self,
+    ) -> Result<Box<dyn Iterator<Item = Sample> + 'static>, MetricsError> {
+        self.host_handled_panics
+            .datum_mut()
+            .set(self.counts.host_handled_count() as i64);
+        self.guest_handled_panics
+            .datum_mut()
+            .set(self.counts.guest_handled_count() as i64);
+        let data = vec![
+            Sample::new(&self.stat_name, &self.guest_handled_panics)?,
+            Sample::new(&self.stat_name, &self.host_handled_panics)?,
+        ];
+
+        Ok(Box::new(data.into_iter()))
+    }
+}

--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -458,6 +458,7 @@ impl VmController {
         let ps2ctrl_id = init.initialize_ps2(&chipset)?;
         let ps2ctrl: Option<Arc<PS2Ctrl>> = inv.get_concrete(ps2ctrl_id);
         init.initialize_qemu_debug_port()?;
+        init.initialize_qemu_pvpanic(properties.id)?;
         init.initialize_network_devices(&chipset)?;
         #[cfg(feature = "falcon")]
         init.initialize_softnpu_ports(&chipset)?;

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -931,12 +931,12 @@ fn setup_instance(
                 chipset.pci_attach(bdf, nvme);
             }
             qemu::pvpanic::DEVICE_NAME => {
-                let enable_isa = dev
+                let enable_mmio = dev
                     .options
-                    .get("enable_isa")
+                    .get("enable_mmio")
                     .and_then(|opt| opt.as_bool())
                     .unwrap_or(false);
-                if enable_isa {
+                if enable_mmio {
                     let pvpanic = QemuPvpanic::create(
                         log.new(slog::o!("dev" => "pvpanic")),
                     );

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -936,6 +936,7 @@ fn setup_instance(
                     .get("enable_isa")
                     .and_then(|opt| opt.as_bool())
                     .unwrap_or(false);
+                slog::debug!(log, "pvpanic enable_isa={enable_isa}");
                 if enable_isa {
                     let pvpanic = QemuPvpanic::create(
                         log.new(slog::o!("dev" => "pvpanic")),

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -16,7 +16,6 @@ use anyhow::Context;
 use clap::Parser;
 use futures::future::BoxFuture;
 use propolis::hw::qemu::pvpanic::QemuPvpanic;
-use propolis::inventory::Entity;
 use slog::{o, Drain};
 use strum::IntoEnumIterator;
 use tokio::runtime;

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -931,12 +931,12 @@ fn setup_instance(
                 chipset.pci_attach(bdf, nvme);
             }
             qemu::pvpanic::DEVICE_NAME => {
-                let enable_mmio = dev
+                let enable_isa = dev
                     .options
-                    .get("enable_mmio")
+                    .get("enable_isa")
                     .and_then(|opt| opt.as_bool())
                     .unwrap_or(false);
-                if enable_mmio {
+                if enable_isa {
                     let pvpanic = QemuPvpanic::create(
                         log.new(slog::o!("dev" => "pvpanic")),
                     );

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -15,15 +15,17 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::Context;
 use clap::Parser;
 use futures::future::BoxFuture;
+use propolis::hw::qemu::pvpanic::QemuPvpanic;
+use propolis::inventory::Entity;
 use slog::{o, Drain};
 use strum::IntoEnumIterator;
 use tokio::runtime;
 
 use propolis::chardev::{BlockingSource, Sink, Source, UDSock};
 use propolis::hw::chipset::{i440fx, Chipset};
-use propolis::hw::ibmpc;
 use propolis::hw::ps2::ctrl::PS2Ctrl;
 use propolis::hw::uart::LpcUart;
+use propolis::hw::{ibmpc, qemu};
 use propolis::intr_pins::FuncPin;
 use propolis::usdt::register_probes;
 use propolis::vcpu::Vcpu;
@@ -928,6 +930,20 @@ fn setup_instance(
                 block::attach(backend, nvme.clone());
 
                 chipset.pci_attach(bdf, nvme);
+            }
+            qemu::pvpanic::DEVICE_NAME => {
+                let enable_isa = dev
+                    .options
+                    .get("enable_isa")
+                    .and_then(|opt| opt.as_bool())
+                    .unwrap_or(false);
+                if enable_isa {
+                    let pvpanic = QemuPvpanic::create(
+                        log.new(slog::o!("dev" => "pvpanic")),
+                    );
+                    pvpanic.attach_pio(pio);
+                    inv.register(&pvpanic)?;
+                }
             }
             _ => {
                 slog::error!(log, "unrecognized driver"; "name" => name);

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -936,7 +936,6 @@ fn setup_instance(
                     .get("enable_isa")
                     .and_then(|opt| opt.as_bool())
                     .unwrap_or(false);
-                slog::debug!(log, "pvpanic enable_isa={enable_isa}");
                 if enable_isa {
                     let pvpanic = QemuPvpanic::create(
                         log.new(slog::o!("dev" => "pvpanic")),

--- a/crates/propolis-api-types/src/instance_spec/components/devices.rs
+++ b/crates/propolis-api-types/src/instance_spec/components/devices.rs
@@ -228,7 +228,7 @@ pub enum MigrationCompatibilityError {
 #[serde(deny_unknown_fields)]
 pub struct QemuPvpanic {
     /// Enable the QEMU PVPANIC ISA bus device (I/O port 0x505).
-    pub enable_mmio: bool,
+    pub enable_isa: bool,
     // TODO(eliza): add support for the PCI PVPANIC device...
 }
 
@@ -428,20 +428,20 @@ mod test {
 
     #[test]
     fn incompatible_qemu_pvpanic() {
-        let d1 = Some(QemuPvpanic { enable_mmio: true });
-        let d2 = Some(QemuPvpanic { enable_mmio: false });
+        let d1 = Some(QemuPvpanic { enable_isa: true });
+        let d2 = Some(QemuPvpanic { enable_isa: false });
         assert!(d1.can_migrate_from_element(&d2).is_err());
         assert!(d1.can_migrate_from_element(&None).is_err());
     }
 
     #[test]
     fn compatible_qemu_pvpanic() {
-        let d1 = Some(QemuPvpanic { enable_mmio: true });
-        let d2 = Some(QemuPvpanic { enable_mmio: true });
+        let d1 = Some(QemuPvpanic { enable_isa: true });
+        let d2 = Some(QemuPvpanic { enable_isa: true });
         assert!(d1.can_migrate_from_element(&d2).is_ok());
 
-        let d1 = Some(QemuPvpanic { enable_mmio: false });
-        let d2 = Some(QemuPvpanic { enable_mmio: false });
+        let d1 = Some(QemuPvpanic { enable_isa: false });
+        let d2 = Some(QemuPvpanic { enable_isa: false });
         assert!(d1.can_migrate_from_element(&d2).is_ok());
     }
 }

--- a/crates/propolis-api-types/src/instance_spec/components/devices.rs
+++ b/crates/propolis-api-types/src/instance_spec/components/devices.rs
@@ -228,7 +228,7 @@ pub enum MigrationCompatibilityError {
 #[serde(deny_unknown_fields)]
 pub struct QemuPvpanic {
     /// Enable the QEMU PVPANIC ISA bus device (I/O port 0x505).
-    pub enable_isa: bool,
+    pub enable_mmio: bool,
     // TODO(eliza): add support for the PCI PVPANIC device...
 }
 
@@ -428,20 +428,20 @@ mod test {
 
     #[test]
     fn incompatible_qemu_pvpanic() {
-        let d1 = Some(QemuPvpanic { enable_isa: true });
-        let d2 = Some(QemuPvpanic { enable_isa: false });
+        let d1 = Some(QemuPvpanic { enable_mmio: true });
+        let d2 = Some(QemuPvpanic { enable_mmio: false });
         assert!(d1.can_migrate_from_element(&d2).is_err());
         assert!(d1.can_migrate_from_element(&None).is_err());
     }
 
     #[test]
     fn compatible_qemu_pvpanic() {
-        let d1 = Some(QemuPvpanic { enable_isa: true });
-        let d2 = Some(QemuPvpanic { enable_isa: true });
+        let d1 = Some(QemuPvpanic { enable_mmio: true });
+        let d2 = Some(QemuPvpanic { enable_mmio: true });
         assert!(d1.can_migrate_from_element(&d2).is_ok());
 
-        let d1 = Some(QemuPvpanic { enable_isa: false });
-        let d2 = Some(QemuPvpanic { enable_isa: false });
+        let d1 = Some(QemuPvpanic { enable_mmio: false });
+        let d2 = Some(QemuPvpanic { enable_mmio: false });
         assert!(d1.can_migrate_from_element(&d2).is_ok());
     }
 }

--- a/crates/propolis-api-types/src/instance_spec/components/devices.rs
+++ b/crates/propolis-api-types/src/instance_spec/components/devices.rs
@@ -232,7 +232,7 @@ pub struct QemuPvpanic {
     // TODO(eliza): add support for the PCI PVPANIC device...
 }
 
-impl MigrationElement for QemuPvpanic {
+impl MigrationElement for Option<QemuPvpanic> {
     fn kind(&self) -> &'static str {
         "QemuPvpanic"
     }
@@ -428,19 +428,20 @@ mod test {
 
     #[test]
     fn incompatible_qemu_pvpanic() {
-        let d1 = QemuPvpanic { enable_isa: true };
-        let d2 = QemuPvpanic { enable_isa: false };
+        let d1 = Some(QemuPvpanic { enable_isa: true });
+        let d2 = Some(QemuPvpanic { enable_isa: false });
         assert!(d1.can_migrate_from_element(&d2).is_err());
+        assert!(d1.can_migrate_from_element(&None).is_err());
     }
 
     #[test]
     fn compatible_qemu_pvpanic() {
-        let d1 = QemuPvpanic { enable_isa: true };
-        let d2 = QemuPvpanic { enable_isa: true };
+        let d1 = Some(QemuPvpanic { enable_isa: true });
+        let d2 = Some(QemuPvpanic { enable_isa: true });
         assert!(d1.can_migrate_from_element(&d2).is_ok());
 
-        let d1 = QemuPvpanic { enable_isa: false };
-        let d2 = QemuPvpanic { enable_isa: false };
+        let d1 = Some(QemuPvpanic { enable_isa: false });
+        let d2 = Some(QemuPvpanic { enable_isa: false });
         assert!(d1.can_migrate_from_element(&d2).is_ok());
     }
 }

--- a/crates/propolis-api-types/src/instance_spec/v0/builder.rs
+++ b/crates/propolis-api-types/src/instance_spec/v0/builder.rs
@@ -176,6 +176,22 @@ impl SpecBuilder {
         }
     }
 
+    /// Adds a QEMU pvpanic device.
+    pub fn add_pvpanic_device(
+        &mut self,
+        pvpanic: components::devices::QemuPvpanic,
+    ) -> Result<&Self, SpecBuilderError> {
+        if self.spec.devices.qemu_pvpanic.is_some() {
+            return Err(SpecBuilderError::DeviceNameInUse(
+                "pvpanic".to_string(),
+            ));
+        }
+
+        self.spec.devices.qemu_pvpanic = Some(pvpanic);
+
+        Ok(self)
+    }
+
     #[cfg(feature = "falcon")]
     pub fn set_softnpu_pci_port(
         &mut self,

--- a/crates/propolis-api-types/src/instance_spec/v0/mod.rs
+++ b/crates/propolis-api-types/src/instance_spec/v0/mod.rs
@@ -113,6 +113,19 @@ pub struct DeviceSpecV0 {
     pub network_devices: HashMap<SpecKey, NetworkDeviceV0>,
     pub serial_ports: HashMap<SpecKey, components::devices::SerialPort>,
     pub pci_pci_bridges: HashMap<SpecKey, components::devices::PciPciBridge>,
+
+    /// This field has a default value (`None`) to allow for
+    /// backwards-compatibility when upgrading from a Propolis
+    /// version that does not support this device. If the pvpanic device was not
+    /// present in the spec being deserialized, a `None` will be produced,
+    /// rather than rejecting the spec.
+    #[serde(default)]
+    /// Skip serializing this field if it is `None`. This is so that Propolis
+    /// versions with support for this device are backwards-compatible with
+    /// older versions that don't, as long as the spec doesn't define a pvpanic
+    /// device --- if there is no panic device, skipping the field from the spec
+    /// means that the older version will still accept the spec.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub qemu_pvpanic: Option<components::devices::QemuPvpanic>,
 
     #[cfg(feature = "falcon")]

--- a/crates/propolis-api-types/src/instance_spec/v0/mod.rs
+++ b/crates/propolis-api-types/src/instance_spec/v0/mod.rs
@@ -113,7 +113,7 @@ pub struct DeviceSpecV0 {
     pub network_devices: HashMap<SpecKey, NetworkDeviceV0>,
     pub serial_ports: HashMap<SpecKey, components::devices::SerialPort>,
     pub pci_pci_bridges: HashMap<SpecKey, components::devices::PciPciBridge>,
-    pub qemu_pvpanic: components::devices::QemuPvpanic,
+    pub qemu_pvpanic: Option<components::devices::QemuPvpanic>,
 
     #[cfg(feature = "falcon")]
     pub softnpu_pci_port: Option<components::devices::SoftNpuPciPort>,

--- a/crates/propolis-api-types/src/instance_spec/v0/mod.rs
+++ b/crates/propolis-api-types/src/instance_spec/v0/mod.rs
@@ -113,6 +113,7 @@ pub struct DeviceSpecV0 {
     pub network_devices: HashMap<SpecKey, NetworkDeviceV0>,
     pub serial_ports: HashMap<SpecKey, components::devices::SerialPort>,
     pub pci_pci_bridges: HashMap<SpecKey, components::devices::PciPciBridge>,
+    pub qemu_pvpanic: components::devices::QemuPvpanic,
 
     #[cfg(feature = "falcon")]
     pub softnpu_pci_port: Option<components::devices::SoftNpuPciPort>,
@@ -165,6 +166,15 @@ impl DeviceSpecV0 {
             .map_err(|e| {
                 MigrationCompatibilityError::CollectionMismatch(
                     "PCI bridges".to_string(),
+                    e,
+                )
+            })?;
+
+        self.qemu_pvpanic
+            .can_migrate_from_element(&other.qemu_pvpanic)
+            .map_err(|e| {
+                MigrationCompatibilityError::ElementMismatch(
+                    "QEMU PVPANIC device".to_string(),
                     e,
                 )
             })?;

--- a/crates/propolis-api-types/src/instance_spec/v0/mod.rs
+++ b/crates/propolis-api-types/src/instance_spec/v0/mod.rs
@@ -114,17 +114,17 @@ pub struct DeviceSpecV0 {
     pub serial_ports: HashMap<SpecKey, components::devices::SerialPort>,
     pub pci_pci_bridges: HashMap<SpecKey, components::devices::PciPciBridge>,
 
-    /// This field has a default value (`None`) to allow for
-    /// backwards-compatibility when upgrading from a Propolis
-    /// version that does not support this device. If the pvpanic device was not
-    /// present in the spec being deserialized, a `None` will be produced,
-    /// rather than rejecting the spec.
+    // This field has a default value (`None`) to allow for
+    // backwards-compatibility when upgrading from a Propolis
+    // version that does not support this device. If the pvpanic device was not
+    // present in the spec being deserialized, a `None` will be produced,
+    // rather than rejecting the spec.
     #[serde(default)]
-    /// Skip serializing this field if it is `None`. This is so that Propolis
-    /// versions with support for this device are backwards-compatible with
-    /// older versions that don't, as long as the spec doesn't define a pvpanic
-    /// device --- if there is no panic device, skipping the field from the spec
-    /// means that the older version will still accept the spec.
+    // Skip serializing this field if it is `None`. This is so that Propolis
+    // versions with support for this device are backwards-compatible with
+    // older versions that don't, as long as the spec doesn't define a pvpanic
+    // device --- if there is no panic device, skipping the field from the spec
+    // means that the older version will still accept the spec.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub qemu_pvpanic: Option<components::devices::QemuPvpanic>,
 

--- a/lib/propolis/src/hw/qemu/mod.rs
+++ b/lib/propolis/src/hw/qemu/mod.rs
@@ -4,4 +4,5 @@
 
 pub mod debug;
 pub mod fwcfg;
+pub mod pvpanic;
 pub mod ramfb;

--- a/lib/propolis/src/hw/qemu/pvpanic.rs
+++ b/lib/propolis/src/hw/qemu/pvpanic.rs
@@ -7,6 +7,15 @@ use std::sync::{Arc, Mutex};
 use crate::common::*;
 use crate::pio::{PioBus, PioFn};
 
+/// Implements the QEMU [pvpanic device], which
+/// may be used by guests to notify the host when a kernel panic has occurred.
+///
+/// QEMU exposes the pvpanic virtual device as a device on the ISA bus (I/O port
+/// 0x505), a PCI device, and through ACPI. Currently, Propolis only implements
+/// the ISA bus pvpanic device, but the PCI device may be implemented in the
+/// future.
+///
+/// [pvpanic device]: https://www.qemu.org/docs/master/specs/pvpanic.html
 #[derive(Debug)]
 pub struct QemuPvpanic {
     counts: Mutex<Counts>,
@@ -42,6 +51,7 @@ impl QemuPvpanic {
         })
     }
 
+    /// Attaches this pvpanic device to the provided [`PioBus`].
     pub fn attach_pio(self: &Arc<Self>, pio: &PioBus) {
         let piodev = self.clone();
         let piofn = Arc::new(move |_port: u16, rwo: RWOp| piodev.pio_rw(rwo))

--- a/lib/propolis/src/hw/qemu/pvpanic.rs
+++ b/lib/propolis/src/hw/qemu/pvpanic.rs
@@ -68,12 +68,10 @@ impl QemuPioPvpanic {
 }
 
 impl PanicCounts {
-    #[must_use]
     pub fn host_handled_count(&self) -> usize {
         self.host_handled.load(Relaxed)
     }
 
-    #[must_use]
     pub fn guest_handled_count(&self) -> usize {
         self.guest_handled.load(Relaxed)
     }

--- a/lib/propolis/src/hw/qemu/pvpanic.rs
+++ b/lib/propolis/src/hw/qemu/pvpanic.rs
@@ -11,9 +11,10 @@ use crate::common::*;
 use crate::pio::{PioBus, PioFn};
 
 pub struct QemuPioPvpanic {
-    counts: Arc<PanicCOunts>,
+    counts: Arc<PanicCounts>,
 }
 
+#[derive(Debug, Default)]
 pub struct PanicCounts {
     host_handled: AtomicUsize,
     guest_handled: AtomicUsize,
@@ -74,6 +75,6 @@ impl PanicCounts {
 
 impl Entity for QemuPioPvpanic {
     fn type_name(&self) -> &'static str {
-        "qemu-vpanic-pio"
+        "qemu-pvpanic-pio"
     }
 }

--- a/lib/propolis/src/hw/qemu/pvpanic.rs
+++ b/lib/propolis/src/hw/qemu/pvpanic.rs
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::sync::Arc;
+
+use crate::chardev::{BlockingSource, BlockingSourceConsumer, ConsumerCell};
+use crate::common::*;
+use crate::pio::{PioBus, PioFn};
+
+const QEMU_PVPANIC_IOPORT: u16 = 0x505;
+
+/// Indicates that a guest panic has happened and should be processed by the
+/// host
+const HOST_HANDLED: u8 = 0b01;
+/// Indicates a guest panic has happened and will be handled by the guest; the
+/// host should record it or report it, but should not affect the execution of
+/// the guest.
+const GUEST_HANDLED: u8 = 0b10;
+
+pub struct QemuPioPvpanic {
+    consumer: ConsumerCell,
+}
+
+impl QemuPioPvpanic {
+    pub fn create(pio: &PioBus) -> Arc<Self> {
+        let this = Arc::new(Self { consumer: ConsumerCell::new() });
+
+        let piodev = this.clone();
+        let piofn = Arc::new(move |_port: u16, rwo: RWOp| piodev.pio_rw(rwo))
+            as Arc<PioFn>;
+        pio.register(QEMU_PVPANIC_IOPORT, 1, piofn).unwrap();
+        this
+    }
+
+    fn pio_rw(&self, rwo: RWOp) {
+        match rwo {
+            RWOp::Read(ro) => {
+                ro.write_u8(HOST_HANDLED | GUEST_HANDLED);
+            }
+            RWOp::Write(wo) => {
+                let c = wo.read_u8();
+                self.consumer.consume(&[c]);
+            }
+        }
+    }
+}
+
+impl BlockingSource for QemuDebugPort {
+    fn set_consumer(&self, f: Option<BlockingSourceConsumer>) {
+        self.consumer.set(f);
+    }
+}
+
+impl Entity for QemuDebugPort {
+    fn type_name(&self) -> &'static str {
+        "qemu-lpc-debug"
+    }
+}

--- a/lib/propolis/src/hw/qemu/pvpanic.rs
+++ b/lib/propolis/src/hw/qemu/pvpanic.rs
@@ -30,6 +30,8 @@ struct Counts {
     guest_handled: usize,
 }
 
+pub const DEVICE_NAME: &str = "qemu-pvpanic";
+
 /// Indicates that a guest panic has happened and should be processed by the
 /// host
 const HOST_HANDLED: u8 = 0b01;
@@ -102,6 +104,6 @@ impl QemuPvpanic {
 
 impl Entity for QemuPvpanic {
     fn type_name(&self) -> &'static str {
-        "qemu-pvpanic"
+        DEVICE_NAME
     }
 }

--- a/openapi/propolis-server-falcon.json
+++ b/openapi/propolis-server-falcon.json
@@ -631,6 +631,14 @@
               "$ref": "#/components/schemas/PciPciBridge"
             }
           },
+          "qemu_pvpanic": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/QemuPvpanic"
+              }
+            ]
+          },
           "serial_ports": {
             "type": "object",
             "additionalProperties": {
@@ -1402,6 +1410,19 @@
         "required": [
           "downstream_bus",
           "pci_path"
+        ],
+        "additionalProperties": false
+      },
+      "QemuPvpanic": {
+        "type": "object",
+        "properties": {
+          "enable_isa": {
+            "description": "Enable the QEMU PVPANIC ISA bus device (I/O port 0x505).",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enable_isa"
         ],
         "additionalProperties": false
       },

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -625,7 +625,6 @@
           },
           "qemu_pvpanic": {
             "nullable": true,
-            "description": "This field has a default value (`None`) to allow for backwards-compatibility when upgrading from a Propolis version that does not support this device. If the pvpanic device was not present in the spec being deserialized, a `None` will be produced, rather than rejecting the spec. Skip serializing this field if it is `None`. This is so that Propolis versions with support for this device are backwards-compatible with older versions that don't, as long as the spec doesn't define a pvpanic device --- if there is no panic device, skipping the field from the spec means that the older version will still accept the spec.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/QemuPvpanic"

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -1351,13 +1351,13 @@
       "QemuPvpanic": {
         "type": "object",
         "properties": {
-          "enable_isa": {
+          "enable_mmio": {
             "description": "Enable the QEMU PVPANIC ISA bus device (I/O port 0x505).",
             "type": "boolean"
           }
         },
         "required": [
-          "enable_isa"
+          "enable_mmio"
         ],
         "additionalProperties": false
       },

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -1351,13 +1351,13 @@
       "QemuPvpanic": {
         "type": "object",
         "properties": {
-          "enable_mmio": {
+          "enable_isa": {
             "description": "Enable the QEMU PVPANIC ISA bus device (I/O port 0x505).",
             "type": "boolean"
           }
         },
         "required": [
-          "enable_mmio"
+          "enable_isa"
         ],
         "additionalProperties": false
       },

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -623,6 +623,14 @@
               "$ref": "#/components/schemas/PciPciBridge"
             }
           },
+          "qemu_pvpanic": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/QemuPvpanic"
+              }
+            ]
+          },
           "serial_ports": {
             "type": "object",
             "additionalProperties": {
@@ -1337,6 +1345,19 @@
         "required": [
           "downstream_bus",
           "pci_path"
+        ],
+        "additionalProperties": false
+      },
+      "QemuPvpanic": {
+        "type": "object",
+        "properties": {
+          "enable_isa": {
+            "description": "Enable the QEMU PVPANIC ISA bus device (I/O port 0x505).",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enable_isa"
         ],
         "additionalProperties": false
       },

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -625,6 +625,7 @@
           },
           "qemu_pvpanic": {
             "nullable": true,
+            "description": "This field has a default value (`None`) to allow for backwards-compatibility when upgrading from a Propolis version that does not support this device. If the pvpanic device was not present in the spec being deserialized, a `None` will be produced, rather than rejecting the spec. Skip serializing this field if it is `None`. This is so that Propolis versions with support for this device are backwards-compatible with older versions that don't, as long as the spec doesn't define a pvpanic device --- if there is no panic device, skipping the field from the spec means that the older version will still accept the spec.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/QemuPvpanic"


### PR DESCRIPTION
This branch adds support for the [pvpanic] virtual device implemented by
QEMU. This device allows guests to report kernel panics to the
hypervisor. In `propolis-server`, guest-reported kernel panics are
handled by incrementing an Oximeter metric.

The pvpanic device can be exposed to the guest either as an ISA bus I/O
port device or as a PCI bus device. This branch implements the ISA bus
device. I'd like to also add a PCI pvpanic device, but will implement
that in a subsequent pull request.

In order for the guest to detect the ISA bus pvpanic device, it's
necessary to add an entry for the panic device to the ACPI DSDT table.
This is the AML that QEMU adds to its DSDT when the ISA bus pvpanic
device is enabled:

```
//
// QEMU panic device
//
Device (PEVT)
{
    Name (_HID, "QEMU0001")  // _HID: Hardware ID
    Name (_CRS, ResourceTemplate ()  // _CRS: Current Resource Settings
    {
        IO (Decode16,
            0x0505,             // Range Minimum
            0x0505,             // Range Maximum
            0x01,               // Alignment
            0x01,               // Length
            )
    })
    OperationRegion (PEOR, SystemIO, 0x0505, One)
    Field (PEOR, ByteAcc, NoLock, Preserve)
    {
        PEPT,   8
    }

    Name (_STA, 0x0F)  // _STA: Status
    Method (RDPT, 0, NotSerialized)
    {
        Local0 = PEPT /* \_SB_.PCI0.S08_.PEVT.PEPT */
        Return (Local0)
    }

    Method (WRPT, 1, NotSerialized)
    {
        PEPT = Arg0
    }
}
```

This means that in order for guests to use this device, we need to boot
with an ACPI table that contains this entry. For testing purposes, I
modified EDK2 OVMF to add this entry to the DSDT. In the future, though,
we'll likely want Propolis to generate ACPI tables dynamically on boot
based on the instance spec.

The EDK2 changes I used for testing this are available [here][edk2].

To test this change, I ran `propolis-standalone` with an Alpine Linux
3.19 guest,, and the following device added to the VM config file:

```toml
[dev.pvpanic]
driver = "qemu-pvpanic"
enable_mmio = true
```

The guest correctly detects the panic device and loads the appropriate
kernel module. If I then trigger a panic in the guest using SysRq, like
this:

```console
$ echo 1 > /proc/sys/kernel/sysrq
$ echo c > /proc/sysrq-trigger
```

The guest crashes, and `propolis-standalone` logs:

```
dev: pvpanic
 Jan 11 18:14:13.494 DEBG guest kernel panic, guest_handled: false, host_handled: true
```

Closes #592 

[pvpanic]: https://www.qemu.org/docs/master/specs/pvpanic.html
[edk2]:
    https://github.com/oxidecomputer/edk2/commit/6ca196ffca7a91884b4bd693df7b58d833d1ad42