### PR TITLE
Attempt to set WCE for raw file backends

### DIFF
--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -882,6 +882,12 @@ impl Drop for VmController {
         let hdl = machine.destroy();
         let _ = hdl.destroy();
 
+        // Detach block backends so they can do any final clean-up
+        debug!(self.log, "Detaching block backends");
+        for backend in self.vm_objects.block_backends.values() {
+            let _ = backend.attachment().detach();
+        }
+
         // A fully-initialized controller is kept alive in part by its worker
         // thread, which owns the sender side of the controller's state-change
         // notification channel. Since the controller is being dropped, the

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -224,6 +224,16 @@ impl Inventory {
     ) {
         self.block.insert(name, be.clone());
     }
+    fn destroy(&mut self) {
+        // Detach all block backends from their devices
+        for backend in self.block.values() {
+            let _ = backend.attachment().detach();
+        }
+
+        // Drop all refs in the hopes that things can clean up after themselves
+        self.devs.clear();
+        self.block.clear();
+    }
 }
 
 struct InstState {
@@ -479,6 +489,9 @@ impl Instance {
                 State::Destroy => {
                     // Drop the machine
                     let _ = guard.machine.take().unwrap();
+
+                    // Clean up the inventory as well
+                    guard.inventory.destroy();
 
                     // Communicate that destruction is complete
                     slog::info!(&log, "Instance destroyed");

--- a/lib/propolis/src/util/mod.rs
+++ b/lib/propolis/src/util/mod.rs
@@ -4,3 +4,22 @@
 
 pub mod aspace;
 pub mod regmap;
+
+mod ioctl {
+    use std::io::{Error, Result};
+    use std::os::fd::RawFd;
+    use std::os::raw::c_void;
+
+    pub(crate) unsafe fn ioctl(
+        fd: RawFd,
+        cmd: i32,
+        data: *mut c_void,
+    ) -> Result<i32> {
+        // Paper over differing type for request parameter
+        match libc::ioctl(fd, cmd as _, data) {
+            -1 => Err(Error::last_os_error()),
+            res => Ok(res),
+        }
+    }
+}
+pub(crate) use ioctl::ioctl;


### PR DESCRIPTION
When the file-based block backend is running atop a zvol, it will default to synchronous writes unless otherwise toggled by DKIOCSETWCE. Since the backend is already minding flush requests via fsync(), we should enable the write cache on the device for a significant performance gain.