### PR TITLE
standalone: allow overriding log level from CLI

### DIFF
--- a/bin/propolis-standalone/Cargo.toml
+++ b/bin/propolis-standalone/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 anyhow.workspace = true
 atty.workspace = true
 bhyve_api.workspace = true
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "env"] }
 ctrlc.workspace = true
 fatfs.workspace = true
 futures.workspace = true

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -1031,7 +1031,12 @@ struct Args {
     restore: bool,
 
     /// Maximum log level filter.
-    #[clap(long, env = "PROPOLIS_LOG", default_value_t = LogFilter(slog::Level::Info))]
+    #[clap(
+        long,
+        env = "PROPOLIS_LOG",
+        default_value_t = LogFilter(slog::Level::Info),
+        ignore_case(true),
+    )]
     log_level: LogFilter,
 }
 

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -1105,6 +1105,8 @@ fn main() -> anyhow::Result<ExitCode> {
     Ok(inst.wait_destroyed())
 }
 
+/// Wrapper around `slog::Level` to implement `clap::ValueEnum`, so that this
+/// type can be parsed from the command line.
 #[derive(Clone, Debug)]
 struct LogFilter(slog::Level);
 


### PR DESCRIPTION
Currently, `propolis-standalone` hard-codes the maximum `slog` log level to `Info`. Since `propolis-standalone` is intended for development use, it may sometimes be useful to enable more verbose logging. Therefore, this branch adds a `--log-level` CLI argument to allow overriding the maximum log level filter. The `PROPOLIS_LOG` environment variable may also be used to configure the log level.