### PR TITLE
phd: Ensure min disk size fits read-only parents

### DIFF
--- a/phd-tests/framework/src/disk/mod.rs
+++ b/phd-tests/framework/src/disk/mod.rs
@@ -186,13 +186,15 @@ impl DiskFactory {
     ///   If the source data is stored as a file on the local disk, the
     ///   resulting disk's `VolumeConstructionRequest`s will specify that this
     ///   file should be used as a read-only parent volume.
-    /// - disk_size_gib: The disk's expected size in GiB.
+    /// - min_disk_size_gib: The disk's minimum size in GiB. If the size of the
+    ///   `source` artifact is larger than the minimum size, the disk will be
+    ///   the size of the source artifact, instead.
     /// - block_size: The disk's block size.
     pub(crate) fn create_crucible_disk(
         &self,
         name: String,
         source: DiskSource,
-        disk_size_gib: u64,
+        min_disk_size_gib: u64,
         block_size: BlockSize,
     ) -> Result<Arc<CrucibleDisk>, DiskError> {
         let binary_path = self.artifact_store.get_crucible_downstairs()?;
@@ -208,7 +210,7 @@ impl DiskFactory {
 
         CrucibleDisk::new(
             name,
-            disk_size_gib,
+            min_disk_size_gib,
             block_size,
             &binary_path.as_std_path(),
             &ports,

--- a/phd-tests/framework/src/test_vm/config.rs
+++ b/phd-tests/framework/src/test_vm/config.rs
@@ -26,7 +26,7 @@ pub enum DiskInterface {
 #[derive(Clone, Copy, Debug)]
 pub enum DiskBackend {
     File,
-    Crucible { disk_size_gib: u64, block_size: crate::disk::BlockSize },
+    Crucible { min_disk_size_gib: u64, block_size: crate::disk::BlockSize },
 }
 
 #[derive(Clone, Debug)]
@@ -156,13 +156,13 @@ impl VmConfig {
                             &req.source_artifact
                         )
                     })?,
-                DiskBackend::Crucible { disk_size_gib, block_size } => {
+                DiskBackend::Crucible { min_disk_size_gib, block_size } => {
                     framework
                         .disk_factory
                         .create_crucible_disk(
                             name,
                             source,
-                            disk_size_gib,
+                            min_disk_size_gib,
                             block_size,
                         )
                         .with_context(|| {

--- a/phd-tests/tests/src/crucible/mod.rs
+++ b/phd-tests/tests/src/crucible/mod.rs
@@ -19,7 +19,7 @@ fn add_crucible_boot_disk_or_skip(
     artifact: &str,
     interface: DiskInterface,
     pci_slot: u8,
-    disk_size_gib: u64,
+    min_disk_size_gib: u64,
     block_size: BlockSize,
 ) -> phd_testcase::Result<()> {
     if !ctx.crucible_enabled() {
@@ -29,7 +29,7 @@ fn add_crucible_boot_disk_or_skip(
     config.boot_disk(
         artifact,
         interface,
-        DiskBackend::Crucible { disk_size_gib, block_size },
+        DiskBackend::Crucible { min_disk_size_gib, block_size },
         pci_slot,
     );
 


### PR DESCRIPTION
Today PHD's Crucible tests unconditionally specify a 10 GiB guest disk
even if the guest image being used as a read-only parent is larger than
that. To avoid truncating, tests should specify a minimum guest disk
size, and PHD should expand it to the underlying guest image size if
that exceeds what the test specified.

This branch changes the `disk_size_gib` argument to functions that
create Crucible disks to `min_disk_size_gib`. If a disk is created with
a read-only parent, the code that constructs new Crucible disks
(`CrucibleDisk::new`) will now read the FS metadata for the parent image
to determine its size, and uses that to set the size of the created disk
to ensure that the read-only parent image fits.

Fixes #605