### PR TITLE
PHD: convert to async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3301,6 +3301,7 @@ name = "phd-framework"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "backoff",
  "base64 0.21.7",
  "bhyve_api",
@@ -3378,6 +3379,7 @@ dependencies = [
 name = "phd-tests"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "futures",
  "http 0.2.11",
  "phd-testcase",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3344,6 +3344,7 @@ dependencies = [
  "clap 4.4.0",
  "phd-framework",
  "phd-tests",
+ "tokio",
  "tracing",
  "tracing-appender",
  "tracing-bunyan-formatter",
@@ -3356,6 +3357,7 @@ name = "phd-testcase"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "futures",
  "inventory",
  "phd-framework",
  "phd-testcase-macros",
@@ -3366,6 +3368,7 @@ dependencies = [
 name = "phd-testcase-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3375,6 +3378,7 @@ dependencies = [
 name = "phd-tests"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "http 0.2.11",
  "phd-testcase",
  "propolis-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3301,7 +3301,6 @@ name = "phd-framework"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "backoff",
  "base64 0.21.7",
  "bhyve_api",
@@ -3379,7 +3378,6 @@ dependencies = [
 name = "phd-tests"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "futures",
  "http 0.2.11",
  "phd-testcase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ num_enum = "0.5.11"
 owo-colors = "4"
 pin-project-lite = "0.2.13"
 proc-macro2 = "1.0"
+proc-macro-error = "1"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor", ref = "v0.5.0" }
 quote = "1.0"
 rand = "0.8"

--- a/phd-tests/framework/Cargo.toml
+++ b/phd-tests/framework/Cargo.toml
@@ -9,7 +9,6 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 backoff = { workspace = true, features = ["tokio"] }
 base64.workspace = true
 bytes.workspace = true

--- a/phd-tests/framework/Cargo.toml
+++ b/phd-tests/framework/Cargo.toml
@@ -9,6 +9,7 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 backoff = { workspace = true, features = ["tokio"] }
 base64.workspace = true
 bytes.workspace = true

--- a/phd-tests/framework/src/artifacts/buildomat.rs
+++ b/phd-tests/framework/src/artifacts/buildomat.rs
@@ -53,7 +53,7 @@ impl Repo {
         &self,
         branch: &str,
     ) -> anyhow::Result<Commit> {
-        (|| async {
+        async {
             let uri = format!("{BASE_URI}/branch/{self}/{branch}");
             let client = reqwest::ClientBuilder::new()
                 .timeout(Duration::from_secs(5))
@@ -64,7 +64,7 @@ impl Repo {
             anyhow::ensure!(status.is_success(), "HTTP status: {status}");
             let bytes = rsp.bytes().await?;
             str_from_bytes(&bytes)?.parse::<Commit>()
-        })()
+        }
         .await
         .with_context(|| {
             format!("Failed to determine HEAD commit for {self}@{branch}")
@@ -78,7 +78,7 @@ impl Repo {
         filename: &Utf8Path,
         downloader: &DownloadConfig,
     ) -> anyhow::Result<String> {
-        (|| async {
+        async {
             let filename = filename
                 .file_name()
                 .ok_or_else(|| {
@@ -109,7 +109,7 @@ impl Repo {
             let uri = format!("{BASE_URI}/file/{self}/{series}/{commit}/{filename}.sha256.txt");
             let bytes = downloader.download_buildomat_uri(&uri).await?;
             str_from_bytes(&bytes).map(String::from)
-        })().await.with_context(|| {
+        }.await.with_context(|| {
             format!("Failed to get SHA256 for {self}@{commit}, series: {series}, file: {filename})")
         })
     }

--- a/phd-tests/framework/src/artifacts/buildomat.rs
+++ b/phd-tests/framework/src/artifacts/buildomat.rs
@@ -35,7 +35,7 @@ impl Repo {
         Self(Cow::Borrowed(s))
     }
 
-    pub(super) fn artifact_for_commit(
+    pub(super) async fn artifact_for_commit(
         self,
         series: Series,
         commit: Commit,
@@ -43,40 +43,42 @@ impl Repo {
         downloader: &DownloadConfig,
     ) -> anyhow::Result<BuildomatArtifact> {
         let filename = filename.as_ref();
-        let sha256 = self.get_sha256(&series, &commit, filename, downloader)?;
+        let sha256 =
+            self.get_sha256(&series, &commit, filename, downloader).await?;
 
         Ok(BuildomatArtifact { repo: self, series, commit, sha256 })
     }
 
-    pub(super) fn get_branch_head(
+    pub(super) async fn get_branch_head(
         &self,
         branch: &str,
     ) -> anyhow::Result<Commit> {
-        (|| {
+        (|| async {
             let uri = format!("{BASE_URI}/branch/{self}/{branch}");
-            let client = reqwest::blocking::ClientBuilder::new()
+            let client = reqwest::ClientBuilder::new()
                 .timeout(Duration::from_secs(5))
                 .build()?;
             let req = client.get(uri).build()?;
-            let rsp = client.execute(req)?;
+            let rsp = client.execute(req).await?;
             let status = rsp.status();
             anyhow::ensure!(status.is_success(), "HTTP status: {status}");
-            let bytes = rsp.bytes()?;
+            let bytes = rsp.bytes().await?;
             str_from_bytes(&bytes)?.parse::<Commit>()
         })()
+        .await
         .with_context(|| {
             format!("Failed to determine HEAD commit for {self}@{branch}")
         })
     }
 
-    fn get_sha256(
+    async fn get_sha256(
         &self,
         series: &Series,
         commit: &Commit,
         filename: &Utf8Path,
         downloader: &DownloadConfig,
     ) -> anyhow::Result<String> {
-        (|| {
+        (|| async {
             let filename = filename
                 .file_name()
                 .ok_or_else(|| {
@@ -105,9 +107,9 @@ impl Repo {
                     )
                 })?;
             let uri = format!("{BASE_URI}/file/{self}/{series}/{commit}/{filename}.sha256.txt");
-            let bytes = downloader.download_buildomat_uri(&uri)?;
+            let bytes = downloader.download_buildomat_uri(&uri).await?;
             str_from_bytes(&bytes).map(String::from)
-        })().with_context(|| {
+        })().await.with_context(|| {
             format!("Failed to get SHA256 for {self}@{commit}, series: {series}, file: {filename})")
         })
     }
@@ -206,7 +208,7 @@ impl super::DownloadConfig {
     /// retry duration. This retry logic serves as a mechanism for PHD to wait
     /// for an artifact we expect to exist to be published, when the build that
     /// publishes that artifact is still in progress.
-    pub(super) fn download_buildomat_uri(
+    pub(super) async fn download_buildomat_uri(
         &self,
         uri: &str,
     ) -> anyhow::Result<bytes::Bytes> {
@@ -215,10 +217,9 @@ impl super::DownloadConfig {
             %uri,
             "Downloading file from Buildomat...",
         );
-        let client = reqwest::blocking::ClientBuilder::new()
-            .timeout(self.timeout)
-            .build()?;
-        let try_download = || {
+        let client =
+            reqwest::ClientBuilder::new().timeout(self.timeout).build()?;
+        let try_download = || async {
             let request = client
                 .get(uri)
                 .build()
@@ -229,7 +230,9 @@ impl super::DownloadConfig {
 
             let response = client
                 .execute(request)
+                .await
                 .map_err(|e| backoff::Error::transient(e.into()))?;
+
             if !response.status().is_success() {
                 // when downloading a file from buildomat, we currently retry
                 // all errors, since buildomat returns 500s when an artifact
@@ -252,17 +255,15 @@ impl super::DownloadConfig {
             );
         };
 
-        let bytes = backoff::retry_notify(
+        let bytes = backoff::future::retry_notify(
             self.buildomat_backoff.clone(),
             try_download,
             log_retry,
         )
-        .map_err(|e| match e {
-            backoff::Error::Permanent(e) => e,
-            backoff::Error::Transient { err, .. } => err,
-        })
+        .await
         .with_context(|| format!("Failed to download '{uri}' from Buildomat"))?
-        .bytes()?;
+        .bytes()
+        .await?;
 
         Ok(bytes)
     }

--- a/phd-tests/framework/src/disk/mod.rs
+++ b/phd-tests/framework/src/disk/mod.rs
@@ -10,7 +10,6 @@
 
 use std::{
     path::{Path, PathBuf},
-    rc::Rc,
     sync::Arc,
 };
 
@@ -62,7 +61,7 @@ impl BlockSize {
 }
 
 /// A trait for functions exposed by all disk backends (files, Crucible, etc.).
-pub trait DiskConfig: std::fmt::Debug {
+pub trait DiskConfig: std::fmt::Debug + Send + Sync {
     /// Yields the backend spec for this disk's storage backend.
     fn backend_spec(&self) -> (String, StorageBackendV0);
 
@@ -113,11 +112,11 @@ pub(crate) struct DiskFactory {
 
     /// A reference to the artifact store to use to look up guest OS artifacts
     /// when those are used as a disk source.
-    artifact_store: Rc<ArtifactStore>,
+    artifact_store: Arc<ArtifactStore>,
 
     /// The port allocator to use to allocate ports to Crucible server
     /// processes.
-    port_allocator: Rc<PortAllocator>,
+    port_allocator: Arc<PortAllocator>,
 
     /// The logging discipline to use for Crucible server processes.
     log_mode: ServerLogMode,
@@ -129,8 +128,8 @@ impl DiskFactory {
     /// supplied `artifact_store`.
     pub fn new(
         storage_dir: &impl AsRef<Path>,
-        artifact_store: Rc<ArtifactStore>,
-        port_allocator: Rc<PortAllocator>,
+        artifact_store: Arc<ArtifactStore>,
+        port_allocator: Arc<PortAllocator>,
         log_mode: ServerLogMode,
     ) -> Self {
         Self {

--- a/phd-tests/framework/src/guest_os/mod.rs
+++ b/phd-tests/framework/src/guest_os/mod.rs
@@ -36,7 +36,7 @@ pub(super) enum CommandSequenceEntry {
 
 pub(super) struct CommandSequence(pub Vec<CommandSequenceEntry>);
 
-pub(super) trait GuestOs {
+pub(super) trait GuestOs: Send + Sync {
     /// Retrieves the command sequence used to wait for the OS to boot and log
     /// into it.
     fn get_login_sequence(&self) -> CommandSequence;

--- a/phd-tests/framework/src/lib.rs
+++ b/phd-tests/framework/src/lib.rs
@@ -309,9 +309,11 @@ impl Framework {
 
     async fn wait_for_dropped_vms(&self) {
         let futs = FuturesUnordered::new();
-        let mut guard = self.vm_drop_rx.lock().unwrap();
-        while let Ok(task) = guard.try_recv() {
-            futs.push(task);
+        {
+            let mut guard = self.vm_drop_rx.lock().unwrap();
+            while let Ok(task) = guard.try_recv() {
+                futs.push(task);
+            }
         }
 
         let _results: Vec<_> = futs.collect().await;

--- a/phd-tests/framework/src/lib.rs
+++ b/phd-tests/framework/src/lib.rs
@@ -53,7 +53,7 @@ pub mod test_vm;
 
 /// An instance of the PHD test framework.
 pub struct Framework {
-    pub(crate) tokio_rt: tokio::runtime::Runtime,
+    pub tokio_rt: tokio::runtime::Runtime,
     pub(crate) tmp_directory: Utf8PathBuf,
     pub(crate) server_log_mode: ServerLogMode,
 

--- a/phd-tests/framework/src/lib.rs
+++ b/phd-tests/framework/src/lib.rs
@@ -27,7 +27,7 @@
 //! environment. The `spawn_successor_vm` function provides a shorthand way to
 //! do this.
 
-use std::{fmt, ops::Range, rc::Rc};
+use std::{fmt, ops::Range, sync::Arc};
 
 use anyhow::Context;
 use artifacts::DEFAULT_PROPOLIS_ARTIFACT;
@@ -68,9 +68,9 @@ pub struct Framework {
     // self-referencing. Since the runner is single-threaded, avoid arguing with
     // anyone about lifetimes by wrapping the relevant shared components in an
     // `Rc`.
-    pub(crate) artifact_store: Rc<artifacts::ArtifactStore>,
+    pub(crate) artifact_store: Arc<artifacts::ArtifactStore>,
     pub(crate) disk_factory: DiskFactory,
-    pub(crate) port_allocator: Rc<PortAllocator>,
+    pub(crate) port_allocator: Arc<PortAllocator>,
 
     pub(crate) crucible_enabled: bool,
     pub(crate) migration_base_enabled: bool,
@@ -164,8 +164,8 @@ impl Framework {
             }
         };
 
-        let artifact_store = Rc::new(artifact_store);
-        let port_allocator = Rc::new(PortAllocator::new(params.port_range));
+        let artifact_store = Arc::new(artifact_store);
+        let port_allocator = Arc::new(PortAllocator::new(params.port_range));
         let disk_factory = DiskFactory::new(
             &params.tmp_directory,
             artifact_store.clone(),

--- a/phd-tests/framework/src/lifecycle.rs
+++ b/phd-tests/framework/src/lifecycle.rs
@@ -62,8 +62,9 @@ impl Framework {
                     let new_vm_name =
                         format!("{}_lifecycle_{}", original_name, idx);
                     vm.stop().await?;
-                    let mut new_vm =
-                        self.spawn_successor_vm(&new_vm_name, &vm, None)?;
+                    let mut new_vm = self
+                        .spawn_successor_vm(&new_vm_name, &vm, None)
+                        .await?;
                     new_vm.launch().await?;
                     new_vm.wait_to_boot().await?;
                     vm = new_vm;
@@ -81,8 +82,9 @@ impl Framework {
 
                     let mut env = self.environment_builder();
                     env.propolis(propolis);
-                    let mut new_vm =
-                        self.spawn_successor_vm(&new_vm_name, &vm, Some(&env))?;
+                    let mut new_vm = self
+                        .spawn_successor_vm(&new_vm_name, &vm, Some(&env))
+                        .await?;
                     let migration_id = Uuid::new_v4();
                     new_vm
                         .migrate_from(

--- a/phd-tests/framework/src/lifecycle.rs
+++ b/phd-tests/framework/src/lifecycle.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use anyhow::Context;
-use futures::future::BoxFuture;
 use tracing::info;
 use uuid::Uuid;
 
@@ -33,6 +32,14 @@ pub enum Action<'a> {
     MigrateToPropolis(&'a str),
 }
 
+/// To run a lifecycle test, store any context needed to check the health of a
+/// VM in a struct, them `impl CheckVm` for the struct and pass an instance of
+/// it to [`lifecycle_test`].
+#[async_trait::async_trait]
+pub trait CheckVm {
+    async fn check(&self, vm: &TestVm);
+}
+
 impl Framework {
     /// Runs a lifecycle test on the supplied `vm` by iterating over the
     /// `actions`, performing the specified action, and then calling `check_fn`
@@ -41,7 +48,7 @@ impl Framework {
         &self,
         vm: TestVm,
         actions: &[Action<'_>],
-        check_fn: impl for<'v> Fn(&'v TestVm) -> BoxFuture<'v, ()>,
+        check_fn: impl CheckVm,
     ) -> anyhow::Result<()> {
         let mut vm = vm;
         let original_name = vm.name().to_owned();
@@ -112,7 +119,7 @@ impl Framework {
                 }
             }
 
-            check_fn(&vm).await;
+            check_fn.check(&vm).await;
         }
 
         Ok(())

--- a/phd-tests/framework/src/lifecycle.rs
+++ b/phd-tests/framework/src/lifecycle.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use anyhow::Context;
+use futures::future::BoxFuture;
 use tracing::info;
 use uuid::Uuid;
 
@@ -36,11 +37,11 @@ impl Framework {
     /// Runs a lifecycle test on the supplied `vm` by iterating over the
     /// `actions`, performing the specified action, and then calling `check_fn`
     /// on the resulting VM to verify invariants.
-    pub fn lifecycle_test(
+    pub async fn lifecycle_test<'a>(
         &self,
         vm: TestVm,
-        actions: &[Action],
-        check_fn: impl Fn(&TestVm),
+        actions: &[Action<'_>],
+        check_fn: impl for<'v> Fn(&'v TestVm) -> BoxFuture<'v, ()>,
     ) -> anyhow::Result<()> {
         let mut vm = vm;
         let original_name = vm.name().to_owned();
@@ -51,7 +52,7 @@ impl Framework {
                         vm_name = original_name,
                         "rebooting VM for lifecycle test"
                     );
-                    vm.reset()?;
+                    vm.reset().await?;
                 }
                 Action::StopAndStart => {
                     info!(
@@ -60,11 +61,11 @@ impl Framework {
                     );
                     let new_vm_name =
                         format!("{}_lifecycle_{}", original_name, idx);
-                    vm.stop()?;
+                    vm.stop().await?;
                     let mut new_vm =
                         self.spawn_successor_vm(&new_vm_name, &vm, None)?;
-                    new_vm.launch()?;
-                    new_vm.wait_to_boot()?;
+                    new_vm.launch().await?;
+                    new_vm.wait_to_boot().await?;
                     vm = new_vm;
                 }
                 Action::MigrateToPropolis(propolis) => {
@@ -83,21 +84,25 @@ impl Framework {
                     let mut new_vm =
                         self.spawn_successor_vm(&new_vm_name, &vm, Some(&env))?;
                     let migration_id = Uuid::new_v4();
-                    new_vm.migrate_from(
-                        &vm,
-                        migration_id,
-                        MigrationTimeout::default(),
-                    )?;
+                    new_vm
+                        .migrate_from(
+                            &vm,
+                            migration_id,
+                            MigrationTimeout::default(),
+                        )
+                        .await?;
 
                     // Explicitly check migration status on both the source and
                     // target to make sure it is available even after migration
                     // has finished.
                     let src_migration_state = vm
                         .get_migration_state(migration_id)
+                        .await
                         .context("Failed to get source VM migration state")?;
                     assert_eq!(src_migration_state, MigrationState::Finish);
                     let target_migration_state = new_vm
                         .get_migration_state(migration_id)
+                        .await
                         .context("Failed to get target VM migration state")?;
                     assert_eq!(target_migration_state, MigrationState::Finish);
 
@@ -105,7 +110,7 @@ impl Framework {
                 }
             }
 
-            check_fn(&vm);
+            check_fn(&vm).await;
         }
 
         Ok(())

--- a/phd-tests/framework/src/test_vm/config.rs
+++ b/phd-tests/framework/src/test_vm/config.rs
@@ -146,7 +146,7 @@ impl VmConfig {
         self
     }
 
-    pub(crate) fn vm_spec(
+    pub(crate) async fn vm_spec(
         &self,
         framework: &Framework,
     ) -> anyhow::Result<VmSpec> {
@@ -155,6 +155,7 @@ impl VmConfig {
         let bootrom = framework
             .artifact_store
             .get_bootrom(&self.bootrom_artifact)
+            .await
             .context("looking up bootrom artifact")?;
 
         let config_toml_contents =
@@ -168,51 +169,19 @@ impl VmConfig {
         let (_, guest_os_kind) = framework
             .artifact_store
             .get_guest_os_image(&self.boot_disk.source_artifact)
+            .await
             .context("getting guest OS kind for boot disk")?;
-
-        // This closure helps to construct disk handles from disk requests.
-        let make_disk = |name: String,
-                         req: &DiskRequest|
-         -> anyhow::Result<Arc<dyn DiskConfig>> {
-            let source = DiskSource::Artifact(&req.source_artifact);
-            Ok(match req.backend {
-                DiskBackend::File => framework
-                    .disk_factory
-                    .create_file_backed_disk(name, source)
-                    .with_context(|| {
-                        format!(
-                            "creating new file-backed disk from '{}'",
-                            &req.source_artifact
-                        )
-                    })?,
-                DiskBackend::Crucible { min_disk_size_gib, block_size } => {
-                    framework
-                        .disk_factory
-                        .create_crucible_disk(
-                            name,
-                            source,
-                            min_disk_size_gib,
-                            block_size,
-                        )
-                        .with_context(|| {
-                            format!(
-                                "creating new Crucible-backed disk from \
-                                    '{}'",
-                                &req.source_artifact
-                            )
-                        })?
-                }
-            })
-        };
 
         let mut disk_handles = Vec::new();
         disk_handles.push(
-            make_disk("boot-disk".to_owned(), &self.boot_disk)
+            make_disk("boot-disk".to_owned(), framework, &self.boot_disk)
+                .await
                 .context("creating boot disk")?,
         );
         for (idx, data_disk) in self.data_disks.iter().enumerate() {
             disk_handles.push(
-                make_disk(format!("data-disk-{}", idx), data_disk)
+                make_disk(format!("data-disk-{}", idx), framework, data_disk)
+                    .await
                     .context("creating data disk")?,
             );
         }
@@ -269,6 +238,38 @@ impl VmConfig {
             config_toml_contents,
         })
     }
+}
+
+async fn make_disk(
+    name: String,
+    framework: &Framework,
+    req: &DiskRequest,
+) -> anyhow::Result<Arc<dyn DiskConfig>> {
+    let source = DiskSource::Artifact(&req.source_artifact);
+    Ok(match req.backend {
+        DiskBackend::File => framework
+            .disk_factory
+            .create_file_backed_disk(name, source)
+            .await
+            .with_context(|| {
+                format!(
+                    "creating new file-backed disk from '{}'",
+                    &req.source_artifact
+                )
+            })? as Arc<dyn DiskConfig>,
+        DiskBackend::Crucible { min_disk_size_gib, block_size } => framework
+            .disk_factory
+            .create_crucible_disk(name, source, min_disk_size_gib, block_size)
+            .await
+            .with_context(|| {
+                format!(
+                    "creating new Crucible-backed disk from \
+                                    '{}'",
+                    &req.source_artifact
+                )
+            })?
+            as Arc<dyn DiskConfig>,
+    })
 }
 
 fn default_migration_failure_device() -> propolis_server_config::Device {

--- a/phd-tests/framework/src/test_vm/config.rs
+++ b/phd-tests/framework/src/test_vm/config.rs
@@ -263,8 +263,7 @@ async fn make_disk(
             .await
             .with_context(|| {
                 format!(
-                    "creating new Crucible-backed disk from \
-                                    '{}'",
+                    "creating new Crucible-backed disk from '{}'",
                     &req.source_artifact
                 )
             })?

--- a/phd-tests/framework/src/test_vm/environment.rs
+++ b/phd-tests/framework/src/test_vm/environment.rs
@@ -37,11 +37,11 @@ impl EnvironmentSpec {
         self
     }
 
-    pub(crate) fn build<'a>(
+    pub(crate) async fn build<'a>(
         &self,
         framework: &'a Framework,
     ) -> anyhow::Result<Environment<'a>> {
-        Environment::from_builder(self, framework)
+        Environment::from_builder(self, framework).await
     }
 }
 
@@ -56,7 +56,7 @@ pub(crate) enum Environment<'a> {
 }
 
 impl<'a> Environment<'a> {
-    fn from_builder(
+    async fn from_builder(
         builder: &EnvironmentSpec,
         framework: &'a Framework,
     ) -> anyhow::Result<Self> {
@@ -65,6 +65,7 @@ impl<'a> Environment<'a> {
                 let propolis_server = framework
                     .artifact_store
                     .get_propolis_server(&builder.propolis_artifact)
+                    .await
                     .context("setting up VM execution environment")?;
                 let server_port = framework
                     .port_allocator

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -504,10 +504,9 @@ impl TestVm {
                                 "error during migration"
                             )))
                         }
-                        _ => Err(backoff::Error::Transient {
-                            err: anyhow!("migration not done yet"),
-                            retry_after: None,
-                        }),
+                        _ => Err(backoff::Error::transient(anyhow!(
+                            "migration not done yet"
+                        ))),
                     }
                 };
 

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -814,7 +814,7 @@ impl Drop for TestVm {
                     Ok(_) => {}
                 }
 
-                info!("stopping test VM on drop");
+                debug!("stopping test VM on drop");
                 if let Err(e) = client
                     .instance_state_put()
                     .body(InstanceStateRequested::Stop)

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -797,7 +797,7 @@ impl Drop for TestVm {
         let client = self.client.clone();
         let server = self.server.take();
         let span = self.tracing_span.clone();
-        let task = tokio::task::spawn(
+        let task = tokio::spawn(
             async move {
                 let _server = server;
                 match client

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -850,7 +850,7 @@ impl Drop for TestVm {
                     }
                 };
 
-                if backoff::future::retry(
+                let destroyed = backoff::future::retry(
                     backoff::ExponentialBackoff {
                         max_elapsed_time: Some(std::time::Duration::from_secs(
                             5,
@@ -859,10 +859,10 @@ impl Drop for TestVm {
                     },
                     check_destroyed,
                 )
-                .await
-                .is_err()
-                {
-                    error!("dropped VM not destroyed after 5 seconds");
+                .await;
+
+                if let Err(e) = destroyed {
+                    error!(%e, "dropped VM not destroyed after 5 seconds");
                 }
             }
             .instrument(span),

--- a/phd-tests/framework/src/test_vm/server.rs
+++ b/phd-tests/framework/src/test_vm/server.rs
@@ -8,7 +8,7 @@ use std::{fmt::Debug, net::SocketAddrV4};
 
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::server_log_mode::ServerLogMode;
 
@@ -89,7 +89,7 @@ impl PropolisServer {
 impl Drop for PropolisServer {
     fn drop(&mut self) {
         let pid = self.server.id().to_string();
-        info!(
+        debug!(
             pid,
             %self.address,
             "Killing Propolis server that was dropped"
@@ -104,7 +104,7 @@ impl Drop for PropolisServer {
             .wait()
             .expect("should be able to wait on a phd-spawned propolis");
 
-        info!(pid,
+        debug!(pid,
               %self.address,
               "Successfully waited for demise of Propolis server that was dropped");
     }

--- a/phd-tests/runner/Cargo.toml
+++ b/phd-tests/runner/Cargo.toml
@@ -16,6 +16,7 @@ camino.workspace = true
 clap = { workspace = true, features = ["derive"] }
 phd-framework.workspace = true
 phd-tests.workspace = true
+tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 tracing-appender.workspace = true
 tracing-bunyan-formatter.workspace = true

--- a/phd-tests/runner/src/execute.rs
+++ b/phd-tests/runner/src/execute.rs
@@ -109,10 +109,12 @@ pub fn run_tests_with_ctx(
         }
 
         stats.tests_not_run -= 1;
-        let test_outcome = std::panic::catch_unwind(|| execution.tc.run(ctx))
-            .unwrap_or_else(|_| {
-                PANIC_MSG.with(|val| TestOutcome::Failed(val.take()))
-            });
+        let test_outcome = std::panic::catch_unwind(|| {
+            ctx.tokio_rt.block_on(async { execution.tc.run(ctx).await })
+        })
+        .unwrap_or_else(|_| {
+            PANIC_MSG.with(|val| TestOutcome::Failed(val.take()))
+        });
 
         info!(
             "test {} ... {}{}",

--- a/phd-tests/runner/src/execute.rs
+++ b/phd-tests/runner/src/execute.rs
@@ -113,10 +113,8 @@ pub async fn run_tests_with_ctx(
         let test_ctx = ctx.clone();
         let tc = execution.tc;
         let test_outcome =
-            match tokio::task::spawn(
-                async move { tc.run(test_ctx.as_ref()).await },
-            )
-            .await
+            match tokio::spawn(async move { tc.run(test_ctx.as_ref()).await })
+                .await
             {
                 Ok(outcome) => outcome,
                 Err(_) => TestOutcome::Failed(Some(

--- a/phd-tests/runner/src/execute.rs
+++ b/phd-tests/runner/src/execute.rs
@@ -151,7 +151,7 @@ pub async fn run_tests_with_ctx(
         }
 
         execution.status = Status::Ran(test_outcome);
-        if let Err(e) = fixtures.test_cleanup() {
+        if let Err(e) = fixtures.test_cleanup().await {
             error!("Error running cleanup fixture: {}", e);
             break 'exec_loop;
         }

--- a/phd-tests/runner/src/fixtures.rs
+++ b/phd-tests/runner/src/fixtures.rs
@@ -49,8 +49,8 @@ impl TestFixtures {
     /// during unwinding, this cleanup fixture will run whenever the
     /// corresponding setup fixture has run.
     #[instrument(skip_all)]
-    pub fn test_cleanup(&mut self) -> Result<()> {
-        self.test_context.reset();
+    pub async fn test_cleanup(&mut self) -> Result<()> {
+        self.test_context.reset().await;
         Ok(())
     }
 }

--- a/phd-tests/runner/src/fixtures.rs
+++ b/phd-tests/runner/src/fixtures.rs
@@ -2,20 +2,22 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use tracing::instrument;
 
 use crate::Framework;
 
 /// A wrapper containing the objects needed to run the executor's test fixtures.
-pub struct TestFixtures<'a> {
-    test_context: &'a Framework,
+pub struct TestFixtures {
+    test_context: Arc<Framework>,
 }
 
-impl<'a> TestFixtures<'a> {
+impl TestFixtures {
     /// Creates a new set of test fixtures using the supplied command-line
     /// parameters and artifact store.
-    pub fn new(test_context: &'a Framework) -> Result<Self> {
+    pub fn new(test_context: Arc<Framework>) -> Result<Self> {
         Ok(Self { test_context })
     }
 

--- a/phd-tests/testcase/Cargo.toml
+++ b/phd-tests/testcase/Cargo.toml
@@ -8,6 +8,7 @@ test = false
 doctest = false
 
 [dependencies]
+futures.workspace = true
 inventory.workspace = true
 thiserror.workspace = true
 phd-framework.workspace = true

--- a/phd-tests/testcase/src/lib.rs
+++ b/phd-tests/testcase/src/lib.rs
@@ -35,7 +35,7 @@ pub enum TestOutcome {
 /// A wrapper for test functions. This is needed to allow [`TestCase`] to have a
 /// `const` constructor for the inventory crate.
 pub struct TestFunction {
-    pub f: fn(&Framework) -> TestOutcome,
+    pub f: fn(&Framework) -> futures::future::BoxFuture<'_, TestOutcome>,
 }
 
 /// A description of a single test case.
@@ -75,8 +75,8 @@ impl TestCase {
 
     /// Runs the test case's body with the supplied test context and returns its
     /// outcome.
-    pub fn run(&self, ctx: &Framework) -> TestOutcome {
-        (self.function.f)(ctx)
+    pub async fn run(&self, ctx: &Framework) -> TestOutcome {
+        (self.function.f)(ctx).await
     }
 }
 

--- a/phd-tests/testcase/src/lib.rs
+++ b/phd-tests/testcase/src/lib.rs
@@ -23,7 +23,7 @@ pub enum TestOutcome {
     /// The test passed.
     Passed,
 
-    /// The test failed; the payload is an optional failure message.
+    /// The test failed.
     Failed(Option<String>),
 
     /// The test chose to be skipped, i.e. it detected a parameter or condition

--- a/phd-tests/testcase_macro/Cargo.toml
+++ b/phd-tests/testcase_macro/Cargo.toml
@@ -10,5 +10,6 @@ doctest = false
 
 [dependencies]
 proc-macro2.workspace = true
+proc-macro-error.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["full"] }

--- a/phd-tests/testcase_macro/src/lib.rs
+++ b/phd-tests/testcase_macro/src/lib.rs
@@ -45,6 +45,7 @@ pub fn phd_testcase(_attrib: TokenStream, input: TokenStream) -> TokenStream {
     let fn_sig = item_fn.sig.clone();
     let fn_block = item_fn.block.stmts;
     let remade_fn = quote! {
+        #[tracing::instrument(level = "info", name = #fn_name, skip_all)]
         #fn_vis #fn_sig -> TestOutcome {
             let res: phd_testcase::Result<()> = async {
                 #(#fn_block)*

--- a/phd-tests/testcase_macro/src/lib.rs
+++ b/phd-tests/testcase_macro/src/lib.rs
@@ -44,8 +44,12 @@ pub fn phd_testcase(_attrib: TokenStream, input: TokenStream) -> TokenStream {
     let fn_vis = item_fn.vis.clone();
     let fn_sig = item_fn.sig.clone();
     let fn_block = item_fn.block.stmts;
+
     let remade_fn = quote! {
-        #[tracing::instrument(level = "info", name = #fn_name, skip_all)]
+        #[tracing::instrument(level = "info",
+                              name = #fn_name,
+                              fields(module = module_path!()),
+                              skip_all)]
         #fn_vis #fn_sig -> TestOutcome {
             let res: phd_testcase::Result<()> = async {
                 #(#fn_block)*

--- a/phd-tests/testcase_macro/src/lib.rs
+++ b/phd-tests/testcase_macro/src/lib.rs
@@ -51,7 +51,7 @@ pub fn phd_testcase(_attrib: TokenStream, input: TokenStream) -> TokenStream {
             let res: phd_testcase::Result<()> = async {
                 #(#fn_block)*
                 Ok(())
-            }.instrument(tracing::info_span!(#fn_name, module = module_path!())).await;
+            }.instrument(tracing::info_span!("test", path = %concat!(module_path!(), "::", #fn_name))).await;
             match res {
                 Ok(()) => phd_testcase::TestOutcome::Passed,
                 Err(e) => {

--- a/phd-tests/testcase_macro/src/lib.rs
+++ b/phd-tests/testcase_macro/src/lib.rs
@@ -46,15 +46,12 @@ pub fn phd_testcase(_attrib: TokenStream, input: TokenStream) -> TokenStream {
     let fn_block = item_fn.block.stmts;
 
     let remade_fn = quote! {
-        #[tracing::instrument(level = "info",
-                              name = #fn_name,
-                              fields(module = module_path!()),
-                              skip_all)]
         #fn_vis #fn_sig -> TestOutcome {
+            use tracing::Instrument;
             let res: phd_testcase::Result<()> = async {
                 #(#fn_block)*
                 Ok(())
-            }.await;
+            }.instrument(tracing::info_span!(#fn_name, module = module_path!())).await;
             match res {
                 Ok(()) => phd_testcase::TestOutcome::Passed,
                 Err(e) => {

--- a/phd-tests/testcase_macro/src/lib.rs
+++ b/phd-tests/testcase_macro/src/lib.rs
@@ -3,8 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use proc_macro::TokenStream;
+use proc_macro_error::{abort, proc_macro_error};
 use quote::quote;
-use syn::{parse_macro_input, ItemFn};
+use syn::{parse_macro_input, spanned::Spanned, ItemFn};
 
 /// The macro for labeling PHD testcases.
 ///
@@ -13,6 +14,7 @@ use syn::{parse_macro_input, ItemFn};
 /// wrapper function that returns a `phd_testcase::TestOutcome` and creates an
 /// entry in the test case inventory that allows the PHD runner to enumerate the
 /// test.
+#[proc_macro_error]
 #[proc_macro_attribute]
 pub fn phd_testcase(_attrib: TokenStream, input: TokenStream) -> TokenStream {
     let item_fn = parse_macro_input!(input as ItemFn);
@@ -27,23 +29,28 @@ pub fn phd_testcase(_attrib: TokenStream, input: TokenStream) -> TokenStream {
             phd_testcase::TestCase::new(
                 module_path!(),
                 #fn_name,
-                phd_testcase::TestFunction { f: #fn_ident }
+                phd_testcase::TestFunction { f: |ctx| Box::pin(#fn_ident(ctx)) }
             )
         }
     };
+
+    if item_fn.sig.asyncness.is_none() {
+        abort!(item_fn.sig.span(), "PHD test cases must be async");
+    }
 
     // Rebuild the test body into an immediately-executed function that returns
     // an `anyhow::Result`. This allows tests to use the `?` operator and to
     // `return Ok(())` to allow a test to pass early.
     let fn_vis = item_fn.vis.clone();
     let fn_sig = item_fn.sig.clone();
-    let fn_block = item_fn.block;
+    let fn_block = item_fn.block.stmts;
     let remade_fn = quote! {
         #fn_vis #fn_sig -> TestOutcome {
-            match || -> phd_testcase::Result<()> {
-                #fn_block
+            let res: phd_testcase::Result<()> = async {
+                #(#fn_block)*
                 Ok(())
-            }(){
+            }.await;
+            match res {
                 Ok(()) => phd_testcase::TestOutcome::Passed,
                 Err(e) => {
                     // Treat the test as skipped if the error downcasts to the

--- a/phd-tests/tests/Cargo.toml
+++ b/phd-tests/tests/Cargo.toml
@@ -8,6 +8,7 @@ test = false
 doctest = false
 
 [dependencies]
+futures.workspace = true
 http.workspace = true
 propolis-client.workspace = true
 phd-testcase.workspace = true

--- a/phd-tests/tests/Cargo.toml
+++ b/phd-tests/tests/Cargo.toml
@@ -8,7 +8,6 @@ test = false
 doctest = false
 
 [dependencies]
-async-trait.workspace = true
 futures.workspace = true
 http.workspace = true
 propolis-client.workspace = true

--- a/phd-tests/tests/Cargo.toml
+++ b/phd-tests/tests/Cargo.toml
@@ -8,6 +8,7 @@ test = false
 doctest = false
 
 [dependencies]
+async-trait.workspace = true
 futures.workspace = true
 http.workspace = true
 propolis-client.workspace = true

--- a/phd-tests/tests/src/crucible/migrate.rs
+++ b/phd-tests/tests/src/crucible/migrate.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 async fn smoke_test(ctx: &Framework) {
     let mut config = ctx.vm_config_builder("crucible_migrate_smoke_source");
     super::add_default_boot_disk(ctx, &mut config)?;
-    let mut source = ctx.spawn_vm(&config, None)?;
+    let mut source = ctx.spawn_vm(&config, None).await?;
     let disk_handles = source.cloned_disk_handles();
     let disk = disk_handles[0].as_crucible().unwrap();
     disk.set_generation(1);
@@ -25,8 +25,9 @@ async fn smoke_test(ctx: &Framework) {
     source.run_shell_command("sync ./foo.bar").await?;
 
     disk.set_generation(2);
-    let mut target =
-        ctx.spawn_successor_vm("crucible_migrate_smoke_target", &source, None)?;
+    let mut target = ctx
+        .spawn_successor_vm("crucible_migrate_smoke_target", &source, None)
+        .await?;
 
     target
         .migrate_from(&source, Uuid::new_v4(), MigrationTimeout::default())
@@ -39,7 +40,7 @@ async fn smoke_test(ctx: &Framework) {
 async fn load_test(ctx: &Framework) {
     let mut config = ctx.vm_config_builder("crucible_load_test_source");
     super::add_default_boot_disk(ctx, &mut config)?;
-    let mut source = ctx.spawn_vm(&config, None)?;
+    let mut source = ctx.spawn_vm(&config, None).await?;
     let disk_handles = source.cloned_disk_handles();
     let disk = disk_handles[0].as_crucible().unwrap();
     disk.set_generation(1);
@@ -48,8 +49,9 @@ async fn load_test(ctx: &Framework) {
     source.wait_to_boot().await?;
 
     disk.set_generation(2);
-    let mut target =
-        ctx.spawn_successor_vm("crucible_load_test_target", &source, None)?;
+    let mut target = ctx
+        .spawn_successor_vm("crucible_load_test_target", &source, None)
+        .await?;
 
     // Create some random data.
     let block_count = 10;

--- a/phd-tests/tests/src/crucible/migrate.rs
+++ b/phd-tests/tests/src/crucible/migrate.rs
@@ -8,7 +8,7 @@ use tracing::info;
 use uuid::Uuid;
 
 #[phd_testcase]
-fn smoke_test(ctx: &Framework) {
+async fn smoke_test(ctx: &Framework) {
     let mut config = ctx.vm_config_builder("crucible_migrate_smoke_source");
     super::add_default_boot_disk(ctx, &mut config)?;
     let mut source = ctx.spawn_vm(&config, None)?;
@@ -16,29 +16,27 @@ fn smoke_test(ctx: &Framework) {
     let disk = disk_handles[0].as_crucible().unwrap();
     disk.set_generation(1);
 
-    source.launch()?;
-    source.wait_to_boot()?;
+    source.launch().await?;
+    source.wait_to_boot().await?;
 
-    let lsout = source.run_shell_command("ls foo.bar 2> /dev/null")?;
+    let lsout = source.run_shell_command("ls foo.bar 2> /dev/null").await?;
     assert_eq!(lsout, "");
-    source.run_shell_command("touch ./foo.bar")?;
-    source.run_shell_command("sync ./foo.bar")?;
+    source.run_shell_command("touch ./foo.bar").await?;
+    source.run_shell_command("sync ./foo.bar").await?;
 
     disk.set_generation(2);
     let mut target =
         ctx.spawn_successor_vm("crucible_migrate_smoke_target", &source, None)?;
 
-    target.migrate_from(
-        &source,
-        Uuid::new_v4(),
-        MigrationTimeout::default(),
-    )?;
-    let lsout = target.run_shell_command("ls foo.bar")?;
+    target
+        .migrate_from(&source, Uuid::new_v4(), MigrationTimeout::default())
+        .await?;
+    let lsout = target.run_shell_command("ls foo.bar").await?;
     assert_eq!(lsout, "foo.bar");
 }
 
 #[phd_testcase]
-fn load_test(ctx: &Framework) {
+async fn load_test(ctx: &Framework) {
     let mut config = ctx.vm_config_builder("crucible_load_test_source");
     super::add_default_boot_disk(ctx, &mut config)?;
     let mut source = ctx.spawn_vm(&config, None)?;
@@ -46,8 +44,8 @@ fn load_test(ctx: &Framework) {
     let disk = disk_handles[0].as_crucible().unwrap();
     disk.set_generation(1);
 
-    source.launch()?;
-    source.wait_to_boot()?;
+    source.launch().await?;
+    source.wait_to_boot().await?;
 
     disk.set_generation(2);
     let mut target =
@@ -55,32 +53,35 @@ fn load_test(ctx: &Framework) {
 
     // Create some random data.
     let block_count = 10;
-    let ddout = source.run_shell_command(
-        format!("dd if=/dev/random of=./rand.txt bs=5M count={}", block_count)
+    let ddout = source
+        .run_shell_command(
+            format!(
+                "dd if=/dev/random of=./rand.txt bs=5M count={}",
+                block_count
+            )
             .as_str(),
-    )?;
+        )
+        .await?;
     assert!(ddout.contains(format!("{}+0 records in", block_count).as_str()));
 
     // Compute the data's hash.
-    let sha256sum_out = source.run_shell_command("sha256sum rand.txt")?;
+    let sha256sum_out = source.run_shell_command("sha256sum rand.txt").await?;
     let checksum = sha256sum_out.split_whitespace().next().unwrap();
     info!("Generated SHA256 checksum: {}", checksum);
 
     // Start copying the generated file into a second file, then start a
     // migration while that copy is in progress.
-    source.run_shell_command("dd if=./rand.txt of=./rand_new.txt &")?;
-    target.migrate_from(
-        &source,
-        Uuid::new_v4(),
-        MigrationTimeout::default(),
-    )?;
+    source.run_shell_command("dd if=./rand.txt of=./rand_new.txt &").await?;
+    target
+        .migrate_from(&source, Uuid::new_v4(), MigrationTimeout::default())
+        .await?;
 
     // Wait for the background command to finish running, then compute the
     // hash of the copied file. If all went well this will match the hash of
     // the source file.
-    target.run_shell_command("wait $!")?;
+    target.run_shell_command("wait $!").await?;
     let sha256sum_target =
-        target.run_shell_command("sha256sum rand_new.txt")?;
+        target.run_shell_command("sha256sum rand_new.txt").await?;
     let checksum_target = sha256sum_target.split_whitespace().next().unwrap();
     assert_eq!(checksum, checksum_target);
 }

--- a/phd-tests/tests/src/crucible/smoke.rs
+++ b/phd-tests/tests/src/crucible/smoke.rs
@@ -11,7 +11,7 @@ use propolis_client::types::InstanceState;
 async fn boot_test(ctx: &Framework) {
     let mut config = ctx.vm_config_builder("crucible_boot_test");
     super::add_default_boot_disk(ctx, &mut config)?;
-    let mut vm = ctx.spawn_vm(&config, None)?;
+    let mut vm = ctx.spawn_vm(&config, None).await?;
     vm.launch().await?;
     vm.wait_to_boot().await?;
 }
@@ -21,7 +21,7 @@ async fn shutdown_persistence_test(ctx: &Framework) {
     let mut config =
         ctx.vm_config_builder("crucible_shutdown_persistence_test");
     super::add_default_boot_disk(ctx, &mut config)?;
-    let mut vm = ctx.spawn_vm(&config, None)?;
+    let mut vm = ctx.spawn_vm(&config, None).await?;
     if vm.guest_os_has_read_only_fs() {
         phd_skip!(
             "Can't run data persistence test on a guest with a read-only file
@@ -47,11 +47,9 @@ async fn shutdown_persistence_test(ctx: &Framework) {
 
     // Increment the disk's generation before attaching it to a new VM.
     disk.set_generation(2);
-    let mut vm = ctx.spawn_successor_vm(
-        "crucible_shutdown_persistence_test_2",
-        &vm,
-        None,
-    )?;
+    let mut vm = ctx
+        .spawn_successor_vm("crucible_shutdown_persistence_test_2", &vm, None)
+        .await?;
 
     vm.launch().await?;
     vm.wait_to_boot().await?;

--- a/phd-tests/tests/src/framework.rs
+++ b/phd-tests/tests/src/framework.rs
@@ -9,7 +9,7 @@ use phd_testcase::*;
 
 #[phd_testcase]
 async fn multiline_serial_test(ctx: &Framework) {
-    let mut vm = ctx.spawn_default_vm("multiline_test")?;
+    let mut vm = ctx.spawn_default_vm("multiline_test").await?;
     vm.launch().await?;
     vm.wait_to_boot().await?;
 

--- a/phd-tests/tests/src/framework.rs
+++ b/phd-tests/tests/src/framework.rs
@@ -8,11 +8,11 @@
 use phd_testcase::*;
 
 #[phd_testcase]
-fn multiline_serial_test(ctx: &Framework) {
+async fn multiline_serial_test(ctx: &Framework) {
     let mut vm = ctx.spawn_default_vm("multiline_test")?;
-    vm.launch()?;
-    vm.wait_to_boot()?;
+    vm.launch().await?;
+    vm.wait_to_boot().await?;
 
-    let out = vm.run_shell_command("echo \\\nhello \\\nworld")?;
+    let out = vm.run_shell_command("echo \\\nhello \\\nworld").await?;
     assert_eq!(out, "hello world");
 }

--- a/phd-tests/tests/src/hw.rs
+++ b/phd-tests/tests/src/hw.rs
@@ -6,22 +6,34 @@ use phd_framework::lifecycle::Action;
 use phd_testcase::*;
 
 #[phd_testcase]
-fn lspci_lifecycle_test(ctx: &Framework) {
+async fn lspci_lifecycle_test(ctx: &Framework) {
     const LSPCI: &str = "sudo lspci -vvx";
     const LSHW: &str = "sudo lshw -notime";
 
     let mut vm =
         ctx.spawn_vm(&ctx.vm_config_builder("lspci_lifecycle_test"), None)?;
 
-    vm.launch()?;
-    vm.wait_to_boot()?;
+    vm.launch().await?;
+    vm.wait_to_boot().await?;
 
-    let lspci = vm.run_shell_command(LSPCI)?;
-    let lshw = vm.run_shell_command(LSHW)?;
-    ctx.lifecycle_test(vm, &[Action::StopAndStart], |vm| {
-        let new_lspci = vm.run_shell_command(LSPCI).unwrap();
-        assert_eq!(new_lspci, lspci);
-        let new_lshw = vm.run_shell_command(LSHW).unwrap();
-        assert_eq!(new_lshw, lshw);
-    })?;
+    let lspci = vm.run_shell_command(LSPCI).await?;
+    let lshw = vm.run_shell_command(LSHW).await?;
+    ctx.lifecycle_test(
+        vm,
+        &[Action::StopAndStart],
+        // REVIEW(gjc): the clone here is very ugly but was the most
+        // straightforward way to convince the compiler that the lspci/lshw
+        // outputs live long enough. There has to be a better way.
+        move |vm| {
+            let lspci = lspci.clone();
+            let lshw = lshw.clone();
+            Box::pin(async move {
+                let new_lspci = vm.run_shell_command(LSPCI).await.unwrap();
+                assert_eq!(new_lspci, lspci);
+                let new_lshw = vm.run_shell_command(LSHW).await.unwrap();
+                assert_eq!(new_lshw, lshw);
+            })
+        },
+    )
+    .await?;
 }

--- a/phd-tests/tests/src/hw.rs
+++ b/phd-tests/tests/src/hw.rs
@@ -2,39 +2,42 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use async_trait::async_trait;
 use phd_framework::lifecycle::Action;
-use phd_testcase::*;
+use phd_testcase::{
+    phd_framework::{lifecycle::CheckVm, TestVm},
+    *,
+};
+
+const LSPCI: &str = "sudo lspci -vvx";
+const LSHW: &str = "sudo lshw -notime";
 
 #[phd_testcase]
 async fn lspci_lifecycle_test(ctx: &Framework) {
-    const LSPCI: &str = "sudo lspci -vvx";
-    const LSHW: &str = "sudo lshw -notime";
-
     let mut vm = ctx
         .spawn_vm(&ctx.vm_config_builder("lspci_lifecycle_test"), None)
         .await?;
 
     vm.launch().await?;
     vm.wait_to_boot().await?;
+    struct Check {
+        lspci: String,
+        lshw: String,
+    }
 
-    let lspci = vm.run_shell_command(LSPCI).await?;
-    let lshw = vm.run_shell_command(LSHW).await?;
-    ctx.lifecycle_test(
-        vm,
-        &[Action::StopAndStart],
-        // REVIEW(gjc): the clone here is very ugly but was the most
-        // straightforward way to convince the compiler that the lspci/lshw
-        // outputs live long enough. There has to be a better way.
-        move |vm| {
-            let lspci = lspci.clone();
-            let lshw = lshw.clone();
-            Box::pin(async move {
-                let new_lspci = vm.run_shell_command(LSPCI).await.unwrap();
-                assert_eq!(new_lspci, lspci);
-                let new_lshw = vm.run_shell_command(LSHW).await.unwrap();
-                assert_eq!(new_lshw, lshw);
-            })
-        },
-    )
-    .await?;
+    #[async_trait]
+    impl CheckVm for Check {
+        async fn check(&self, vm: &TestVm) {
+            let new_lspci = vm.run_shell_command(LSPCI).await.unwrap();
+            assert_eq!(new_lspci, self.lspci);
+            let new_lshw = vm.run_shell_command(LSHW).await.unwrap();
+            assert_eq!(new_lshw, self.lshw);
+        }
+    }
+
+    let check = Check {
+        lspci: vm.run_shell_command(LSPCI).await?,
+        lshw: vm.run_shell_command(LSHW).await?,
+    };
+    ctx.lifecycle_test(vm, &[Action::StopAndStart], check).await?;
 }

--- a/phd-tests/tests/src/hw.rs
+++ b/phd-tests/tests/src/hw.rs
@@ -10,8 +10,9 @@ async fn lspci_lifecycle_test(ctx: &Framework) {
     const LSPCI: &str = "sudo lspci -vvx";
     const LSHW: &str = "sudo lshw -notime";
 
-    let mut vm =
-        ctx.spawn_vm(&ctx.vm_config_builder("lspci_lifecycle_test"), None)?;
+    let mut vm = ctx
+        .spawn_vm(&ctx.vm_config_builder("lspci_lifecycle_test"), None)
+        .await?;
 
     vm.launch().await?;
     vm.wait_to_boot().await?;

--- a/phd-tests/tests/src/migrate.rs
+++ b/phd-tests/tests/src/migrate.rs
@@ -2,14 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use async_trait::async_trait;
 use phd_framework::{
     artifacts, lifecycle::Action, test_vm::MigrationTimeout, TestVm,
 };
-use phd_testcase::{phd_framework::lifecycle::CheckVm, *};
-use propolis_client::types::{
-    InstanceSerialConsoleHistoryResponse, MigrationState,
-};
+use phd_testcase::*;
+use propolis_client::types::MigrationState;
 use tracing::info;
 use uuid::Uuid;
 
@@ -30,9 +27,6 @@ async fn serial_history(ctx: &Framework) {
 /// Tests for migrating from a "migration base" Propolis revision (e.g. the
 /// latest commit to the `master` git branch) to the revision under test.
 mod from_base {
-    use async_trait::async_trait;
-    use phd_testcase::phd_framework::lifecycle::CheckVm;
-
     use super::*;
 
     #[phd_testcase]
@@ -66,20 +60,6 @@ mod from_base {
         source.run_shell_command("touch ./foo.bar").await?;
         source.run_shell_command("sync ./foo.bar").await?;
 
-        struct CheckContext;
-
-        #[async_trait]
-        impl CheckVm for CheckContext {
-            async fn check(&self, target: &TestVm) {
-                // the file should still exist on the target VM after migration.
-                let lsout = target
-                    .run_shell_command("ls foo.bar")
-                    .await
-                    .expect("`ls foo.bar` should succeed");
-                assert_eq!(lsout, "foo.bar");
-            }
-        }
-
         ctx.lifecycle_test(
             source,
             &[
@@ -87,7 +67,16 @@ mod from_base {
                 Action::MigrateToPropolis(artifacts::BASE_PROPOLIS_ARTIFACT),
                 Action::MigrateToPropolis(artifacts::DEFAULT_PROPOLIS_ARTIFACT),
             ],
-            CheckContext,
+            |target: &TestVm| {
+                Box::pin(async move {
+                    // the file should still exist on the target VM after migration.
+                    let lsout = target
+                        .run_shell_command("ls foo.bar")
+                        .await
+                        .expect("`ls foo.bar` should succeed");
+                    assert_eq!(lsout, "foo.bar");
+                })
+            },
         )
         .await?;
     }
@@ -328,23 +317,19 @@ async fn run_smoke_test(ctx: &Framework, mut source: TestVm) -> Result<()> {
     source.run_shell_command("touch ./foo.bar").await?;
     source.run_shell_command("sync ./foo.bar").await?;
 
-    struct Check;
-    #[async_trait]
-    impl CheckVm for Check {
-        async fn check(&self, target: &TestVm) {
-            // the file should still exist on the target VM after migration.
-            let lsout = target
-                .run_shell_command("ls foo.bar")
-                .await
-                .expect("`ls foo.bar` should succeed after migration");
-            assert_eq!(lsout, "foo.bar");
-        }
-    }
-
     ctx.lifecycle_test(
         source,
         &[Action::MigrateToPropolis(artifacts::DEFAULT_PROPOLIS_ARTIFACT)],
-        Check,
+        |target: &TestVm| {
+            Box::pin(async move {
+                // the file should still exist on the target VM after migration.
+                let lsout = target
+                    .run_shell_command("ls foo.bar")
+                    .await
+                    .expect("`ls foo.bar` should succeed after migration");
+                assert_eq!(lsout, "foo.bar");
+            })
+        },
     )
     .await
 }
@@ -363,32 +348,26 @@ async fn run_serial_history_test(
     let serial_hist_pre = source.get_serial_console_history(0).await?;
     assert!(!serial_hist_pre.data.is_empty());
 
-    struct Check {
-        serial_hist_pre: InstanceSerialConsoleHistoryResponse,
-    }
-
-    #[async_trait]
-    impl CheckVm for Check {
-        async fn check(&self, target: &TestVm) {
-            let serial_hist_post = target
-                .get_serial_console_history(0)
-                .await
-                .expect("should get serial console history from the target");
-            assert_eq!(
-                self.serial_hist_pre.data,
-                serial_hist_post.data[..self.serial_hist_pre.data.len()]
-            );
-            assert!(
-                self.serial_hist_pre.last_byte_offset
-                    <= serial_hist_post.last_byte_offset
-            );
-        }
-    }
-
     ctx.lifecycle_test(
         source,
         &[Action::MigrateToPropolis(artifacts::DEFAULT_PROPOLIS_ARTIFACT)],
-        Check { serial_hist_pre },
+        move |target| {
+            let serial_hist_pre = serial_hist_pre.clone();
+            Box::pin(async move {
+                let serial_hist_post =
+                    target.get_serial_console_history(0).await.expect(
+                        "should get serial console history from the target",
+                    );
+                assert_eq!(
+                    serial_hist_pre.data,
+                    serial_hist_post.data[..serial_hist_pre.data.len()]
+                );
+                assert!(
+                    serial_hist_pre.last_byte_offset
+                        <= serial_hist_post.last_byte_offset
+                );
+            })
+        },
     )
     .await
 }

--- a/phd-tests/tests/src/migrate.rs
+++ b/phd-tests/tests/src/migrate.rs
@@ -68,7 +68,7 @@ mod from_base {
                 Action::MigrateToPropolis(artifacts::DEFAULT_PROPOLIS_ARTIFACT),
             ],
             |target: &TestVm| {
-                Box::pin(async move {
+                Box::pin(async {
                     // the file should still exist on the target VM after migration.
                     let lsout = target
                         .run_shell_command("ls foo.bar")
@@ -321,7 +321,7 @@ async fn run_smoke_test(ctx: &Framework, mut source: TestVm) -> Result<()> {
         source,
         &[Action::MigrateToPropolis(artifacts::DEFAULT_PROPOLIS_ARTIFACT)],
         |target: &TestVm| {
-            Box::pin(async move {
+            Box::pin(async {
                 // the file should still exist on the target VM after migration.
                 let lsout = target
                     .run_shell_command("ls foo.bar")

--- a/phd-tests/tests/src/server_state_machine.rs
+++ b/phd-tests/tests/src/server_state_machine.rs
@@ -10,78 +10,81 @@ use phd_testcase::*;
 use propolis_client::types::InstanceState;
 
 #[phd_testcase]
-fn instance_start_stop_test(ctx: &Framework) {
+async fn instance_start_stop_test(ctx: &Framework) {
     let mut vm = ctx.spawn_default_vm("instance_ensure_running_test")?;
 
-    vm.instance_ensure()?;
-    let instance = vm.get()?.instance;
+    vm.instance_ensure().await?;
+    let instance = vm.get().await?.instance;
     assert_eq!(instance.state, InstanceState::Creating);
 
-    vm.launch()?;
-    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
+    vm.launch().await?;
+    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60)).await?;
 
-    vm.stop()?;
-    vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))?;
+    vm.stop().await?;
+    vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))
+        .await?;
 }
 
 #[phd_testcase]
-fn instance_stop_causes_destroy_test(ctx: &Framework) {
+async fn instance_stop_causes_destroy_test(ctx: &Framework) {
     let mut vm = ctx.spawn_default_vm("instance_stop_causes_destroy_test")?;
 
-    vm.launch()?;
-    vm.stop()?;
-    vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))?;
+    vm.launch().await?;
+    vm.stop().await?;
+    vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))
+        .await?;
 
     assert!(matches!(
-        vm.run().unwrap_err().status().unwrap(),
+        vm.run().await.unwrap_err().status().unwrap(),
         http::status::StatusCode::NOT_FOUND
     ));
     assert!(matches!(
-        vm.stop().unwrap_err().status().unwrap(),
+        vm.stop().await.unwrap_err().status().unwrap(),
         http::status::StatusCode::NOT_FOUND
     ));
     assert!(matches!(
-        vm.reset().unwrap_err().status().unwrap(),
+        vm.reset().await.unwrap_err().status().unwrap(),
         http::status::StatusCode::NOT_FOUND
     ));
 }
 
 #[phd_testcase]
-fn instance_reset_test(ctx: &Framework) {
+async fn instance_reset_test(ctx: &Framework) {
     let mut vm =
         ctx.spawn_default_vm("instance_reset_returns_to_running_test")?;
 
-    assert!(vm.reset().is_err());
-    vm.launch()?;
-    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
+    assert!(vm.reset().await.is_err());
+    vm.launch().await?;
+    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60)).await?;
 
     // Because "Rebooting" is not a steady state, the Propolis state worker may
     // transition the instance from Running to Rebooting to Running before the
     // test gets a chance to monitor its state any further. Thus, it's not safe
     // to test that the Rebooting state was observed here.
-    vm.reset()?;
-    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
+    vm.reset().await?;
+    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60)).await?;
 
     // Queue multiple reset attempts. These should all succeed, even though
     // Propolis will only allow one reboot to be enqueued at a time. Once again,
     // the specific number of reboots that will be queued depends on factors
     // outside of the test's control.
     for _ in 0..10 {
-        vm.reset()?;
+        vm.reset().await?;
     }
 
-    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
-    vm.stop()?;
-    vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))?;
-    assert!(vm.reset().is_err());
+    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60)).await?;
+    vm.stop().await?;
+    vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))
+        .await?;
+    assert!(vm.reset().await.is_err());
 }
 
 #[phd_testcase]
-fn instance_reset_requires_running_test(ctx: &Framework) {
+async fn instance_reset_requires_running_test(ctx: &Framework) {
     let mut vm =
         ctx.spawn_default_vm("instance_reset_requires_running_test")?;
 
-    assert!(vm.reset().is_err());
-    vm.launch()?;
-    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60))?;
+    assert!(vm.reset().await.is_err());
+    vm.launch().await?;
+    vm.wait_for_state(InstanceState::Running, Duration::from_secs(60)).await?;
 }

--- a/phd-tests/tests/src/server_state_machine.rs
+++ b/phd-tests/tests/src/server_state_machine.rs
@@ -11,7 +11,7 @@ use propolis_client::types::InstanceState;
 
 #[phd_testcase]
 async fn instance_start_stop_test(ctx: &Framework) {
-    let mut vm = ctx.spawn_default_vm("instance_ensure_running_test")?;
+    let mut vm = ctx.spawn_default_vm("instance_ensure_running_test").await?;
 
     vm.instance_ensure().await?;
     let instance = vm.get().await?.instance;
@@ -27,7 +27,8 @@ async fn instance_start_stop_test(ctx: &Framework) {
 
 #[phd_testcase]
 async fn instance_stop_causes_destroy_test(ctx: &Framework) {
-    let mut vm = ctx.spawn_default_vm("instance_stop_causes_destroy_test")?;
+    let mut vm =
+        ctx.spawn_default_vm("instance_stop_causes_destroy_test").await?;
 
     vm.launch().await?;
     vm.stop().await?;
@@ -51,7 +52,7 @@ async fn instance_stop_causes_destroy_test(ctx: &Framework) {
 #[phd_testcase]
 async fn instance_reset_test(ctx: &Framework) {
     let mut vm =
-        ctx.spawn_default_vm("instance_reset_returns_to_running_test")?;
+        ctx.spawn_default_vm("instance_reset_returns_to_running_test").await?;
 
     assert!(vm.reset().await.is_err());
     vm.launch().await?;
@@ -82,7 +83,7 @@ async fn instance_reset_test(ctx: &Framework) {
 #[phd_testcase]
 async fn instance_reset_requires_running_test(ctx: &Framework) {
     let mut vm =
-        ctx.spawn_default_vm("instance_reset_requires_running_test")?;
+        ctx.spawn_default_vm("instance_reset_requires_running_test").await?;
 
     assert!(vm.reset().await.is_err());
     vm.launch().await?;

--- a/phd-tests/tests/src/smoke.rs
+++ b/phd-tests/tests/src/smoke.rs
@@ -7,7 +7,7 @@ use phd_testcase::*;
 #[phd_testcase]
 async fn nproc_test(ctx: &Framework) {
     let mut vm =
-        ctx.spawn_vm(ctx.vm_config_builder("nproc_test").cpus(6), None)?;
+        ctx.spawn_vm(ctx.vm_config_builder("nproc_test").cpus(6), None).await?;
     vm.launch().await?;
     vm.wait_to_boot().await?;
 
@@ -17,10 +17,14 @@ async fn nproc_test(ctx: &Framework) {
 
 #[phd_testcase]
 async fn instance_spec_get_test(ctx: &Framework) {
-    let mut vm = ctx.spawn_vm(
-        ctx.vm_config_builder("instance_spec_test").cpus(4).memory_mib(3072),
-        None,
-    )?;
+    let mut vm = ctx
+        .spawn_vm(
+            ctx.vm_config_builder("instance_spec_test")
+                .cpus(4)
+                .memory_mib(3072),
+            None,
+        )
+        .await?;
     vm.launch().await?;
 
     let spec_get_response = vm.get_spec().await?;

--- a/phd-tests/tests/src/smoke.rs
+++ b/phd-tests/tests/src/smoke.rs
@@ -5,25 +5,25 @@
 use phd_testcase::*;
 
 #[phd_testcase]
-fn nproc_test(ctx: &Framework) {
+async fn nproc_test(ctx: &Framework) {
     let mut vm =
         ctx.spawn_vm(ctx.vm_config_builder("nproc_test").cpus(6), None)?;
-    vm.launch()?;
-    vm.wait_to_boot()?;
+    vm.launch().await?;
+    vm.wait_to_boot().await?;
 
-    let nproc = vm.run_shell_command("nproc")?;
+    let nproc = vm.run_shell_command("nproc").await?;
     assert_eq!(nproc.parse::<u8>().unwrap(), 6);
 }
 
 #[phd_testcase]
-fn instance_spec_get_test(ctx: &Framework) {
+async fn instance_spec_get_test(ctx: &Framework) {
     let mut vm = ctx.spawn_vm(
         ctx.vm_config_builder("instance_spec_test").cpus(4).memory_mib(3072),
         None,
     )?;
-    vm.launch()?;
+    vm.launch().await?;
 
-    let spec_get_response = vm.get_spec()?;
+    let spec_get_response = vm.get_spec().await?;
     let propolis_client::types::VersionedInstanceSpec::V0(spec) =
         spec_get_response.spec;
     assert_eq!(spec.devices.board.cpus, 4);


### PR DESCRIPTION
This PR converts the PHD framework to run on an async runtime (instead of running mostly synchronously and using `block_on` to handle cases where async calls are needed, e.g. working with Progenitor clients).

# Motivation

PHD tests that use file-backed disks make hard copies of the artifacts that are supposed to underlie those disks. This takes up a lot of space and is a significant performance bottleneck. This isn't very obvious with the tiny Alpine image that PHD uses by default, but creating a new copy of a 30 GiB Windows image for every test gets expensive quickly!

One promising way to solve this is to use ZFS snapshots and clones to create copy-on-write forks of these artifacts. PHD used to do this, but it exacerbated a second problem that PHD already has: if you interrupt a PHD run via SIGINT, the resources that it was using--kernel VMMs, copies of images, and Crucible downstairs data directories--don't get cleaned up. Adding another set of leak-able resources into the mix makes this problem worse.

Solving the SIGINT problem in a synchronous runner is tricky. It's not too hard to install a handler, catch the signal, and cleanly cancel the test run after the current test completes, but if the current test is *stuck*, e.g. waiting for serial console output that will never arrive, this can take a long time. A more advanced approach is to ensure (via signal masks, see generally `SIGNAL(3HEAD)`) that incoming SIGINT signals are directed to the thread that's running the test. In PHD's current architecture, the signal handler can panic to abort the test then and there. But it's not clear (to this author) how this would work in a hypothetical future where there are multiple threads executing tests simultaneously.

On the other hand, if test cases are futures, things get a lot simpler: the runner's test execution tasks can simply `select!` between a test execution future and an indicator that the run was canceled by a signal; in the latter case, each task simply needs to drop the test execution future to drop all of the VM and disk objects it was using and clean up their resources.

# Implementation

Most of the delta in this change just comes from sticking `async` and `await` on everything. The parts of the change that *don't* do that are as follows:

- The `testcase` and `testcase_macro` crates changed a bit to reflect the fact that test cases are now futures that yield a `TestOutcome` instead of functions that return one.
- The `Drop` impl for `TestVm` changed significantly. Before, it could use `block_on` to call Progenitor client functions to try to stop a Propolis VM when its `TestVm` dropped. Since there's no async drop, this impl now builds a task to handle this cleanup and sends it back to the PHD framework, which allows the runner to await it in its test cleanup fixture.
- `Framework::lifecycle_test` can no longer take a callback that operates on a test VM; instead, it takes a callback that produces a future that runs checks on that VM. This is painless in some cases, but getting the lifetimes right for check functions that capture from their environments turned out to be a major hassle. I'm too inexperienced as yet to have worked out how to express the relevant lifetimes to `rustc` to get this to compile without an ugly workaround. Guidance here would be much appreciated; see the `REVIEW(gjc)` comments in the code for the places where this came up.

Tested via local runs with Alpine and Debian 11 guests.