### PR TITLE
PHD: demote artifact store logs to DEBUG, enable DEBUG on CI

### DIFF
--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -55,7 +55,7 @@ ls $propolis
 # Disable errexit so that we still upload logs on failure
 set +e
 
-(RUST_BACKTRACE=1 RUST_LOG=debug ptime -m pfexec $runner \
+(RUST_BACKTRACE=1 RUST_LOG="info,phd=debug" ptime -m pfexec $runner \
 	--emit-bunyan \
 	run \
 	--propolis-server-cmd $propolis \

--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -55,7 +55,7 @@ ls $propolis
 # Disable errexit so that we still upload logs on failure
 set +e
 
-(RUST_BACKTRACE=1 ptime -m pfexec $runner \
+(RUST_BACKTRACE=1 RUST_LOG=debug ptime -m pfexec $runner \
 	--emit-bunyan \
 	run \
 	--propolis-server-cmd $propolis \

--- a/phd-tests/framework/src/artifacts/buildomat.rs
+++ b/phd-tests/framework/src/artifacts/buildomat.rs
@@ -6,7 +6,7 @@ use anyhow::Context;
 use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, fmt, str::FromStr, time::Duration};
-use tracing::{debug, info};
+use tracing::{debug, warn};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(transparent)]

--- a/phd-tests/framework/src/artifacts/buildomat.rs
+++ b/phd-tests/framework/src/artifacts/buildomat.rs
@@ -6,6 +6,7 @@ use anyhow::Context;
 use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, fmt, str::FromStr, time::Duration};
+use tracing::{debug, info};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -209,7 +210,7 @@ impl super::DownloadConfig {
         &self,
         uri: &str,
     ) -> anyhow::Result<bytes::Bytes> {
-        tracing::info!(
+        debug!(
             timeout = ?self.timeout,
             %uri,
             "Downloading file from Buildomat...",
@@ -244,7 +245,7 @@ impl super::DownloadConfig {
         };
 
         let log_retry = |error, wait| {
-            tracing::info!(
+            warn!(
                 %error,
                 %uri,
                 "Buildomat download failed, trying again in {wait:?}..."


### PR DESCRIPTION
In most cases, developers running the PHD tests don't actually care that
much about the details of what the artifact store is doing. If I'm
trying to test changes to Propolis, I probably only want to see logs
that actually tell me about what the test is doing. If the artifact
store is correctly configured, seeing these logs doesn't help me
understand my test's behavior. However, these logs *are* useful for
debugging the test framework itself, or while debugging a new test case
that isn't working as expected.

Therefore, I've demoted most of the `tracing` logs in the PHD artifact
store module from `INFO` to `DEBUG`. Now, they are hidden by default
when running tests, to reduce output noise, but we can opt in to them
when debugging the test framework by setting `RUST_LOG=info,phd=debug`
or similar. 

Additionally, I've changed `phd-run.sh` to set the `tracing` filter to
`info,phd=debug` when running on Buildomat. This way, the logs I changed
to `DEBUG` are still captured in the CI logs. On CI, we can use the
display filtering I added to Buildomat's rendered Bunyan pages in
oxidecomputer/buildomat#49 to hide them when viewing the test's logs.
This way, we can _capture_ all the logs when running CI, but pick and
choose what's shown when reading them in the web UI.