### PR TITLE
Bump crucible and update APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/mkeeter/crucible?branch=packed-data#22d96989d9728e32b02566c06fcc9ab4c5ab95ce"
+source = "git+https://github.com/oxidecomputer/crucible?rev=952c7d60d22be5198b892bec8d92f4291b9160c2#952c7d60d22be5198b892bec8d92f4291b9160c2"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/mkeeter/crucible?branch=packed-data#22d96989d9728e32b02566c06fcc9ab4c5ab95ce"
+source = "git+https://github.com/oxidecomputer/crucible?rev=952c7d60d22be5198b892bec8d92f4291b9160c2#952c7d60d22be5198b892bec8d92f4291b9160c2"
 dependencies = [
  "base64 0.21.7",
  "crucible-workspace-hack",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/mkeeter/crucible?branch=packed-data#22d96989d9728e32b02566c06fcc9ab4c5ab95ce"
+source = "git+https://github.com/oxidecomputer/crucible?rev=952c7d60d22be5198b892bec8d92f4291b9160c2#952c7d60d22be5198b892bec8d92f4291b9160c2"
 dependencies = [
  "anyhow",
  "atty",
@@ -820,6 +820,7 @@ dependencies = [
  "slog-term",
  "tempfile",
  "thiserror",
+ "tokio",
  "tokio-rustls 0.24.1",
  "toml 0.8.10",
  "twox-hash",
@@ -830,7 +831,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/mkeeter/crucible?branch=packed-data#22d96989d9728e32b02566c06fcc9ab4c5ab95ce"
+source = "git+https://github.com/oxidecomputer/crucible?rev=952c7d60d22be5198b892bec8d92f4291b9160c2#952c7d60d22be5198b892bec8d92f4291b9160c2"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=1c1574fb721f98f2df1b23e3fd27d83be018882e#1c1574fb721f98f2df1b23e3fd27d83be018882e"
+source = "git+https://github.com/mkeeter/crucible?branch=packed-data#22d96989d9728e32b02566c06fcc9ab4c5ab95ce"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=1c1574fb721f98f2df1b23e3fd27d83be018882e#1c1574fb721f98f2df1b23e3fd27d83be018882e"
+source = "git+https://github.com/mkeeter/crucible?branch=packed-data#22d96989d9728e32b02566c06fcc9ab4c5ab95ce"
 dependencies = [
  "base64 0.21.7",
  "crucible-workspace-hack",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=1c1574fb721f98f2df1b23e3fd27d83be018882e#1c1574fb721f98f2df1b23e3fd27d83be018882e"
+source = "git+https://github.com/mkeeter/crucible?branch=packed-data#22d96989d9728e32b02566c06fcc9ab4c5ab95ce"
 dependencies = [
  "anyhow",
  "atty",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=1c1574fb721f98f2df1b23e3fd27d83be018882e#1c1574fb721f98f2df1b23e3fd27d83be018882e"
+source = "git+https://github.com/mkeeter/crucible?branch=packed-data#22d96989d9728e32b02566c06fcc9ab4c5ab95ce"
 dependencies = [
  "anyhow",
  "bincode",
@@ -841,6 +841,7 @@ dependencies = [
  "schemars",
  "serde",
  "strum_macros 0.25.3",
+ "tokio",
  "tokio-util",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,8 @@ oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch =
 oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 
 # Crucible
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "1c1574fb721f98f2df1b23e3fd27d83be018882e" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "1c1574fb721f98f2df1b23e3fd27d83be018882e" }
+crucible = { git = "https://github.com/mkeeter/crucible", branch = "packed-data" }
+crucible-client-types = { git = "https://github.com/mkeeter/crucible", branch = "packed-data" }
 
 # External dependencies
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,8 @@ oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch =
 oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 
 # Crucible
-crucible = { git = "https://github.com/mkeeter/crucible", branch = "packed-data" }
-crucible-client-types = { git = "https://github.com/mkeeter/crucible", branch = "packed-data" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "952c7d60d22be5198b892bec8d92f4291b9160c2" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "952c7d60d22be5198b892bec8d92f4291b9160c2" }
 
 # External dependencies
 anyhow = "1.0"


### PR DESCRIPTION
This bumps Crucible to the latest `main`.  https://github.com/oxidecomputer/crucible/pull/1206 makes some changes to the `BlockIO::write` API, so it requires minor updates to Propolis as well.