### PR TITLE
Add `IntrPin::import_state` and migrate LPC UART pin states

### DIFF
--- a/lib/propolis/src/hw/chipset/i440fx.rs
+++ b/lib/propolis/src/hw/chipset/i440fx.rs
@@ -88,6 +88,13 @@ impl IntrPin for LNKPin {
         let inner = self.inner.lock().unwrap();
         inner.asserted
     }
+    fn import_state(&self, is_asserted: bool) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.asserted = is_asserted;
+        if let Some(pin) = inner.pin.as_ref() {
+            pin.import_state(is_asserted);
+        }
+    }
 }
 
 struct IrqConfig {

--- a/lib/propolis/src/hw/uart/lpc.rs
+++ b/lib/propolis/src/hw/uart/lpc.rs
@@ -189,6 +189,8 @@ impl MigrateSingle for LpcUart {
     ) -> Result<(), MigrateStateError> {
         let data = offer.parse::<migrate::Uart16550V1>()?;
         let mut state = self.state.lock().unwrap();
-        state.uart.import(&data)
+        state.uart.import(&data)?;
+        state.irq_pin.import_state(state.uart.intr_state());
+        Ok(())
     }
 }

--- a/lib/propolis/src/intr_pins.rs
+++ b/lib/propolis/src/intr_pins.rs
@@ -28,7 +28,9 @@ pub trait IntrPin: Send + Sync + 'static {
         }
     }
 
-    /// Set the state of this interrupt pin when importing a guest.
+    /// Set the state of this interrupt pin *without* treating the state change
+    /// as an edge in the interrupt line. Used when importing a guest.
+    ///
     /// This method differs from [`IntrPin::set_state`], as it updates the
     /// internal accounting of the pin's state *without* notifying consumers of
     /// the interrupt pin of a rising/falling edge. This is because it's called

--- a/lib/propolis/src/intr_pins.rs
+++ b/lib/propolis/src/intr_pins.rs
@@ -32,7 +32,7 @@ pub trait IntrPin: Send + Sync + 'static {
     /// as an edge in the interrupt line. Used when importing a guest.
     ///
     /// This method differs from [`IntrPin::set_state`], as it updates the
-    /// internal accounting of the pin's state *without* notifying consumers of
+    /// internal accounting of the pin's state without notifying consumers of
     /// the interrupt pin of a rising/falling edge. This is because it's called
     /// during an import of a guest from a different VMM, which has *already*
     /// observed the edge event; this VMM is just updating its internal state to


### PR DESCRIPTION
Currently, interrupt pin state for userspace-emulated devices, like the
LPC UART, is accounted for both by the kernel in Bhyve and userspace in
Propolis. When userspace wishes to assert an IRQ for such a device, it
records the assertion of the IRQ line in userspace and then calls the
`ioctl` that asserts the IRQ in kernelspace.  However, when such devices
are _migrated_, only the kernelspace Bhyve state is migrated, and any
userspace-tracked pin assertion counts are not. This means that these
states may become out of sync during a migration, potentially resulting
in a lost interrupt.

This branch introduces a mechanism for migrating userspace's
understanding of pin counts, in addition to migrating kernelspace's.
Because incrementing the userspace-tracked pin counts through the
`IntrPin::assert` or `IntrPin::set_state` methods may generate an
`ioctl` that changes the kernelspace state of that interrupt pin, we
cannot just call those methods while importing userspace pin assertion
counts. Instead, I've introduced a new `import_state` method to the
`IntrPin` trait, which is intended to be called only during imports.
This method sets the userspace-tracked pin state, the same as
`set_state`, but will *not* perform an `ioctl` call. This way, we can
import the userspace state independently of the kernelspace state,
without triggering additional interrupts that don't actually exist. I've
modified the LPC UART to use this new mechanism.

I've manually tested this change by running a migration between two lab
machines while mashing keys into the serial console, and the console
does not appear to get stuck.