### PR TITLE
PHD: Use ZFS clones for file-backed disks

### DIFF
--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -21,9 +21,10 @@ indir="/input"
 indir_suffix="phd-build/out/*.tar.gz"
 phddir="$PWD/phd-test"
 
-# Download artifacts to /work so that the runner can create ZFS clones of them
-# to reduce the number of files it needs to copy repeatedly.
-artifactdir="/work/phd-artifacts"
+# Put artifacts on the runner's SSDs (the /work ramdisk is small by design, too
+# small for images of any appreciable size).
+pfexec zpool create -f phd-artifacts c1t1d0 c2t1d0
+artifactdir="/phd-artifacts"
 
 banner 'Inputs'
 find $indir -ls

--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -32,9 +32,6 @@ find $indir -ls
 rm -rf "$phddir"
 mkdir "$phddir"
 
-rm -rf "$artifactdir"
-mkdir "$artifactdir"
-
 for p in $indir/$indir_suffix; do
 	tar xzvf $p -C $phddir
 	for f in $(tar tf "$p"); do

--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -21,11 +21,18 @@ indir="/input"
 indir_suffix="phd-build/out/*.tar.gz"
 phddir="$PWD/phd-test"
 
+# Download artifacts to /work so that the runner can create ZFS clones of them
+# to reduce the number of files it needs to copy repeatedly.
+artifactdir="/work/phd-artifacts"
+
 banner 'Inputs'
 find $indir -ls
 
 rm -rf "$phddir"
 mkdir "$phddir"
+
+rm -rf "$artifactdir"
+mkdir "$artifactdir"
 
 for p in $indir/$indir_suffix; do
 	tar xzvf $p -C $phddir
@@ -63,7 +70,7 @@ set +e
 	--crucible-downstairs-commit auto \
 	--artifact-toml-path $artifacts \
 	--tmp-directory $tmpdir \
-	--artifact-directory $tmpdir | \
+	--artifact-directory $artifactdir | \
 	tee /tmp/phd-runner.log)
 failcount=$?
 set -e

