### PR TITLE
nvme: Expose MDTS value with basic logic

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -540,8 +540,11 @@ impl<'a> MachineInitializer<'a> {
                     chipset.pci_attach(bdf, vioblk);
                 }
                 DeviceInterface::Nvme => {
+                    // Limit data transfers to 1MiB (2^8 * 4k) in size
+                    let mdts = Some(8);
                     let nvme = nvme::PciNvme::create(
                         name.to_string(),
+                        mdts,
                         self.log.new(
                             slog::o!("component" => format!("nvme-{}", name)),
                         ),

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -990,7 +990,9 @@ fn setup_instance(
                         .to_string();
                     let log =
                         log.new(slog::o!("dev" => format!("nvme-{}", name)));
-                    let nvme = hw::nvme::PciNvme::create(dev_serial, log);
+                    // Limit data transfers to 1MiB (2^8 * 4k) in size
+                    let mdts = Some(8);
+                    let nvme = hw::nvme::PciNvme::create(dev_serial, mdts, log);
 
                     guard.inventory.register_instance(&nvme, &bdf.to_string());
                     guard.inventory.register_block(&backend, name);

--- a/lib/propolis/src/hw/nvme/bits.rs
+++ b/lib/propolis/src/hw/nvme/bits.rs
@@ -252,6 +252,12 @@ bitstruct! {
         reserved4: u8 = 56..64;
     }
 }
+impl Capabilities {
+    /// Size in bytes represented by the MPSMIN value
+    pub fn mpsmin_sz(&self) -> usize {
+        1 << (12 + self.mpsmin())
+    }
+}
 
 bitstruct! {
     /// Representation of the Controller Configuration (CC) register.


### PR DESCRIPTION
While the interaction between the block backends and frontends like NVMe could be improved to include negotiation of parameters such as MDTS, it would be nice to define a reasonable value in the mean time.