### PR TITLE
PHD: use `clap` for more `cargo xtask phd` args

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,6 +20,7 @@ struct Args {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 enum Cmds {
     /// Run suite of clippy checks
     Clippy {


### PR DESCRIPTION
Currently, `cargo xtask phd` does a bunch of "bash-style" arg parsing, looping over any unrecognized arguments. This was intended as a way of passing through arguments to `phd-runner`. However, because `clap` will stick any unrecognized arguments in `trailing_var_args`, we can just use normal `clap` arg parsing to handle the arguments that we default before passing through to `phd-runner`.

Now, the `cargo xtask phd` command has nicer help text for its overridden arguments, and it can use `clap`'s built-in validation of conflicting arguments. This seems nicer.