--- a/phd-tests/framework/src/disk/file.rs
+++ b/phd-tests/framework/src/disk/file.rs
@@ -30,12 +30,14 @@ impl BackingFile {
         artifact_path: &Utf8Path,
         data_dir: &Utf8Path,
     ) -> anyhow::Result<Self> {
-        if let Ok(file) = ZfsClonedFile::create_from_path(artifact_path) {
-            return Ok(Self::Zfs(file));
+        match ZfsClonedFile::create_from_path(artifact_path) {
+            Ok(file) => return Ok(Self::Zfs(file)),
+            Err(error) => warn!(
+                %artifact_path,
+                %error,
+                "failed to make ZFS clone of backing artifact, will copy it"
+            ),
         }
-
-        warn!(%artifact_path,
-              "failed to make ZFS clone of backing artifact, will copy it");
 
         let mut disk_path = data_dir.to_path_buf();
         disk_path.push(format!("{}.phd_disk", Uuid::new_v4()));

--- a/phd-tests/framework/src/disk/file.rs
+++ b/phd-tests/framework/src/disk/file.rs
@@ -103,11 +103,10 @@ impl FileBackedDisk {
             artifact_path.as_ref(),
             data_dir.as_ref(),
         )?;
-        let disk_path = artifact.path().into_std_path_buf();
 
         // Make sure the disk is writable (the artifact may have been
         // read-only).
-        let disk_file = std::fs::File::open(disk_path)?;
+        let disk_file = std::fs::File::open(artifact.path())?;
         let mut permissions = disk_file.metadata()?.permissions();
 
         // TODO: Clippy is upset that `set_readonly(false)` results in

--- a/phd-tests/framework/src/disk/mod.rs
+++ b/phd-tests/framework/src/disk/mod.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use anyhow::Context;
+use camino::Utf8PathBuf;
 use propolis_client::types::StorageBackendV0;
 use thiserror::Error;
 
@@ -145,11 +146,10 @@ impl DiskFactory {
     async fn get_guest_artifact_info(
         &self,
         artifact_name: &str,
-    ) -> Result<(PathBuf, GuestOsKind), DiskError> {
+    ) -> Result<(Utf8PathBuf, GuestOsKind), DiskError> {
         self.artifact_store
             .get_guest_os_image(artifact_name)
             .await
-            .map(|(utf8, kind)| (utf8.into_std_path_buf(), kind))
             .with_context(|| {
                 format!("failed to get guest OS artifact '{}'", artifact_name)
             })
@@ -167,13 +167,8 @@ impl DiskFactory {
         let (artifact_path, guest_os) =
             self.get_guest_artifact_info(artifact_name).await?;
 
-        FileBackedDisk::new_from_artifact(
-            name,
-            &artifact_path,
-            &self.storage_dir,
-            Some(guest_os),
-        )
-        .map(Arc::new)
+        FileBackedDisk::new_from_artifact(name, &artifact_path, Some(guest_os))
+            .map(Arc::new)
     }
 
     /// Creates a new Crucible-backed disk by creating three region files to

--- a/phd-tests/framework/src/lib.rs
+++ b/phd-tests/framework/src/lib.rs
@@ -55,6 +55,7 @@ mod port_allocator;
 mod serial;
 pub mod server_log_mode;
 pub mod test_vm;
+pub(crate) mod zfs;
 
 /// An instance of the PHD test framework.
 pub struct Framework {

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -824,78 +824,39 @@ impl Drop for TestVm {
         // `block_on` here to guarantee that VMMs are synchronously cleaned up
         // when a `TestVm` is dropped.
         //
-        // As an alternative, destructure the client and server and hand them
-        // off to their own separate task. (The server needs to be moved into
-        // the task explicitly so that its `Drop` impl, which terminates the
-        // server process, won't run until this work is complete.)
-        //
-        // Send the task back to the framework so that the test runner can wait
-        // for all under-destruction VMs to be reaped before exiting.
+        // To drop the VMM safely, destructure this VM into its client, server,
+        // and attached disk objects, and hand them all off to a separate
+        // destructor task. Once the task is spawned, send it back to the
+        // framework so that the test runner can wait for all the VMs destroyed
+        // by a test case to be reaped before starting another test.
         let client = self.client.clone();
-        let server = self.server.take();
+        let mut server = self.server.take().expect(
+            "TestVm should always have a valid server until it's dropped",
+        );
+
+        let disks: Vec<_> = self.vm_spec().disk_handles.drain(..).collect();
+
+        // The order in which the task destroys objects is important: the server
+        // can't be killed until the client has gotten a chance to shut down
+        // the VM, and the disks can't be destroyed until the server process has
+        // been killed.
         let task = tokio::spawn(
             async move {
-                let _server = server;
-                match client
-                    .instance_get()
-                    .send()
-                    .await
-                    .map(|r| r.instance.state)
-                {
-                    Ok(InstanceState::Destroyed) => return,
-                    Err(e) => warn!(
-                        ?e,
-                        "error getting instance state from dropped VM"
-                    ),
-                    Ok(_) => {}
-                }
+                // The task doesn't use the disks directly, but they need to be
+                // kept alive until the server process is gone.
+                let _disks = disks;
 
-                debug!("stopping test VM on drop");
-                if let Err(e) = client
-                    .instance_state_put()
-                    .body(InstanceStateRequested::Stop)
-                    .send()
-                    .await
-                {
-                    error!(?e, "error stopping dropping VM");
-                    return;
-                }
+                // Try to make sure the server's kernel VMM is cleaned up before
+                // killing the server process. This is best-effort; if it fails,
+                // the kernel VMM is leaked. This generally indicates a bug in
+                // Propolis (e.g. a VMM reference leak or an instance taking an
+                // unexpectedly long time to stop).
+                try_ensure_vm_destroyed(&client).await;
 
-                let check_destroyed = || async {
-                    match client
-                        .instance_get()
-                        .send()
-                        .await
-                        .map(|r| r.instance.state)
-                    {
-                        Ok(InstanceState::Destroyed) => Ok(()),
-                        Ok(state) => {
-                            Err(backoff::Error::transient(anyhow::anyhow!(
-                                "instance not destroyed yet (state: {:?})",
-                                state
-                            )))
-                        }
-                        Err(e) => {
-                            error!(%e, "failed to get state of dropping VM");
-                            Err(backoff::Error::permanent(e.into()))
-                        }
-                    }
-                };
-
-                let destroyed = backoff::future::retry(
-                    backoff::ExponentialBackoff {
-                        max_elapsed_time: Some(std::time::Duration::from_secs(
-                            5,
-                        )),
-                        ..Default::default()
-                    },
-                    check_destroyed,
-                )
-                .await;
-
-                if let Err(e) = destroyed {
-                    error!(%e, "dropped VM not destroyed after 5 seconds");
-                }
+                // Make sure the server process is dead before trying to clean
+                // up any disks. Otherwise, ZFS may refuse to delete a cloned
+                // disk because the server process still has it open.
+                server.kill();
             }
             .instrument(
                 info_span!("VM cleanup", vm = self.spec.vm_name, vm_id = %self.id),
@@ -903,5 +864,56 @@ impl Drop for TestVm {
         );
 
         let _ = self.cleanup_task_tx.send(task);
+    }
+}
+
+/// Attempts to ensure that the Propolis server referred to by `client` is in
+/// the `Destroyed` state by stopping any VM that happens to be running in that
+/// server.
+///
+/// This function is best-effort.
+async fn try_ensure_vm_destroyed(client: &Client) {
+    match client.instance_get().send().await.map(|r| r.instance.state) {
+        Ok(InstanceState::Destroyed) => return,
+        Err(e) => warn!(?e, "error getting instance state from dropped VM"),
+        Ok(_) => {}
+    }
+
+    debug!("trying to ensure Propolis server VM is destroyed");
+    if let Err(e) = client
+        .instance_state_put()
+        .body(InstanceStateRequested::Stop)
+        .send()
+        .await
+    {
+        error!(%e, "error stopping VM to move it to Destroyed");
+        return;
+    }
+
+    let check_destroyed = || async {
+        match client.instance_get().send().await.map(|r| r.instance.state) {
+            Ok(InstanceState::Destroyed) => Ok(()),
+            Ok(state) => Err(backoff::Error::transient(anyhow::anyhow!(
+                "instance not destroyed yet (state: {:?})",
+                state
+            ))),
+            Err(e) => {
+                error!(%e, "failed to get state of VM being destroyed");
+                Err(backoff::Error::permanent(e.into()))
+            }
+        }
+    };
+
+    let destroyed = backoff::future::retry(
+        backoff::ExponentialBackoff {
+            max_elapsed_time: Some(std::time::Duration::from_secs(5)),
+            ..Default::default()
+        },
+        check_destroyed,
+    )
+    .await;
+
+    if let Err(e) = destroyed {
+        error!(%e, "VM not destroyed after 5 seconds");
     }
 }

--- a/phd-tests/framework/src/zfs.rs
+++ b/phd-tests/framework/src/zfs.rs
@@ -147,6 +147,11 @@ impl ClonedFile {
 
         zfs_command("clone", &[&snapshot.name.0, &clone_name])?;
 
+        // If any errors occur between this point and the construction of a
+        // `Clone` wrapper, this function needs to destroy the new clone
+        // manually. The only thing needed to construct a `Clone` is its mount
+        // point, so put that logic in a function and clean up manually if it
+        // fails.
         fn get_clone_mount_point(
             clone_name: &str,
         ) -> anyhow::Result<Utf8PathBuf> {

--- a/phd-tests/framework/src/zfs.rs
+++ b/phd-tests/framework/src/zfs.rs
@@ -1,0 +1,319 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Support functions for working with ZFS snapshots and clones.
+
+use anyhow::Context;
+use camino::{Utf8Path, Utf8PathBuf};
+use tracing::{debug, error};
+use uuid::Uuid;
+
+#[derive(Debug)]
+struct DatasetName(String);
+
+#[derive(Debug)]
+struct SnapshotName(String);
+
+#[derive(Debug)]
+struct CloneName(String);
+
+/// Describes a dataset that's mounted at a specific point in the global
+/// directory hierarchy.
+#[derive(Debug)]
+struct Dataset {
+    /// The name of this dataset, used to refer to it as a subject of a ZFS
+    /// operation.
+    name: DatasetName,
+
+    /// The mount point of this dataset. Stripping this prefix from the absolute
+    /// path of a file that lies in this dataset yields the path to the file
+    /// relative to the dataset root. This is needed to find the file if the
+    /// dataset (or a clone of it) is mounted someplace else.
+    mount_point: Utf8PathBuf,
+}
+
+/// Describes a snapshot of a specific dataset. When dropped, attempts to delete
+/// itself using `zfs destroy`.
+#[derive(Debug)]
+struct Snapshot {
+    /// The name of this snapshot, used to refer to it as a subject of a ZFS
+    /// operation.
+    name: SnapshotName,
+}
+
+impl Snapshot {
+    /// Takes a snapshot of the supplied `dataset`.
+    fn create_from_dataset(dataset: &DatasetName) -> anyhow::Result<Self> {
+        let snapshot_name = format!("{}@phd-{}", dataset.0, Uuid::new_v4());
+        zfs_command("snapshot", &[&snapshot_name])?;
+
+        Ok(Self { name: SnapshotName(snapshot_name) })
+    }
+}
+
+impl Drop for Snapshot {
+    fn drop(&mut self) {
+        debug!(name = self.name.0, "zfs snapshot dropped");
+        let _ = zfs_command("destroy", &[&self.name.0]);
+    }
+}
+
+/// Describes a clone of a specific snapshot. When dropped, attempts to delete
+/// itself using `zfs destroy`.
+#[derive(Debug)]
+struct Clone {
+    /// The name of this clone, used to refer to it as a subject of a ZFS
+    /// operation.
+    name: CloneName,
+
+    /// The point at which this clone is mounted in the global directory
+    /// hierarchy.
+    mount_point: Utf8PathBuf,
+
+    /// The snapshot this clone derives from. Snapshots can't be deleted until
+    /// all their clones are gone; this reference helps to ensure that clones
+    /// and snapshots are deleted in the correct order irrespective of when the
+    /// clones and the [`CloneManager`] are dropped.
+    _snapshot: Snapshot,
+}
+
+impl Drop for Clone {
+    fn drop(&mut self) {
+        debug!(name = self.name.0, "zfs clone dropped");
+        let _ = zfs_command("destroy", &[&self.name.0]);
+    }
+}
+
+/// Represents a specific copy-on-write file within a ZFS clone. When this is
+/// dropped, attempts to delete the associated clone.
+#[derive(Debug)]
+pub struct ClonedFile {
+    /// The clone to which this file belongs.
+    clone: Clone,
+
+    /// The path to this file relative to the mount point of the clone.
+    relative_path: Utf8PathBuf,
+}
+
+impl ClonedFile {
+    /// Creates a snapshot and clone of the dataset that contains the canonical
+    /// location of the file indicated by `path`.
+    pub fn create_from_path(path: &Utf8Path) -> anyhow::Result<Self> {
+        // Canonicalize the path to resolve any symbolic links before doing any
+        // prefix matching.
+        let canonical_path = path.canonicalize_utf8()?;
+
+        let containing_dataset = Dataset::from_path(&canonical_path)
+            .with_context(|| format!("getting dataset containing {path}"))?;
+
+        let relative_file_path = canonical_path
+            .strip_prefix(&containing_dataset.mount_point)
+            .context("getting relative path to file to clone")?;
+
+        let snapshot = Snapshot::create_from_dataset(&containing_dataset.name)?;
+        Self::create_from_paths_and_snapshot(relative_file_path, snapshot)
+            .context("creating zfs clone")
+    }
+
+    /// Yields the absolute path to this cloned file in the global directory
+    /// hierarchy.
+    pub fn path(&self) -> Utf8PathBuf {
+        let mut path = self.clone.mount_point.clone();
+        path.push(&self.relative_path);
+        path
+    }
+
+    /// Given a path to a file relative to the root of its (mounted) dataset,
+    /// and the name of a snapshot of that dataset, clones the snapshot and
+    /// returns a handle to the clone. The [`path`] method can be used to find
+    /// the absolute path to the file within the clone.
+    fn create_from_paths_and_snapshot(
+        relative_file_path: &Utf8Path,
+        snapshot: Snapshot,
+    ) -> anyhow::Result<Self> {
+        // Naively assume the existence of a root pool named `rpool` in lieu of
+        // trying to parse the output of `zpool list`.
+        const ZFS_ROOT_POOL: &str = "rpool";
+        let clone_name =
+            format!("{ZFS_ROOT_POOL}/phd-clone-{}", Uuid::new_v4());
+
+        zfs_command("clone", &[&snapshot.name.0, &clone_name])?;
+
+        fn get_clone_mount_point(
+            clone_name: &str,
+        ) -> anyhow::Result<Utf8PathBuf> {
+            let output = zfs_command("list", &[&clone_name])?;
+            let (object_name, mount_point) = parse_zfs_list_output(output)?;
+
+            anyhow::ensure!(
+                object_name == clone_name,
+                "zfs list returned object {object_name} when asked about clone \
+                {clone_name}"
+            );
+
+            let Some(mount_point) = mount_point else {
+                anyhow::bail!("new zfs clone {clone_name} not mounted");
+            };
+
+            Ok(mount_point)
+        }
+
+        let mount_point = match get_clone_mount_point(&clone_name) {
+            Ok(mount_point) => mount_point,
+            Err(e) => {
+                let _ = zfs_command("destroy", &[&clone_name]);
+                return Err(e);
+            }
+        };
+
+        Ok(Self {
+            clone: Clone {
+                name: CloneName(clone_name),
+                mount_point,
+                _snapshot: snapshot,
+            },
+            relative_path: relative_file_path.to_path_buf(),
+        })
+    }
+}
+
+impl Dataset {
+    /// Looks up the dataset containing `path`.
+    ///
+    /// This routine fails if any `zfs` command line operations fail or return
+    /// no output. It also fails if the found dataset's mount point is not a
+    /// prefix of the supplied `path`, e.g. because of a symbolic link somewhere
+    /// in the path.
+    fn from_path(path: &Utf8Path) -> anyhow::Result<Self> {
+        let output = zfs_command("list", &[path.as_str()])?;
+        let (name, mount_point) = parse_zfs_list_output(output)
+            .with_context(|| format!("parsing output from zfs list {path}"))?;
+
+        let Some(mount_point) = mount_point else {
+            anyhow::bail!(
+                "`zfs list {path}` produced a dataset with no mount point"
+            );
+        };
+
+        // The rest of this module needs to be able to strip the mount point
+        // from the original path to get a dataset-relative path to the target
+        // file. If the file path isn't prefixed by the mount point, this won't
+        // work. This should generally not happen if the caller was diligent
+        // about providing canonicalized paths.
+        anyhow::ensure!(
+            path.starts_with(&mount_point),
+            "zfs dataset containing '{path}' is not prefixed by dataset mount
+            point {mount_point} (is the path canonicalized?)"
+        );
+
+        Ok(Self { name: DatasetName(name.to_owned()), mount_point })
+    }
+}
+
+/// Parses the output returned from a `zfs list` command into an object name and
+/// a mountpoint.
+///
+/// This routine assumes the caller scoped its `zfs list` command so that it
+/// returns exactly one (non-header) line of output. If it finds more, this
+/// routine fails.
+fn parse_zfs_list_output(
+    output: std::process::Output,
+) -> anyhow::Result<(String, Option<Utf8PathBuf>)> {
+    let output = String::from_utf8(output.stdout)
+        .context("converting `zfs list` output to string")?;
+
+    debug!(stdout = output, "parsing zfs list output");
+
+    // The expected output format from this command is
+    //
+    // NAME              USED  AVAIL     REFER  MOUNTPOINT
+    // rpool/home/user   263G  549G       263G  /home/user
+    let mut lines = output.lines();
+
+    // Consume the header line and make sure it looks like it's sensibly
+    // formatted. In particular, if the supplied path isn't part of a dataset,
+    // `zfs` will return `cannot open 'path'`.
+    let header = lines.next().ok_or_else(|| {
+        anyhow::anyhow!("`zfs list` unexpectedly printed nothing")
+    })?;
+
+    anyhow::ensure!(
+        header.starts_with("NAME"),
+        "expected first line of `zfs list` output to start with NAME \
+        (got '{header}')"
+    );
+
+    // Capture the first line of actual output for splitting and parsing. If
+    // there are more output lines than this, fail instead of ignoring some
+    // output.
+    let answer = lines.next().ok_or_else(|| {
+        anyhow::anyhow!("`zfs list` didn't have an output line")
+    })?;
+
+    if lines.next().is_some() {
+        anyhow::bail!("`zfs list` returned more than one output line");
+    }
+
+    // `zfs list` output looks something like this (with a header line for
+    // reference):
+    //
+    // NAME              USED  AVAIL     REFER  MOUNTPOINT
+    // rpool/home/user   263G  549G       263G  /home/user
+    //
+    // The object name is the first token and the mount point is the fifth
+    // (fourth after consuming the name).
+    let mut words = answer.split_whitespace();
+    let name = words.next().ok_or_else(|| {
+        anyhow::anyhow!("`zfs list` didn't produce a dataset name")
+    })?;
+
+    // An unmounted object's mount point displays as "-", so this token should
+    // always be present, even for unmounted objects.
+    let mount_point = words.nth(3).ok_or_else(|| {
+        anyhow::anyhow!("`zfs list` didn't produce a mount point")
+    })?;
+
+    let mount_point = mount_point
+        .starts_with('/')
+        .then_some(mount_point)
+        .map(Utf8PathBuf::from);
+
+    Ok((name.to_owned(), mount_point))
+}
+
+/// Executes `zfs <verb>` with the supplied `args` as trailing arguments.
+/// Returns the full command output on success. Fails if `zfs` returned a
+/// nonzero error code.
+fn zfs_command(
+    verb: &str,
+    args: &[&str],
+) -> anyhow::Result<std::process::Output> {
+    debug!(verb, ?args, "executing ZFS command");
+
+    let output = std::process::Command::new("pfexec")
+        .arg("zfs")
+        .arg(verb)
+        .args(args)
+        .output()
+        .with_context(|| format!("running `zfs {verb}` with args {args:?}"))?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!(
+            verb,
+            ?args,
+            error_code = output.status.code(),
+            %stdout,
+            %stderr,
+            "zfs command failed"
+        );
+        anyhow::bail!(
+            "`zfs {verb}` with args {args:?} returned error {:?}",
+            output.status.code()
+        );
+    }
+
+    Ok(output)
+}

--- a/phd-tests/framework/src/zfs.rs
+++ b/phd-tests/framework/src/zfs.rs
@@ -74,7 +74,7 @@ struct Clone {
     /// The snapshot this clone derives from. Snapshots can't be deleted until
     /// all their clones are gone; this reference helps to ensure that clones
     /// and snapshots are deleted in the correct order irrespective of when the
-    /// clones and the [`CloneManager`] are dropped.
+    /// clones are dropped.
     _snapshot: Snapshot,
 }
 

--- a/phd-tests/framework/src/zfs.rs
+++ b/phd-tests/framework/src/zfs.rs
@@ -117,7 +117,12 @@ impl ClonedFile {
             relative_file_path,
             snapshot,
         )
-        .context("creating zfs clone")
+        .with_context(|| {
+            format!(
+                "creating zfs clone of {canonical_path} with original path \
+                {path}"
+            )
+        })
     }
 
     /// Yields the absolute path to this cloned file in the global directory


### PR DESCRIPTION
(N.B. Stacked on #634.) 

When creating a file-backed disk from an artifact, create a ZFS snapshot and of the dataset containing the artifact, then create and mount a clone of the snapshot and back the disk from the clone. This is much, much less expensive than copying the underlying file and markedly improves performance for test runs with disks of nontrivial size. (On my local test machine, a full test run with a 2 GiB Debian nocloud image took 688 seconds before this change and 610 seconds after, about a 10% speedup.)

This is unfortunately not likely to move the needle much on CI times because the Alpine test image CI uses is very small. However, this should make it much easier to switch to non-Alpine CI guest(s) without needlessly bloating CI times.

Tested with full runs against Debian 11 and Alpine guests.