### PR TITLE
PHD: add `pfexec` to xtask phd-runner invocation

### DIFF
--- a/xtask/src/task_phd.rs
+++ b/xtask/src/task_phd.rs
@@ -350,7 +350,18 @@ impl Cmd {
         }
 
         let phd_runner = build_bin("phd-runner", false)?;
-        let mut cmd = phd_runner.command();
+        let mut cmd = if cfg!(target_os = "illumos") {
+            let mut cmd = Command::new("pfexec");
+            cmd.arg(phd_runner.path());
+            cmd
+        } else {
+            // If we're not on Illumos, running the tests probably won't
+            // actually work, because there's almost certainly no Bhyve. But,
+            // we'll build and run the command anyway, because being able to run
+            // on other systems may still be useful for PHD development (e.g.
+            // testing changes to artifact management, etc).
+            Command::new(phd_runner.path())
+        };
         cmd.arg("run")
             .arg("--propolis-server-cmd")
             .arg(&propolis_local_path)


### PR DESCRIPTION
Currently, when using `cargo xtask phd run` to run the PHD test suite, ensuring that the runner has the correct permissions requires running `pfexec cargo xtask phd`. This means that the commands run by the xtask to set up the artifact store and temp directories, and to build `phd-runner` and `propolis-server`, are run under the profile specified by `pfexec`, resulting in a bunch of files in the Cargo `target/` directory that the user doesn't actually own. This is annoying if you want to then run `cargo clean` or something.

This commit changes `cargo xtask phd run` to just execute the runner command with `pfexec` when compiled for Illumos. This saves the user from having to type it themself, and (more importantly) means that the binaries aren't built with a different owner than the user who builds them.