### PR TITLE
PHD: fix `cargo xtask phd` tidy not doing anything

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -38,11 +38,9 @@ enum Cmds {
     /// Preform pre-push checks (clippy, license, fmt, etc)
     Prepush,
     /// Run the PHD test suite
-    #[clap(disable_help_subcommand = true)]
     Phd {
-        /// Arguments to pass to `phd-runner`.
-        #[clap(trailing_var_arg = true)]
-        phd_args: Vec<String>,
+        #[clap(subcommand)]
+        cmd: task_phd::Cmd,
     },
 }
 
@@ -58,7 +56,7 @@ fn main() -> Result<()> {
             println!("License checks pass");
             Ok(())
         }
-        Cmds::Phd { phd_args } => task_phd::cmd_phd(phd_args),
+        Cmds::Phd { cmd } => cmd.run(),
         Cmds::Prepush => {
             task_prepush::cmd_prepush()?;
 

--- a/xtask/src/task_phd.rs
+++ b/xtask/src/task_phd.rs
@@ -79,7 +79,13 @@ pub(crate) struct RunArgs {
 
     /// Arguments to pass to `phd-runner run`.
     ///
-    /// Use `cargo xtask phd runner-help` for details on the arguments passed to `phd-runner`.
+    /// If the `--propolis-server-cmd`, `--crucible-downstairs-commit`,
+    /// `--base-propolis-branch`, `--artifact-toml-path`, or
+    /// `--artifact-directory` arguments are passed here, they will override
+    /// `cargo xtask phd`'s default values for those arguments.
+    ///
+    /// Use `cargo xtask phd runner-help` for details on the arguments passed to
+    /// `phd-runner`.
     #[clap(trailing_var_arg = true)]
     phd_args: Vec<String>,
 }
@@ -221,7 +227,7 @@ impl Cmd {
         let status = run_exit_code(
             phd_runner
                 .command()
-                .arg(args::RUN)
+                .arg("run")
                 .arg(args::PROPOLIS_CMD)
                 .arg(&propolis_local_path)
                 .arg(args::CRUCIBLE_COMMIT)
@@ -242,7 +248,6 @@ impl Cmd {
 }
 
 mod args {
-    pub(super) const RUN: &str = "run";
     pub(super) const PROPOLIS_CMD: &str = "--propolis-server-cmd";
     pub(super) const PROPOLIS_BASE: &str = "--base-propolis-branch";
     pub(super) const CRUCIBLE_COMMIT: &str = "--crucible-downstairs-commit";

--- a/xtask/src/task_phd.rs
+++ b/xtask/src/task_phd.rs
@@ -228,19 +228,19 @@ impl Cmd {
             phd_runner
                 .command()
                 .arg("run")
-              .arg(args::PROPOLIS_CMD)
-              .arg(&propolis_local_path)
-              .arg(args::CRUCIBLE_COMMIT)
-              .arg(crucible_commit.unwrap_or("auto"))
-              .arg(args::PROPOLIS_BASE)
-              .arg(propolis_base_branch.unwrap_or("master"))
-              .arg(args::ARTIFACTS_TOML)
-              .arg(&artifacts_toml)
-              .arg(args::ARTIFACTS_DIR)
-              .arg(&artifact_dir)
-              .arg("--tmp-directory")
-              .arg(&tmp_dir)
-              .args(bonus_args),
+                .arg(args::PROPOLIS_CMD)
+                .arg(&propolis_local_path)
+                .arg(args::CRUCIBLE_COMMIT)
+                .arg(crucible_commit.unwrap_or("auto"))
+                .arg(args::PROPOLIS_BASE)
+                .arg(propolis_base_branch.unwrap_or("master"))
+                .arg(args::ARTIFACTS_TOML)
+                .arg(&artifacts_toml)
+                .arg(args::ARTIFACTS_DIR)
+                .arg(&artifact_dir)
+                .arg("--tmp-directory")
+                .arg(&tmp_dir)
+                .args(bonus_args),
         )?;
 
         std::process::exit(status);


### PR DESCRIPTION
`cargo xtask phd` attempts to delete test temporary directories that are older than one day. However, because the code for seeing how old a temp dir is accidentally used the dir's last accessed time, checking how old the dir is makes it look like it's always less than a day old, so stuff never gets deleted. I've changed this code to use the last modified time instead.

In addition, I've added a new `cargo xtask phd tidy` subcommand that *just* deletes old temp dirs, without building `phd-runner` or `propolis-server`. This is a bit quicker if all you want is to free up some space.