### PR TITLE
PHD: assume specialized Windows images

### DIFF
--- a/phd-tests/README.md
+++ b/phd-tests/README.md
@@ -217,6 +217,7 @@ encoded into the logon sequences for each adapter and reproduced below:
 | Alpine Linux        | `root`          |              |
 | Debian 11 (nocloud) | `root`          |              |
 | Ubuntu 20.04        | `ubuntu`        | `1!Passw0rd` |
+| Windows Server 2019 | `Administrator` | `0xide#1Fan` |
 | Windows Server 2022 | `Administrator` | `0xide#1Fan` |
 
 If you add a custom image to your artifact file, you must make sure either to

--- a/phd-tests/framework/src/guest_os/windows.rs
+++ b/phd-tests/framework/src/guest_os/windows.rs
@@ -11,12 +11,6 @@ use super::{CommandSequence, CommandSequenceEntry, GuestOsKind};
 ///
 /// This login sequence assumes the following:
 ///
-/// - The image has been generalized (by running `sysprep /generalize`) and is
-///   configured so that on first boot it will skip the out-of-box experience
-///   (OOBE) and initialize the local administrator account with the appropriate
-///   password. See [MSDN's Windows Setup
-///   documentation](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/generalize?view=windows-11)
-///   for more details.
 /// - Cygwin is installed to C:\cygwin and can be launched by invoking
 ///   C:\cygwin\cygwin.bat.
 /// - The local administrator account is enabled with password `0xide#1Fan`.
@@ -27,11 +21,6 @@ pub(super) fn get_login_sequence_for(guest: GuestOsKind) -> CommandSequence {
     ));
 
     let mut commands = vec![
-        // Assume the image will need to reboot one last time after being
-        // specialized.
-        CommandSequenceEntry::WaitFor(
-            "Computer is booting, SAC started and initialized.",
-        ),
         CommandSequenceEntry::WaitFor(
             "Computer is booting, SAC started and initialized.",
         ),


### PR DESCRIPTION
Change the Windows guest adapters to assume they're operating on a fully- specialized, post-OOBE guest image. This fixes tests like the `lspci` lifecycle test that stop and start a VM and assume that it will go through the same boot sequence on its initial and subsequent attempts to start.

Also fix up the PHD README to describe the WS2019 adapter (missed this in the change that added the adapter).

Tested with WS2019 and WS2022 guests.

Fixes #625.