### PR TITLE
PHD: several `cargo xtask phd` CLI fixes

### DIFF
--- a/xtask/src/task_phd.rs
+++ b/xtask/src/task_phd.rs
@@ -54,14 +54,14 @@ pub(crate) enum Cmd {
     /// List PHD tests
     List {
         /// Arguments to pass to `phd-runner list`.
-        #[clap(trailing_var_arg = true)]
+        #[clap(trailing_var_arg = true, allow_hyphen_values = true)]
         phd_args: Vec<String>,
     },
 
     /// Display `phd-runner`'s help output.
     RunnerHelp {
         /// Arguments to pass to `phd-runner help`.
-        #[clap(trailing_var_arg = true)]
+        #[clap(trailing_var_arg = true, allow_hyphen_values = true)]
         phd_args: Vec<String>,
     },
 }
@@ -93,7 +93,7 @@ pub(crate) struct RunArgs {
     ///
     /// Use `cargo xtask phd runner-help` for details on the arguments passed to
     /// `phd-runner`.
-    #[clap(trailing_var_arg = true)]
+    #[clap(trailing_var_arg = true, allow_hyphen_values = true)]
     phd_args: Vec<String>,
 }
 

--- a/xtask/src/task_phd.rs
+++ b/xtask/src/task_phd.rs
@@ -133,6 +133,8 @@ impl Cmd {
         let mut arg_iter = phd_args.iter().map(String::as_str);
         let mut bonus_args = Vec::new();
         let mut propolis_base_branch = None;
+        // If set, the `base-propolis-cmd` or `base-propolis-commit` CLI args
+        // were passed, so we should skip adding `--base-propolis-branch`.
         let mut overridden_base_propolis = false;
         let mut propolis_local_path = None;
         let mut crucible_commit = None;
@@ -157,6 +159,12 @@ impl Cmd {
                 args::PROPOLIS_BASE_COMMIT | args::PROPOLIS_BASE_CMD => {
                     overridden_base_propolis = true;
                     bonus_args.push(arg);
+
+                    let val = arg_iter.next().ok_or_else(|| {
+                        anyhow::anyhow!("Missing value for argument `{arg}`")
+                    })?;
+                    bonus_args.push(val);
+                    cargo_log!("Overridden", "{} {val:?}", arg);
                 }
 
                 _ => bonus_args.push(arg),

--- a/xtask/src/task_phd.rs
+++ b/xtask/src/task_phd.rs
@@ -79,7 +79,7 @@ pub(crate) struct RunArgs {
 
     /// If set, skip migration-from-base tests.
     ///
-    /// If this flag is present, `cargo xtask phd` will not not pass
+    /// If this flag is present, `cargo xtask phd` will not pass
     /// `--base-propolis-branch master` to the `phd-runner` command.
     #[clap(long)]
     no_base_propolis: bool,

--- a/xtask/src/task_phd.rs
+++ b/xtask/src/task_phd.rs
@@ -77,6 +77,13 @@ pub(crate) struct RunArgs {
     #[clap(long)]
     no_tidy: bool,
 
+    /// If set, skip migration-from-base tests.
+    ///
+    /// If this flag is present, `cargo xtask phd` will not not pass
+    /// `--base-propolis-branch master` to the `phd-runner` command.
+    #[clap(long)]
+    no_base_propolis: bool,
+
     /// Arguments to pass to `phd-runner run`.
     ///
     /// If the `--propolis-server-cmd`, `--crucible-downstairs-commit`,
@@ -101,7 +108,12 @@ impl Cmd {
         let mut tmp_dir = phd_dir.join("tmp");
         let now = time::SystemTime::now();
 
-        let RunArgs { propolis_release_mode, no_tidy, phd_args } = match self {
+        let RunArgs {
+            propolis_release_mode,
+            no_tidy,
+            phd_args,
+            no_base_propolis,
+        } = match self {
             Self::Run { args } => args,
             Self::Tidy => {
                 cargo_log!("Tidying up", "old temporary directories...");
@@ -135,7 +147,7 @@ impl Cmd {
         let mut propolis_base_branch = None;
         // If set, the `base-propolis-cmd` or `base-propolis-commit` CLI args
         // were passed, so we should skip adding `--base-propolis-branch`.
-        let mut overridden_base_propolis = false;
+        let mut overridden_base_propolis = no_base_propolis;
         let mut propolis_local_path = None;
         let mut crucible_commit = None;
         let mut artifacts_toml = None;


### PR DESCRIPTION
This branch fixes a bunch of things that were broken and/or annoying about the `cargo xtask phd` CLI user experience. In particular, I've made the following changes:


- **PHD: don't require `--` in xtask arg passthrough** (a573d7914c55a7f01fbd06e681c4200e773c5a5d)

  Currently, `cargo xtask phd` requires a `--` delimiter prior to any
  arguments that are passed through to `phd-runner`. This is a bit
  unfortunate, as the command invocation accepts some arguments that are
  consumed by the xtask command, and others that are passed through to
  `phd-runner`. This commit adds [`allow_hyphen_values`] to the trailing
  varargs in the Clap CLI for `cargo xtask phd`, so that the user doesn't
  need to explicitly pass the `--` delimiter. This makes the CLI a bit
  nicer to use.

  [`allow_hyphen_values`]: https://docs.rs/clap/latest/clap/struct.Arg.html#method.allow_hyphen_values

- **PHD: add `cargo xtask phd run --no-base-propolis`** (f6913ca4e522b778352c395654a296d6d2b7c080)

  Currently, there's no way to *disable* the migration-from-base tests in
  `cargo xtask phd run`, only set where the base Propolis artifact comes
  from. This branch adds a `--no-base-propolis` flag to `cargo xtask phd
  run` so that migration-from-base tests can be skipped entirely, the way
  they can with a raw `phd-runner` invocation.

- **PHD: allow overriding base commit with `xtask phd`** (03a64f6b8e435f9a3a37cb8dd1aaf36a306d01a9)

  Currently, `cargo xtask phd` accepts a custom `--base-propolis-branch`
  argument, and doesn't automatically populate that argument if it's
  provided. However, it doesn't support the `--base-propolis-commit` or
  `--base-propolis-cmd` arguments at all, and if they are present, `cargo
  xtask phd` will still pass `--base-propolis-branch` to `phd-runner`,
  causing a conflict between the `--base-propolis-branch` and
  `--base-propolis-commit`/`--base-propolis-cmd` args. This means that
  it's impossible to use `cargo xtask phd` with an explicit base commit or
  local base binary.

  This commit fixes that, by changing `cargo xtask phd run` to also look
  for those arguments, and skip setting the default
  `--base-propolis-branch` if either are present.

- **PHD: fix `cargo xtask phd list` not doing that** (882a034b158afa765cb33460f98196c1e1fa2081)

  The `cargo xtask phd list` subcommand is currently broken, as it doesn't
  actually pass the `list` subcommand to `phd-runner` --- it just passes
  through any trailing args. So, running `cargo xtask phd list` gets you

  ```console
  $ cargo xtask phd list
     Compiling phd-runner
      Finished phd-runner dev [unoptimized + debuginfo] in 19.78s
       Running target/x86_64-unknown-illumos/debug/phd-runner
  Runtime configuration options for the runner.

  Usage: phd-runner [OPTIONS] <COMMAND>

  Commands:
    run
    list
    help  Print this message or the help of the given subcommand(s)

  Options:
        --disable-ansi  Suppress emission of terminal control codes in the runner's log output
        --emit-bunyan   Emit Bunyan-formatted logs
    -h, --help          Print help
  ```

  rather than actually listing tests.

  This commit fixes that by actually passing the `list` subcommand to
  `phd-runner` before any trailing args. Now, it works:

  ```console
  $ cargo xtask phd list
      Compiling phd-runner
      Finished phd-runner dev [unoptimized + debuginfo] in 0.44s
       Running target/x86_64-unknown-illumos/debug/phd-runner list
  2024-02-14T20:47:45.015748Z  INFO phd_runner: 35: runner_args=ProcessArgs { command: List(ListOptions { include_filter: [], exclude_filter: [] }), disable_ansi: false, em it_bunyan: false }
  Tests enabled after applying filters:

      phd_tests::smoke::instance_spec_get_test
      phd_tests::smoke::nproc_test
      phd_tests::migrate::from_base::migration_from_base_and_back
      phd_tests::migrate::from_base::serial_history
      phd_tests::migrate::from_base::can_migrate_from_base
      phd_tests::server_state_machine::instance_reset_requires_running_test
      phd_tests::server_state_machine::instance_reset_test
      phd_tests::server_state_machine::instance_stop_causes_destroy_test
      phd_tests::server_state_machine::instance_start_stop_test
      phd_tests::migrate::running_process::export_failure
      phd_tests::migrate::running_process::import_failure
      phd_tests::migrate::running_process::migrate_running_process
      phd_tests::hw::lspci_lifecycle_test
      phd_tests::framework::multiline_serial_test
      phd_tests::crucible::migrate::load_test
      phd_tests::crucible::migrate::smoke_test
      phd_tests::crucible::smoke::shutdown_persistence_test
      phd_tests::crucible::smoke::boot_test
      phd_tests::migrate::multiple_migrations
      phd_tests::migrate::incompatible_vms
      phd_tests::migrate::serial_history
      phd_tests::migrate::smoke_test

    22 test(s) selected
   ```

  My bad!