### PR TITLE
standalone: improve virtual device creation errors

### DIFF
--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -879,6 +879,8 @@ fn setup_instance(
 
     for (name, dev) in config.devices.iter() {
         let driver = &dev.driver as &str;
+        slog::debug!(log, "creating device"; "name" => ?name, "driver" => %driver);
+
         let bdf = if driver.starts_with("pci-") {
             config::parse_bdf(
                 dev.options.get("pci-path").unwrap().as_str().unwrap(),
@@ -953,7 +955,7 @@ fn setup_instance(
                     }
                 }
                 _ => {
-                    slog::error!(log, "unrecognized driver"; "name" => name);
+                    slog::error!(log, "unrecognized driver {driver}"; "name" => name);
                     return Err(Error::new(
                         ErrorKind::Other,
                         "Unrecognized driver",

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -908,7 +908,10 @@ fn setup_instance(
 
                     let viona = hw::virtio::PciVirtioViona::new(
                         vnic_name, 0x100, &hdl,
-                    )?;
+                    )
+                    .with_context(|| {
+                        format!("Could not connect to VioNA VNIC '{vnic_name}'")
+                    })?;
                     inv.register_instance(&viona, bdf.to_string())?;
                     chipset.pci_attach(bdf, viona);
                 }

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -886,73 +886,83 @@ fn setup_instance(
         } else {
             None
         };
-        match driver {
-            "pci-virtio-block" => {
-                let (backend, creg) = config::block_backend(&config, dev, log);
-                let bdf = bdf.unwrap();
+        let create_device = || -> anyhow::Result<()> {
+            match driver {
+                "pci-virtio-block" => {
+                    let (backend, creg) =
+                        config::block_backend(&config, dev, log);
+                    let bdf = bdf.unwrap();
 
-                let vioblk = hw::virtio::PciVirtioBlock::new(0x100);
-                let id = inv.register_instance(&vioblk, bdf.to_string())?;
-                let _be_id = inv.register_child(creg, id)?;
+                    let vioblk = hw::virtio::PciVirtioBlock::new(0x100);
+                    let id = inv.register_instance(&vioblk, bdf.to_string())?;
+                    let _be_id = inv.register_child(creg, id)?;
 
-                block::attach(backend, vioblk.clone());
+                    block::attach(backend, vioblk.clone());
 
-                chipset.pci_attach(bdf, vioblk);
-            }
-            "pci-virtio-viona" => {
-                let vnic_name =
-                    dev.options.get("vnic").unwrap().as_str().unwrap();
-                let bdf = bdf.unwrap();
-
-                let viona =
-                    hw::virtio::PciVirtioViona::new(vnic_name, 0x100, &hdl)?;
-                inv.register_instance(&viona, bdf.to_string())?;
-                chipset.pci_attach(bdf, viona);
-            }
-            "pci-nvme" => {
-                let (backend, creg) = config::block_backend(&config, dev, log);
-                let bdf = bdf.unwrap();
-
-                let dev_serial = dev
-                    .options
-                    .get("block_dev")
-                    .unwrap()
-                    .as_str()
-                    .unwrap()
-                    .to_string();
-                let log = log.new(slog::o!("dev" => format!("nvme-{}", name)));
-                let nvme = hw::nvme::PciNvme::create(dev_serial, log);
-
-                let id = inv.register_instance(&nvme, bdf.to_string())?;
-                let _be_id = inv.register_child(creg, id)?;
-
-                block::attach(backend, nvme.clone());
-
-                chipset.pci_attach(bdf, nvme);
-            }
-            qemu::pvpanic::DEVICE_NAME => {
-                let enable_isa = dev
-                    .options
-                    .get("enable_isa")
-                    .and_then(|opt| opt.as_bool())
-                    .unwrap_or(false);
-                if enable_isa {
-                    let pvpanic = QemuPvpanic::create(
-                        log.new(slog::o!("dev" => "pvpanic")),
-                    );
-                    pvpanic.attach_pio(pio);
-                    inv.register(&pvpanic)?;
+                    chipset.pci_attach(bdf, vioblk);
                 }
-            }
-            _ => {
-                slog::error!(log, "unrecognized driver"; "name" => name);
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    "Unrecognized driver",
-                )
-                .into());
-            }
-        }
+                "pci-virtio-viona" => {
+                    let vnic_name =
+                        dev.options.get("vnic").unwrap().as_str().unwrap();
+                    let bdf = bdf.unwrap();
+
+                    let viona = hw::virtio::PciVirtioViona::new(
+                        vnic_name, 0x100, &hdl,
+                    )?;
+                    inv.register_instance(&viona, bdf.to_string())?;
+                    chipset.pci_attach(bdf, viona);
+                }
+                "pci-nvme" => {
+                    let (backend, creg) =
+                        config::block_backend(&config, dev, log);
+                    let bdf = bdf.unwrap();
+
+                    let dev_serial = dev
+                        .options
+                        .get("block_dev")
+                        .unwrap()
+                        .as_str()
+                        .unwrap()
+                        .to_string();
+                    let log =
+                        log.new(slog::o!("dev" => format!("nvme-{}", name)));
+                    let nvme = hw::nvme::PciNvme::create(dev_serial, log);
+
+                    let id = inv.register_instance(&nvme, bdf.to_string())?;
+                    let _be_id = inv.register_child(creg, id)?;
+
+                    block::attach(backend, nvme.clone());
+
+                    chipset.pci_attach(bdf, nvme);
+                }
+                qemu::pvpanic::DEVICE_NAME => {
+                    let enable_isa = dev
+                        .options
+                        .get("enable_isa")
+                        .and_then(|opt| opt.as_bool())
+                        .unwrap_or(false);
+                    if enable_isa {
+                        let pvpanic = QemuPvpanic::create(
+                            log.new(slog::o!("dev" => "pvpanic")),
+                        );
+                        pvpanic.attach_pio(pio);
+                        inv.register(&pvpanic)?;
+                    }
+                }
+                _ => {
+                    slog::error!(log, "unrecognized driver"; "name" => name);
+                    return Err(Error::new(
+                        ErrorKind::Other,
+                        "Unrecognized driver",
+                    )
+                    .into());
+                }
+            };
+            Ok(())
+        };
+        create_device().with_context(|| {
+            format!("Failed to create {driver} device '{name}'")
+        })?;
     }
 
     let mut fwcfg = hw::qemu::fwcfg::FwCfgBuilder::new();


### PR DESCRIPTION
Currently, many of the error messages reported by `propolis-standalone`
when creating a virtual device don't provide a lot of information
describing the error that occurred. None of these errors include the
device name or driver of the device that could not be created.
Furthermore, errors when creating a VioNA virtio device don't include
the name of the VNIC that we attempted to connect to, which is also
useful information for debugging errors. See #612 for a motivating
example of an unhelpful error message.

This branch adds improved error contexts and logging to
`propolis-standalone`'s virtual device creation. In particular, I've
done the following:

- Wrapped the entire virtual device creation in a closure and added an
  `anyhow` error context with the name of the device and the driver, so
  that it's clearer what device couldn't be created.
- Wrapped the call to `PciVirtioViona::new` with an `anyhow` error
  context that includes the name of the VNIC we are attempting to use
- Added a `DEBUG`-level log line for every virtual device we attempt to
  create
- Improved the log line for unrecognized drivers to actually include the
  name of the driver that we didn't know about.

To compare the error messages on this branch with the error messages on
`master`, here's the output I get when I create a VM with VNIC that
doesn't exist, like:

```toml
[dev.net0]
driver = "pci-virtio-viona"
vnic = "fake-vnic0"
pci-path = "0.5.0"
```

On `master`, I get the following output:

```console
eliza@atrium ~/propolis $ pfexec cargo run -p propolis-standalone -- testvm.toml
    Finished dev [unoptimized + debuginfo] target(s) in 0.35s
     Running `target/debug/propolis-standalone testvm.toml`
Jan 29 20:21:02.152 INFO Creating VM with 4 vCPUs, 1073741824 lowmem, 0 highmem
Jan 29 20:21:02.638 INFO VM created, name: testvm
Error: DLADM_STATUS_NOTFOUND
```

On this branch, the output is much more helpful:

```console
eliza@atrium ~/propolis $ pfexec cargo run -p propolis-standalone -- testvm.toml
    Finished dev [unoptimized + debuginfo] target(s) in 0.34s
     Running `target/debug/propolis-standalone testvm.toml`
Jan 29 21:01:59.337 INFO Creating VM with 4 vCPUs, 1073741824 lowmem, 0 highmem
Jan 29 21:01:59.819 INFO VM created, name: testvm
Error: Failed to create pci-virtio-viona device 'net0'

Caused by:
    0: Failed to connect to VioNA VNIC 'fake-vnic0'
    1: DLADM_STATUS_NOTFOUND
```

Closes #612