### PR TITLE
PHD: improve Windows reliability

### DIFF
--- a/phd-tests/framework/src/guest_os/mod.rs
+++ b/phd-tests/framework/src/guest_os/mod.rs
@@ -30,6 +30,10 @@ pub(super) enum CommandSequenceEntry<'a> {
     /// Tell the serial console task to clear its buffer.
     ClearBuffer,
 
+    /// The command executor (not the serial console task!) should sleep for
+    /// this duration.
+    Sleep(std::time::Duration),
+
     /// Change the serial console buffering discipline to the supplied
     /// discipline.
     ChangeSerialConsoleBuffer(crate::serial::BufferKind),

--- a/phd-tests/framework/src/guest_os/mod.rs
+++ b/phd-tests/framework/src/guest_os/mod.rs
@@ -27,12 +27,17 @@ pub(super) enum CommandSequenceEntry<'a> {
     /// Write the specified string as a command to the guest serial console.
     WriteStr(Cow<'a, str>),
 
+    /// Attempt to establish consistent echoing of characters to the guest
+    /// serial console by typing `send` and then waiting for `expect` to appear
+    /// within the supplied `timeout`.
+    EstablishConsistentEcho {
+        send: Cow<'a, str>,
+        expect: Cow<'a, str>,
+        timeout: std::time::Duration,
+    },
+
     /// Tell the serial console task to clear its buffer.
     ClearBuffer,
-
-    /// The command executor (not the serial console task!) should sleep for
-    /// this duration.
-    Sleep(std::time::Duration),
 
     /// Change the serial console buffering discipline to the supplied
     /// discipline.

--- a/phd-tests/framework/src/guest_os/windows.rs
+++ b/phd-tests/framework/src/guest_os/windows.rs
@@ -69,7 +69,7 @@ pub(super) fn get_login_sequence_for<'a>(
             // it only applies when typing the same character multiple times in
             // a row.
             CommandSequenceEntry::SetRepeatedCharacterDebounce(
-                std::time::Duration::from_secs(1),
+                std::time::Duration::from_millis(1500),
             ),
         ]);
     }

--- a/phd-tests/framework/src/guest_os/windows_server_2016.rs
+++ b/phd-tests/framework/src/guest_os/windows_server_2016.rs
@@ -11,7 +11,10 @@
 
 use std::borrow::Cow;
 
-use super::{CommandSequence, GuestOs, GuestOsKind};
+use super::{
+    windows::prepend_reset_to_shell_command, CommandSequence, GuestOs,
+    GuestOsKind,
+};
 
 /// The guest adapter for Windows Server 2016 images. See [the general
 /// Windows module](mod@super::windows) documentation for more information about
@@ -32,13 +35,8 @@ impl GuestOs for WindowsServer2016 {
     }
 
     fn shell_command_sequence<'a>(&self, cmd: &'a str) -> CommandSequence<'a> {
-        // `reset` the command prompt before issuing the command to try to force
-        // Windows to redraw the subsequent command prompt. Without this,
-        // Windows may not draw the prompt if the post-command state happens to
-        // place a prompt at a location that already had one pre-command.
-        let cmd = format!("reset && {cmd}");
         super::shell_commands::shell_command_sequence(
-            Cow::Owned(cmd),
+            Cow::Owned(prepend_reset_to_shell_command(cmd)),
             crate::serial::BufferKind::Vt80x24,
         )
     }

--- a/phd-tests/framework/src/guest_os/windows_server_2016.rs
+++ b/phd-tests/framework/src/guest_os/windows_server_2016.rs
@@ -24,7 +24,7 @@ impl GuestOs for WindowsServer2016 {
     }
 
     fn get_shell_prompt(&self) -> &'static str {
-        "Administrator@PHD-WINDOWS:$ "
+        "$ "
     }
 
     fn read_only_fs(&self) -> bool {

--- a/phd-tests/framework/src/guest_os/windows_server_2019.rs
+++ b/phd-tests/framework/src/guest_os/windows_server_2019.rs
@@ -20,7 +20,7 @@ impl GuestOs for WindowsServer2019 {
     }
 
     fn get_shell_prompt(&self) -> &'static str {
-        "Administrator@PHD-WINDOWS:$ "
+        "$ "
     }
 
     fn read_only_fs(&self) -> bool {

--- a/phd-tests/framework/src/guest_os/windows_server_2019.rs
+++ b/phd-tests/framework/src/guest_os/windows_server_2019.rs
@@ -28,13 +28,8 @@ impl GuestOs for WindowsServer2019 {
     }
 
     fn shell_command_sequence<'a>(&self, cmd: &'a str) -> CommandSequence<'a> {
