### PR TITLE
PHD: improve ctrl-c handling

### DIFF
--- a/phd-tests/runner/src/execute.rs
+++ b/phd-tests/runner/src/execute.rs
@@ -103,6 +103,8 @@ pub async fn run_tests_with_ctx(
         let mut sigint_rx_task = sigint_rx.clone();
         let test_outcome = match tokio::spawn(async move {
             tokio::select! {
+                // Ensure interrupt signals are always handled instead of
+                // continuing to run the test.
                 biased;
                 result = sigint_rx_task.changed() => {
                     assert!(

--- a/phd-tests/runner/src/execute.rs
+++ b/phd-tests/runner/src/execute.rs
@@ -101,7 +101,7 @@ pub async fn run_tests_with_ctx(
         let test_ctx = ctx.clone();
         let tc = execution.tc;
         let mut sigint_rx_task = sigint_rx.clone();
-        let test_outcome = match tokio::spawn(async move {
+        let test_outcome = tokio::spawn(async move {
             tokio::select! {
                 // Ensure interrupt signals are always handled instead of
                 // continuing to run the test.
@@ -120,12 +120,11 @@ pub async fn run_tests_with_ctx(
             }
         })
         .await
-        {
-            Ok(outcome) => outcome,
-            Err(_) => TestOutcome::Failed(Some(
+        .unwrap_or_else(|_| {
+            TestOutcome::Failed(Some(
                 "test task panicked, see test logs".to_string(),
-            )),
-        };
+            ))
+        });
 
         info!(
             "test {} ... {}{}",

--- a/phd-tests/runner/src/execute.rs
+++ b/phd-tests/runner/src/execute.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use phd_tests::phd_testcase::{Framework, TestCase, TestOutcome};
-use tracing::{error, info};
+use tokio::signal::unix::{signal, SignalKind};
+use tokio::sync::watch;
+use tracing::{error, info, warn};
 
 use crate::config::RunOptions;
 use crate::fixtures::TestFixtures;
@@ -76,10 +78,15 @@ pub async fn run_tests_with_ctx(
     }
 
     fixtures.execution_setup().unwrap();
-
+    let sigint_rx = set_sigint_handler();
     info!("Running {} test(s)", executions.len());
     let start_time = Instant::now();
-    'exec_loop: for execution in &mut executions {
+    for execution in &mut executions {
+        if *sigint_rx.borrow() {
+            info!("Test run interrupted by SIGINT");
+            break;
+        }
+
         info!("Starting test {}", execution.tc.fully_qualified_name());
 
         // Failure to run a setup fixture is fatal to the rest of the run, but
@@ -87,21 +94,36 @@ pub async fn run_tests_with_ctx(
         // of panicking.
         if let Err(e) = fixtures.test_setup() {
             error!("Error running test setup fixture: {}", e);
-            break 'exec_loop;
+            break;
         }
 
         stats.tests_not_run -= 1;
         let test_ctx = ctx.clone();
         let tc = execution.tc;
-        let test_outcome =
-            match tokio::spawn(async move { tc.run(test_ctx.as_ref()).await })
-                .await
-            {
-                Ok(outcome) => outcome,
-                Err(_) => TestOutcome::Failed(Some(
-                    "test task panicked, see test logs".to_string(),
-                )),
-            };
+        let mut sigint_rx_task = sigint_rx.clone();
+        let test_outcome = match tokio::spawn(async move {
+            tokio::select! {
+                biased;
+                result = sigint_rx_task.changed() => {
+                    assert!(
+                        result.is_ok(),
+                        "SIGINT channel shouldn't drop while tests are running"
+                    );
+
+                    TestOutcome::Failed(
+                        Some("test interrupted by SIGINT".to_string())
+                    )
+                }
+                outcome = tc.run(test_ctx.as_ref()) => outcome
+            }
+        })
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(_) => TestOutcome::Failed(Some(
+                "test task panicked, see test logs".to_string(),
+            )),
+        };
 
         info!(
             "test {} ... {}{}",
@@ -132,7 +154,7 @@ pub async fn run_tests_with_ctx(
         execution.status = Status::Ran(test_outcome);
         if let Err(e) = fixtures.test_cleanup().await {
             error!("Error running cleanup fixture: {}", e);
-            break 'exec_loop;
+            break;
         }
     }
     stats.duration = start_time.elapsed();
@@ -140,4 +162,36 @@ pub async fn run_tests_with_ctx(
     fixtures.execution_cleanup().unwrap();
 
     stats
+}
+
+/// Sets a global handler for SIGINT and hands the resulting signal channel over
+/// to a task that handles this signal. Returns a receiver to which the signal
+/// handler task publishes `true` to the channel when SIGINT is received.
+fn set_sigint_handler() -> watch::Receiver<bool> {
+    let mut sigint =
+        signal(SignalKind::interrupt()).expect("failed to set SIGINT handler");
+
+    let (sigint_tx, sigint_rx) = watch::channel(false);
+    tokio::spawn(async move {
+        loop {
+            sigint.recv().await;
+
+            // If a signal was previously dispatched to the channel, exit
+            // immediately with the customary SIGINT exit code (130 is 128 +
+            // SIGINT). This allows users to interrupt tests even if they aren't
+            // at an await point (at the cost of not having destructors run).
+            if *sigint_tx.borrow() {
+                error!(
+                    "SIGINT received while shutting down, rudely terminating"
+                );
+                error!("some processes and resources may have been leaked!");
+                std::process::exit(130);
+            }
+
+            warn!("SIGINT received, sending shutdown signal to tests");
+            let _ = sigint_tx.send(true);
+        }
+    });
+
+    sigint_rx
 }


### PR DESCRIPTION
(N.B. Depends on #633.)

Install a SIGINT handler in the PHD runner and use it to broadcast to all test execution tasks that this signal was received. Add a `select!` to the tasks to preempt further execution of test cases when this happens. Dropping the test case futures also drops all the VMs and disks they create, giving the runner a chance to clean up kernel VMMs and disk backing files before exiting. (If one SIGINT is handled and a second is received, exit immediately to allow the runner to be killed even if a test case hasn't reached an `await` point.)

To ensure that Propolis processes get a chance to stop gracefully, add a pre-`exec` hook so that the framework's Propolis servers ignore SIGINT. This is needed so that hitting Ctrl-C to interrupt a foreground runner doesn't take out the Propolis servers in the same process group before `TestVm::drop` gets a chance to clean them up.

Tested with runs of Debian 11 guests, both running to completion (all tests still pass) and interrupted at various points midway (verified that kernel VMMs and disks get cleaned up as expected when they didn't before).