### PR TITLE
phd: use latest "lab-2.0-opte" target, not a specific version

### DIFF
--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "phd-run"
 #: variety = "basic"
-#: target = "lab-2.0-opte-0.23"
+#: target = "lab-2.0-opte"
 #: output_rules = [
 #:	"/tmp/phd-runner.log",
 #:	"/tmp/phd-tmp-files.tar.gz",


### PR DESCRIPTION
Because AWS is a den of sin and has started acting up with the older instance type we are using, I have regenerated the **helios-2.0** images from a current **stlouis** which now includes an improved ENA driver and works with newer instance types.  In order to correctly use artefacts built on that newer image, we need commensurately new **lab-2.0-opte-X** images.  At present I regenerate the images with the three most recent OPTE versions (i.e., 0.26 through 0.28 today) but propolis is still using **lab-2.0-opte-0.23**.

It doesn't seem like you actually care about the OPTE version right now, or at least that was true at the time.  I have created a new virtual **lab-2.0-opte** target in buildomat (akin to the **helios-2.0** virtual target) which will redirect to the latest in the series; viz., today, **lab-2.0-opte-0.28**.