### PR TITLE
PHD: fix missing newlines in serial.log

### DIFF
--- a/phd-tests/framework/src/serial/raw_buffer.rs
+++ b/phd-tests/framework/src/serial/raw_buffer.rs
@@ -31,6 +31,8 @@ impl Inner {
     fn push_character(&mut self, c: char) {
         if c == '\n' {
             self.log.write_all(self.line_buffer.as_bytes()).unwrap();
+            self.log.write_all(b"\n").unwrap();
+            self.log.flush().unwrap();
             self.line_buffer.clear();
         } else {
             self.line_buffer.push(c);


### PR DESCRIPTION
PR #615 changed PHD's serial handling code writes serial output from the guest to a file, `<name_of_test_vm>.serial.log`. Output is written to the file every time a newline is received on the serial port. However, the way this is implemented is by special-casing the receipt of a `\n` character from the serial port to write out the current line and reset it rather than appending the character to the buffer. This means that the serial output is written to the file without any newlines, resulting in a pretty illegible log file.

This commit fixes that by writing a newline character after writing the buffered line. I've also added a `flush` call after writing out a full line to ensure that lines are visible in the log file immediately.