### PR TITLE
PHD: add documentation for `cargo xtask phd`

### DIFF
--- a/phd-tests/README.md
+++ b/phd-tests/README.md
@@ -148,8 +148,9 @@ running `phd-runner` directly:
 
 - Automatically rebuilding the `propolis-server` binary whenever the source code
   changes, to prevent accidentally running tests against a stale build.
-- Automatically [managing a PHD artifact store and test temporary directories]
-  (#artifact-store-and-temporary-directory-management) in `target/phd`.
+- Automatically [managing a PHD artifact store and test temporary
+  directories](#artifact-store-and-temporary-directory-management) in
+  `target/phd`.
 - Providing [reasonable defaults](#default-arguments) (which may be overridden)
   for [arguments required by the `phd-runner` CLI](#runtime-options).
 

--- a/xtask/src/task_phd.rs
+++ b/xtask/src/task_phd.rs
@@ -163,7 +163,7 @@ pub(crate) fn cmd_phd(phd_args: Vec<String>) -> anyhow::Result<()> {
             .arg(propolis_base_branch.unwrap_or("master"))
             .arg(args::ARTIFACTS_TOML)
             .arg(&artifacts_toml)
-            .arg("--artifact-directory")
+            .arg(args::ARTIFACTS_DIR)
             .arg(&artifact_dir)
             .arg("--tmp-directory")
             .arg(&tmp_dir)


### PR DESCRIPTION
Currently, the `cargo xtask phd` command added in #619 lacks documentation. I've added a bit to `phd-tests/README.md` explaining what it does and how to use it.