### PR TITLE
PHD: fix `--artifact-directory` not doing anything

### DIFF
--- a/phd-tests/framework/src/lib.rs
+++ b/phd-tests/framework/src/lib.rs
@@ -81,6 +81,7 @@ pub struct FrameworkParameters<'a> {
     pub base_propolis: Option<BasePropolisSource<'a>>,
 
     pub tmp_directory: Utf8PathBuf,
+    pub artifact_directory: Utf8PathBuf,
     pub artifact_toml: Utf8PathBuf,
     pub server_log_mode: ServerLogMode,
 
@@ -115,7 +116,7 @@ impl Framework {
     /// one framework and then distributes it to tests.
     pub fn new(params: FrameworkParameters<'_>) -> anyhow::Result<Self> {
         let mut artifact_store = artifacts::ArtifactStore::from_toml_path(
-            params.tmp_directory.clone(),
+            params.artifact_directory.clone(),
             &params.artifact_toml,
             params.max_buildomat_wait,
         )

--- a/phd-tests/runner/src/config.rs
+++ b/phd-tests/runner/src/config.rs
@@ -137,8 +137,11 @@ pub struct RunOptions {
 
     /// The directory in which artifacts (guest OS images, bootroms, etc.)
     /// are to be stored.
+    ///
+    /// If this argument is not provided, artifacts will be stored in the
+    /// directory passed to `--tmp-directory`.
     #[clap(long, value_parser)]
-    pub artifact_directory: Utf8PathBuf,
+    artifact_directory: Option<Utf8PathBuf>,
 
     /// If true, direct Propolis servers created by the runner to log to
     /// stdout/stderr handles inherited from the runner.
@@ -237,6 +240,10 @@ impl FromStr for ArtifactCommit {
 }
 
 impl RunOptions {
+    pub fn artifact_directory(&self) -> Utf8PathBuf {
+        self.artifact_directory.as_ref().unwrap_or(&self.tmp_directory).clone()
+    }
+
     pub fn crucible_downstairs(
         &self,
     ) -> anyhow::Result<Option<CrucibleDownstairsSource>> {

--- a/phd-tests/runner/src/main.rs
+++ b/phd-tests/runner/src/main.rs
@@ -50,6 +50,7 @@ fn run_tests(run_opts: &RunOptions) -> anyhow::Result<ExecutionStats> {
         crucible_downstairs: run_opts.crucible_downstairs()?,
         base_propolis: run_opts.base_propolis(),
         tmp_directory: run_opts.tmp_directory.clone(),
+        artifact_directory: run_opts.artifact_directory(),
         artifact_toml: run_opts.artifact_toml_path.clone(),
         server_log_mode: run_opts.server_logging_mode,
         default_guest_cpus: run_opts.default_guest_cpus,


### PR DESCRIPTION
Currently, the `phd-runner` CLI requires both a `--tmp-directory` argument and an `--artifact-directory` argument. This should, in theory, permit the artifact directory to be located outside the temp directory, if requested by the user.

However, the `--artifact-directory` argument is not actually honored by PHD, and the artifact store is always constructed in the temp directory. This is kind of unfortunate, since there are some nice reasons to separate the artifact store and the temp directory. For example, I might want to create a unique temp dir every time I run PHD tests, so that I don't clobber logs from previous test runs. Under the current behavior, since the artifact store is always located in the temp dir, this would mean re-downloading artifacts on every run, which seems sad. Also, it's not great that we require the `--artifact-directory` argument, but then don't ever actually use its value :)

This commit fixes this issue, by making the `--artifact-directory` argument actually control the path of the artifact store. Also, I've made the `--artifact-directory` argument optional, and used the temp dir as the default if the artifact dir isn't provided. If this behavior is unwanted, I can always change this back to a required argument.