-        // `reset` the command prompt before issuing the command to try to force
-        // Windows to redraw the subsequent command prompt. Without this,
-        // Windows may not draw the prompt if the post-command state happens to
-        // place a prompt at a location that already had one pre-command.
-        let cmd = format!("reset && {cmd}");
         super::shell_commands::shell_command_sequence(
-            Cow::Owned(cmd),
+            Cow::Owned(prepend_reset_to_shell_command(cmd)),
             crate::serial::BufferKind::Vt80x24,
         )
     }

--- a/phd-tests/framework/src/guest_os/windows_server_2019.rs
+++ b/phd-tests/framework/src/guest_os/windows_server_2019.rs
@@ -7,7 +7,10 @@
 
 use std::borrow::Cow;
 
-use super::{CommandSequence, GuestOs, GuestOsKind};
+use super::{
+    windows::prepend_reset_to_shell_command, CommandSequence, GuestOs,
+    GuestOsKind,
+};
 
 /// The guest adapter for Windows Server 2019 images. See [the general
 /// Windows module](mod@super::windows) documentation for more information about

--- a/phd-tests/framework/src/guest_os/windows_server_2022.rs
+++ b/phd-tests/framework/src/guest_os/windows_server_2022.rs
@@ -18,7 +18,7 @@ impl GuestOs for WindowsServer2022 {
     }
 
     fn get_shell_prompt(&self) -> &'static str {
-        "Administrator@PHD-WINDOWS:$ "
+        "$ "
     }
 
     fn read_only_fs(&self) -> bool {

--- a/phd-tests/framework/src/serial/raw_buffer.rs
+++ b/phd-tests/framework/src/serial/raw_buffer.rs
@@ -123,11 +123,7 @@ impl Buffer for RawBuffer {
                     self.push_character('\n');
                 }
                 Action::CSI(CSI::Cursor(Right(n))) => {
-                    self.push_str(
-                        &std::iter::repeat(" ")
-                            .take(n as usize)
-                            .collect::<String>(),
-                    );
+                    self.push_str(&" ".repeat(n as usize));
                 }
                 _ => {
                     trace!(?action, "raw buffer ignored action");

--- a/phd-tests/framework/src/serial/vt80x24.rs
+++ b/phd-tests/framework/src/serial/vt80x24.rs
@@ -13,6 +13,8 @@ use termwiz::{
 };
 use tracing::trace;
 
+const SURFACE_ROWS: usize = 24;
+
 use super::{Buffer, OutputWaiter};
 
 /// Simulates a VT100-compatible 80-by-24 terminal to buffer console output from
@@ -129,9 +131,11 @@ impl Buffer for Vt80x24 {
     }
 
     fn clear(&mut self) {
-        let seq = self
-            .surface
-            .add_change(Change::ClearScreen(ColorAttribute::Default));
+        let cursor_pos = self.surface.cursor_position();
+        let seq = self.surface.add_changes(vec![
+            Change::ClearScreen(ColorAttribute::Default),
+            make_absolute_cursor_position(cursor_pos.0, cursor_pos.1),
+        ]);
         self.surface.flush_changes_older_than(seq);
     }
 
@@ -154,12 +158,12 @@ fn make_absolute_cursor_position(col: usize, row: usize) -> Change {
 }
 
 fn trace_buffer_contents(contents: &str) {
-    let mut last_non_empty = None;
-    for (idx, line) in contents.lines().enumerate() {
-        if line.chars().any(|c| c != ' ') {
-            last_non_empty = Some(idx);
-        }
-    }
+    // Find the index of the last line in the buffer that isn't blank.
+    let last_non_empty = contents
+        .lines()
+        .rev()
+        .position(|l| l.chars().any(|c| c != ' '))
+        .map(|pos| SURFACE_ROWS - pos - 1);
 
     if let Some(last_non_empty) = last_non_empty {
         for (idx, line) in contents.lines().enumerate() {

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -773,7 +773,7 @@ impl TestVm {
             self.wait_for_serial_output(expect, expect_timeout)
                 .await
                 .map(|_| ())
-                .map_err(|e| backoff::Error::transient(e))
+                .map_err(backoff::Error::transient)
         };
 
         backoff::future::retry(

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -659,8 +659,18 @@ impl TestVm {
                         self.send_serial_str(s.as_ref()).await?;
                         self.send_serial_str("\n").await?;
                     }
-                    CommandSequenceEntry::Sleep(duration) => {
-                        tokio::time::sleep(duration).await;
+                    CommandSequenceEntry::EstablishConsistentEcho {
+                        send,
+                        expect,
+                        timeout,
+                    } => {
+                        self.establish_serial_console_echo(
+                            send.as_ref(),
+                            expect.as_ref(),
+                            timeout,
+                            SerialOutputTimeout::CallerTimeout,
+                        )
+                        .await?;
                     }
                     CommandSequenceEntry::ClearBuffer => {
                         self.clear_serial_buffer()?
@@ -732,6 +742,53 @@ impl TestVm {
         received?.ok_or_else(|| {
             anyhow!("wait_for_serial_output recv channel unexpectedly closed")
         })
+    }
+
+    /// Attempts to establish that the guest serial console consistently echoes
+    /// characters by writing `send` and waiting for `expect` to appear within
+    /// the supplied `timeout`.
+    ///
+    /// This function will back off between attempts to send and await
+    /// characters (but will *not* change the delay used to wait for characters
+    /// to be echoed) and will retry for up to the duration specified by
+    /// `overall_timeout`.
+    async fn establish_serial_console_echo(
+        &self,
+        send: &str,
+        expect: &str,
+        expect_timeout: std::time::Duration,
+        overall_timeout: impl Into<SerialOutputTimeout>,
+    ) -> Result<()> {
+        let overall_timeout: SerialOutputTimeout = overall_timeout.into();
+        info!(
+            send,
+            expect,
+            ?expect_timeout,
+            ?overall_timeout,
+            "establishing serial console echo"
+        );
+
+        let send_and_expect = || async {
+            self.send_serial_str(send).await?;
+            self.wait_for_serial_output(expect, expect_timeout)
+                .await
+                .map(|_| ())
+                .map_err(|e| backoff::Error::transient(e))
+        };
+
+        backoff::future::retry(
+            backoff::ExponentialBackoff {
+                max_elapsed_time: match overall_timeout {
+                    SerialOutputTimeout::Explicit(d) => Some(d),
+                    SerialOutputTimeout::CallerTimeout => None,
+                },
+                ..Default::default()
+            },
+            send_and_expect,
+        )
+        .await?;
+
+        Ok(())
     }
 
     /// Runs the shell command `cmd` by sending it to the serial console, then

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -659,6 +659,9 @@ impl TestVm {
                         self.send_serial_str(s.as_ref()).await?;
                         self.send_serial_str("\n").await?;
                     }
+                    CommandSequenceEntry::Sleep(duration) => {
+                        tokio::time::sleep(duration).await;
+                    }
                     CommandSequenceEntry::ClearBuffer => {
                         self.clear_serial_buffer()?
                     }


### PR DESCRIPTION
Tweak a handful of things to make Windows tests more (though not perfectly) reliable:

- Explicitly sleep between the time the first `C:\Windows\System32>` prompt is displayed and the time the next command is issued. This appears to reduce the chance that the first command's keystrokes will be eaten.
- On Windows Server 2022, use the `mode` command to set the console session's row/column count explicitly before launching Cygwin. This avoids a problem where Cygwin thought it was on a 30-column terminal and was wrapping lines unexpectedly.
- Shorten the Cygwin prompt from `Administrator@PHD-WINDOWS:$ ` to just `$ `. The test doesn't need the user/host name cue and this reduces the likelihood of a line wrapping unexpectedly on WS2016/2019.
- Handle the "cursor right" control code in the raw serial console buffer, since WS2022 uses it sometimes.
- Add a tracing affordance to the Vt80x24 buffer that prints the current screen contents line-by-line, ignoring blank lines at the end of the output. This makes the terminal contents much easier to read during debugging.
- Bump the repeated character debounce up *again* to try to cut down on 2016/2019 flakiness. In the long run I think it'll make sense to experiment with totally different approaches to this problem. For example, I wonder if things would work better if the serial task waited for individual typed characters to be echoed before sending a subsequent character, but I think doing that will require the serial task and the buffer trait to be restructured somewhat.

Tested with WS2022, WS2019, and Debian 11 guests.