### PR TITLE
Make block attachment mechanism more generic

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -546,7 +546,7 @@ impl<'a> MachineInitializer<'a> {
 
                     self.devices
                         .insert(format!("pci-virtio-{}", bdf), vioblk.clone());
-                    block::attach(backend, vioblk.clone());
+                    block::attach(vioblk.clone(), backend).unwrap();
                     chipset.pci_attach(bdf, vioblk);
                 }
                 DeviceInterface::Nvme => {
@@ -561,7 +561,7 @@ impl<'a> MachineInitializer<'a> {
                     );
                     self.devices
                         .insert(format!("pci-nvme-{bdf}"), nvme.clone());
-                    block::attach(backend, nvme.clone());
+                    block::attach(nvme.clone(), backend).unwrap();
                     chipset.pci_attach(bdf, nvme);
                 }
             };

--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -1094,8 +1094,14 @@ impl StateDriverVmController for VmController {
             dev.halt();
         });
         for (name, backend) in self.vm_objects.block_backends.iter() {
-            debug!(self.log, "Halting block backend {}", name);
-            backend.halt();
+            debug!(self.log, "Stopping and detaching block backend {}", name);
+            backend.stop();
+            if let Err(err) = backend.detach() {
+                error!(
+                    self.log,
+                    "Error while detaching block backend {name}: {err:?}",
+                );
+            }
         }
     }
 

--- a/lib/propolis/src/attachment.rs
+++ b/lib/propolis/src/attachment.rs
@@ -1,0 +1,279 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Frontend (emulated device) attachment point
+pub struct FrontAttachment<T>(Mutex<AttachPoint<T>>);
+impl<T> FrontAttachment<T> {
+    pub fn new() -> Self {
+        Self(Mutex::new(AttachPoint::default()))
+    }
+    pub fn access<R>(
+        &self,
+        when_attached: impl FnOnce(&T, &AttachState) -> R,
+    ) -> Option<R> {
+        self.0.lock().unwrap().access_fallback(when_attached, |_state| ())
+    }
+    pub fn access_fallback<R>(
+        &self,
+        when_attached: impl FnOnce(&T, &AttachState) -> R,
+        fallback: impl FnOnce(&AttachState) -> (),
+    ) -> Option<R> {
+        self.0.lock().unwrap().access_fallback(when_attached, fallback)
+    }
+}
+
+/// Backend (resource provider) attachment point
+pub struct BackAttachment<T>(Mutex<AttachPoint<T>>);
+impl<T> BackAttachment<T> {
+    pub fn new() -> Self {
+        Self(Mutex::new(AttachPoint::default()))
+    }
+    pub fn access<R>(
+        &self,
+        when_attached: impl FnOnce(&T, &AttachState) -> R,
+    ) -> Option<R> {
+        self.0.lock().unwrap().access_fallback(when_attached, |_state| ())
+    }
+    pub fn access_fallback<R>(
+        &self,
+        when_attached: impl FnOnce(&T, &AttachState) -> R,
+        fallback: impl FnOnce(&AttachState) -> (),
+    ) -> Option<R> {
+        self.0.lock().unwrap().access_fallback(when_attached, fallback)
+    }
+}
+
+enum AttachPoint<T> {
+    Attached(Arc<(AttachState, T)>),
+    Detached(AttachState),
+}
+impl<T> Default for AttachPoint<T> {
+    fn default() -> Self {
+        Self::Detached(AttachState::new())
+    }
+}
+impl<T> AttachPoint<T> {
+    fn access_fallback<R>(
+        &self,
+        when_attached: impl FnOnce(&T, &AttachState) -> R,
+        fallback: impl FnOnce(&AttachState) -> (),
+    ) -> Option<R> {
+        match self {
+            AttachPoint::Attached(data) => {
+                Some(when_attached(&data.1, &data.0))
+            }
+            AttachPoint::Detached(state) => {
+                fallback(state);
+                None
+            }
+        }
+    }
+}
+
+/// State of an Attachment ([FrontAttachment] or [BackAttachment])
+#[derive(Clone)]
+pub struct AttachState(Arc<AttachStateInner>);
+impl AttachState {
+    /// Is this Attachment attached to a corresponding peer?
+    ///
+    /// Because the [AttachState] can be cloned to outlive its initial access
+    /// via [FrontAttachment::access] or [BackAttachment::access], the ability
+    /// to check attachedness remains relevant.
+    pub fn is_attached(&self) -> bool {
+        self.0.is_attached.load(Ordering::Acquire)
+    }
+    /// Is the Attachment frontend paused?
+    pub fn is_paused(&self) -> bool {
+        self.0.is_paused.load(Ordering::Acquire)
+    }
+    /// Is the Attachmend backend stopped (from processing additional requests)
+    pub fn is_stopped(&self) -> bool {
+        self.0.is_stopped.load(Ordering::Acquire)
+    }
+    /// Notify waiters of event (either attachment state change, or of
+    /// attachment-specific events, such as new pending requests)
+    pub fn notify(&self) {
+        self.0.notify.notify_waiters()
+    }
+    /// Wait for notification relating to Attachment
+    pub fn notified(&self) -> tokio::sync::futures::Notified<'_> {
+        self.0.notify.notified()
+    }
+    /// Mark Attachment frontend as paused
+    pub fn pause(&self) {
+        if !self.0.is_paused.swap(true, Ordering::Release) {
+            self.0.notify.notify_waiters();
+        }
+    }
+    /// Mark Attachment frontend as resumed (no longer paused)
+    pub fn resume(&self) {
+        if self.0.is_paused.swap(false, Ordering::Release) {
+            self.0.notify.notify_waiters();
+        }
+    }
+    /// Mark Attachment backend as stopped
+    pub fn stop(&self) {
+        if !self.0.is_stopped.swap(true, Ordering::Release) {
+            self.0.notify.notify_waiters();
+        }
+    }
+    /// Mark Attachment backend as started (no longer stopped)
+    pub fn start(&self) {
+        if self.0.is_stopped.swap(false, Ordering::Release) {
+            self.0.notify.notify_waiters();
+        }
+    }
+
+    fn new() -> Self {
+        Self(Arc::new(AttachStateInner::default()))
+    }
+    fn merge(front: &Self, back: &Self) -> Self {
+        // Because `is_paused` state is a property of the frontend (suspending
+        // emission of requests to be processed by backend) and `is_stopped`
+        // state is a property of the backend (stopping workers, so none are
+        // attempting to process requests from frontend), we use those bits of
+        // state from their respective "owners".
+        Self(Arc::new(AttachStateInner {
+            is_attached: AtomicBool::new(false),
+            is_paused: AtomicBool::new(front.is_paused()),
+            is_stopped: AtomicBool::new(back.is_stopped()),
+            ..Default::default()
+        }))
+    }
+    fn split(&self) -> (Self, Self) {
+        (
+            Self(Arc::new(AttachStateInner {
+                is_paused: AtomicBool::new(self.is_paused()),
+                ..Default::default()
+            })),
+            Self(Arc::new(AttachStateInner {
+                is_stopped: AtomicBool::new(self.is_stopped()),
+                ..Default::default()
+            })),
+        )
+    }
+
+    fn attach(&self) {
+        let prev = self.0.is_attached.swap(true, Ordering::Release);
+        self.0.notify.notify_waiters();
+        assert!(!prev, "AttachState was not 'detached' during attach()");
+    }
+    fn detach(&self) {
+        let prev = self.0.is_attached.swap(false, Ordering::Release);
+        self.0.notify.notify_waiters();
+        assert!(prev, "AttachState was not 'attached' during detach()");
+    }
+}
+struct AttachStateInner {
+    is_attached: AtomicBool,
+    is_paused: AtomicBool,
+    is_stopped: AtomicBool,
+    notify: tokio::sync::Notify,
+}
+impl Default for AttachStateInner {
+    fn default() -> Self {
+        Self {
+            is_attached: AtomicBool::new(false),
+            is_paused: AtomicBool::new(false),
+            is_stopped: AtomicBool::new(true),
+            notify: tokio::sync::Notify::new(),
+        }
+    }
+}
+
+/// Errors possible during attempted [attach] call
+#[derive(thiserror::Error, Debug)]
+pub enum AttachError {
+    #[error("frontend is already attached")]
+    FrontAttached,
+    #[error("backend is already attached")]
+    BackAttached,
+}
+
+/// Attempt to attach `front_attach` and `back_attach`.
+///
+/// If neither are already attached to another instance, they'll be attached
+/// together and the `on_attach` handler run against a reference of the provided
+/// `data` once the attachment has been made.
+pub fn attach<T>(
+    data: T,
+    front_attach: &FrontAttachment<T>,
+    back_attach: &BackAttachment<T>,
+    on_attach: impl FnOnce(&T),
+) -> Result<(), AttachError> {
+    let mut front_lock = front_attach.0.lock().unwrap();
+    let mut back_lock = back_attach.0.lock().unwrap();
+
+    let att_state = match (&*front_lock, &*back_lock) {
+        (
+            AttachPoint::Detached(front_state),
+            AttachPoint::Detached(back_state),
+        ) => Ok(AttachState::merge(front_state, back_state)),
+        (AttachPoint::Attached(..), _) => Err(AttachError::FrontAttached),
+        (_, AttachPoint::Attached(..)) => Err(AttachError::BackAttached),
+    }?;
+
+    let att_data = Arc::new((att_state, data));
+    *front_lock = AttachPoint::Attached(att_data.clone());
+    *back_lock = AttachPoint::Attached(att_data.clone());
+
+    att_data.0.attach();
+    on_attach(&att_data.1);
+
+    Ok(())
+}
+
+/// Errors possible during attempted [detach] call
+#[derive(thiserror::Error, Debug)]
+pub enum DetachError {
+    #[error("frontend is not attached")]
+    FrontNotAttached,
+    #[error("backend is not attached")]
+    BackNotAttached,
+    #[error("frontend and backend are not attached to each other")]
+    AttachmentMismatch,
+    #[error("detach handler failed")]
+    DetachFailed,
+}
+
+/// Attempt to detach `front_attach` from `back_attach`.
+///
+/// If those attachment points are indeed attached to each other, the
+/// `on_detach` handler will be run, and if it does not yield an error, the
+/// detach operation will complete successfully.
+pub fn detach<T>(
+    front_attach: &FrontAttachment<T>,
+    back_attach: &BackAttachment<T>,
+    on_detach: impl FnOnce(&T, &AttachState) -> Result<(), ()>,
+) -> Result<(), DetachError> {
+    let mut front_lock = front_attach.0.lock().unwrap();
+    let mut back_lock = back_attach.0.lock().unwrap();
+
+    let data = match (&*front_lock, &*back_lock) {
+        (
+            AttachPoint::Attached(front_data),
+            AttachPoint::Attached(back_data),
+        ) => {
+            if !Arc::ptr_eq(front_data, back_data) {
+                Err(DetachError::AttachmentMismatch)
+            } else {
+                Ok(front_data.clone())
+            }
+        }
+        (AttachPoint::Detached(..), _) => Err(DetachError::FrontNotAttached),
+        (_, AttachPoint::Detached(..)) => Err(DetachError::BackNotAttached),
+    }?;
+
+    on_detach(&data.1, &data.0).map_err(|_| DetachError::DetachFailed)?;
+    data.0.detach();
+    let (front_state, back_state) = data.0.split();
+
+    *front_lock = AttachPoint::Detached(front_state);
+    *back_lock = AttachPoint::Detached(back_state);
+
+    Ok(())
+}

--- a/lib/propolis/src/block/attachment.rs
+++ b/lib/propolis/src/block/attachment.rs
@@ -1,0 +1,358 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Condvar, Mutex};
+use std::task::{Context, Poll};
+
+use super::{Backend, CacheMode, Device, DeviceInfo, Request};
+use crate::accessors::MemAccessor;
+use crate::attachment;
+
+use pin_project_lite::pin_project;
+use tokio::sync::futures::Notified;
+
+struct BlockData {
+    device: Arc<dyn Device>,
+    backend: Arc<dyn Backend>,
+    acc_mem: MemAccessor,
+    lock: Mutex<()>,
+    cv: Condvar,
+}
+impl BlockData {
+    fn new(device: Arc<dyn Device>, backend: Arc<dyn Backend>) -> Arc<Self> {
+        let acc_mem = device.accessor_mem();
+        Arc::new(Self {
+            device,
+            backend,
+            acc_mem,
+            lock: Mutex::new(()),
+            cv: Condvar::new(),
+        })
+    }
+
+    /// Notify any [blocked](Self::block_for_req()) tasks of a state change.
+    /// This could be a change to the device, to the backend, or simply new
+    /// request(s) available.
+    fn notify(&self) {
+        let _guard = self.lock.lock().unwrap();
+        self.cv.notify_all();
+    }
+
+    fn next_req(
+        &self,
+        att_state: &attachment::AttachState,
+    ) -> Result<Request, ReqError> {
+        check_state(att_state)?;
+        match self.device.next() {
+            Some(req) => Ok(req),
+            None => {
+                check_state(att_state)?;
+                Err(ReqError::NonePending)
+            }
+        }
+    }
+
+    fn block_for_req(
+        &self,
+        att_state: &attachment::AttachState,
+    ) -> Option<Request> {
+        loop {
+            match self.next_req(att_state) {
+                Ok(req) => {
+                    return Some(req);
+                }
+                Err(err) => match err {
+                    ReqError::NonePending | ReqError::Paused => {
+                        let guard = self.lock.lock().unwrap();
+                        // Double-check for attachment-related "error"
+                        // conditions under protection of the lock before
+                        // finally blocking.
+                        if check_state(att_state).is_err() {
+                            return None;
+                        }
+                        let _guard = self.cv.wait(guard).unwrap();
+                        continue;
+                    }
+                    _ => {
+                        return None;
+                    }
+                },
+            }
+        }
+    }
+}
+
+fn check_state(state: &attachment::AttachState) -> Result<(), ReqError> {
+    if !state.is_attached() {
+        Err(ReqError::Detached)
+    } else if state.is_stopped() {
+        Err(ReqError::Stopped)
+    } else if state.is_paused() {
+        Err(ReqError::Paused)
+    } else {
+        Ok(())
+    }
+}
+
+pub struct DeviceAttachment(attachment::FrontAttachment<Arc<BlockData>>);
+impl DeviceAttachment {
+    pub fn new() -> Self {
+        Self(attachment::FrontAttachment::new())
+    }
+
+    /// Query [DeviceInfo] from associated backend (if attached)
+    pub fn info(&self) -> Option<DeviceInfo> {
+        self.0.access(|data, _state| data.backend.info())
+    }
+
+    /// Set cache mode on associated backend
+    ///
+    /// # Warning
+    ///
+    /// This is currently unimplemented!
+    pub fn set_cache_mode(&self, _mode: CacheMode) {
+        todo!("wire up cache mode toggling")
+    }
+
+    /// Notify attached backend of (new) pending requests
+    pub fn notify(&self) {
+        self.0.access(|data, state| {
+            if !state.is_paused() {
+                state.notify();
+                data.notify();
+            }
+        });
+    }
+
+    /// Pause request processing for this device.
+    ///
+    /// Backend (if attached) will not be able to retrieving any requests from
+    /// this device while paused.  The completions for any requests in flight,
+    /// however, will be able to flow through.
+    pub fn pause(&self) {
+        self.0.access_fallback(
+            |data, state| {
+                state.pause();
+                data.notify();
+            },
+            |state| state.pause(),
+        );
+    }
+
+    /// Clear the paused state on this device, allowing the backend (if
+    /// attached) to retrieve requests once again.
+    pub fn resume(&self) {
+        self.0.access_fallback(
+            |data, state| {
+                state.resume();
+                data.notify();
+            },
+            |state| state.resume(),
+        );
+    }
+
+    /// Attempt to detach device from backend
+    pub fn detach(&self) -> Result<(), attachment::DetachError> {
+        if let Some((dev, backend)) = self
+            .0
+            .access(|data, _state| (data.device.clone(), data.backend.clone()))
+        {
+            detach(dev, backend)
+        } else {
+            Err(attachment::DetachError::FrontNotAttached)
+        }
+    }
+}
+
+/// Reason why next request is unavailable from associated device
+pub enum ReqError {
+    /// No request is pending from the device
+    NonePending,
+    /// Processing of requests from the device is paused
+    Paused,
+    /// Backend is not attached to any device
+    Detached,
+    /// Backend is stopping workers
+    Stopped,
+}
+
+pub struct BackendAttachment(attachment::BackAttachment<Arc<BlockData>>);
+impl BackendAttachment {
+    pub fn new() -> Self {
+        Self(attachment::BackAttachment::new())
+    }
+
+    /// Attempt to retrieve the next [Request] from the attached (if any)
+    /// device.
+    ///
+    /// Will return an error if:
+    ///
+    /// - No device is attached
+    /// - The device is paused
+    /// - The backend is stopped
+    /// - No requests are queued in the device
+    pub fn next_req(&self) -> Result<Request, ReqError> {
+        match self.0.access(|data, state| data.next_req(state)) {
+            None => Err(ReqError::Detached),
+            Some(Err(e)) => Err(e),
+            Some(Ok(r)) => Ok(r),
+        }
+    }
+
+    /// Block (synchronously) in order to retrieve the next [Request] from the
+    /// device.  Will return [None] if no device is attached, or the backend
+    /// is stopped, otherwise it will block until a request is available.
+    pub fn block_for_req(&self) -> Option<Request> {
+        match self.0.access(|data, state| {
+            // If we do not immediately get a request, clone the BackendData
+            // so we can do our blocking through that, instead of repeated calls
+            // into BackAttachment::access()
+            data.next_req(state).map_err(|_e| (data.clone(), state.clone()))
+        })? {
+            Ok(req) => Some(req),
+            Err((be, state)) => be.block_for_req(&state),
+        }
+    }
+
+    /// Get a [Waiter], through which one can asynchronously poll for new
+    /// requests via [`Waiter::for_req()`].  Will return [None] if no device
+    /// is attached, or the backend is stopped.
+    pub fn waiter(&self) -> Option<Waiter> {
+        self.0.access(|data, state| Waiter(data.clone(), state.clone()))
+    }
+
+    /// Run provided function against [MemAccessor] for this backend.
+    ///
+    /// Intended to provide caller with means of creating/associated child
+    /// accessors.
+    pub fn accessor_mem<R>(
+        &self,
+        f: impl FnOnce(&MemAccessor) -> R,
+    ) -> Option<R> {
+        self.0.access(|data, _state| f(&data.acc_mem))
+    }
+
+    /// Assert stopped state on this Attachment
+    pub fn stop(&self) {
+        self.0.access_fallback(
+            |data, state| {
+                state.stop();
+                data.notify();
+            },
+            |state| state.stop(),
+        );
+    }
+
+    /// Clear stopped state from this Attachment
+    pub fn start(&self) {
+        self.0.access_fallback(
+            |data, state| {
+                state.start();
+                data.notify();
+            },
+            |state| state.start(),
+        );
+    }
+
+    /// Attempt to detach backend from device
+    pub fn detach(&self) -> Result<(), attachment::DetachError> {
+        if let Some((dev, backend)) = self
+            .0
+            .access(|data, _state| (data.device.clone(), data.backend.clone()))
+        {
+            detach(dev, backend)
+        } else {
+            Err(attachment::DetachError::BackNotAttached)
+        }
+    }
+}
+
+pub struct Waiter(Arc<BlockData>, attachment::AttachState);
+impl Waiter {
+    /// Wait (via a [Future]) to retrieve the next [Request] from the device.
+    pub fn for_req(&self) -> WaitForReq<'_> {
+        WaitForReq { be: &self.0, att_state: &self.1, wait: self.1.notified() }
+    }
+}
+
+pin_project! {
+    /// [Future] returned from [`Waiter::for_req()`]
+    pub struct WaitForReq<'a> {
+        be: &'a BlockData,
+        att_state: &'a attachment::AttachState,
+        #[pin]
+        wait: Notified<'a>
+    }
+}
+impl Future for WaitForReq<'_> {
+    type Output = Option<Request>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+        loop {
+            match this.be.next_req(this.att_state) {
+                Ok(req) => return Poll::Ready(Some(req)),
+                Err(ReqError::NonePending) | Err(ReqError::Paused) => {
+                    if let Poll::Ready(_) =
+                        Notified::poll(this.wait.as_mut(), cx)
+                    {
+                        // The `Notified` future is fused, so we must "refresh"
+                        // prior to any subsequent attempts to poll it after it
+                        // emits `Ready`
+                        this.wait.set(this.att_state.notified());
+
+                        // Take another lap if woken by the notifier to check
+                        // for a pending request
+                        continue;
+                    }
+                    return Poll::Pending;
+                }
+                Err(_) => {
+                    // Let the consumer know that they should bail
+                    return Poll::Ready(None);
+                }
+            }
+        }
+    }
+}
+
+/// Attempt to attach a block [Device] to a block [Backend].
+pub fn attach(
+    device: Arc<dyn Device>,
+    backend: Arc<dyn Backend>,
+) -> Result<(), attachment::AttachError> {
+    attachment::attach(
+        BlockData::new(device.clone(), backend.clone()),
+        &device.attachment().0,
+        &backend.attachment().0,
+        |data| {
+            data.device.on_attach(data.backend.info());
+        },
+    )
+}
+
+fn detach(
+    device: Arc<dyn Device>,
+    backend: Arc<dyn Backend>,
+) -> Result<(), attachment::DetachError> {
+    attachment::detach(
+        &device.attachment().0,
+        &backend.attachment().0,
+        |data, state| {
+            if !state.is_stopped() {
+                // Demand that backend be stopped before detaching.
+                //
+                // Assuming it is otherwise well behaved, such a check should
+                // ensure that it is not holding on any unprocessed requests
+                // from the device.
+                Err(())
+            } else {
+                data.notify();
+                Ok(())
+            }
+        },
+    )
+}

--- a/lib/propolis/src/hw/nvme/mod.rs
+++ b/lib/propolis/src/hw/nvme/mod.rs
@@ -494,9 +494,9 @@ pub struct PciNvme {
     /// PCI device state
     pci_state: pci::DeviceState,
 
-    block_attach: block::device::Attachment,
+    block_attach: block::DeviceAttachment,
 
-    block_tracking: block::device::Tracking<Permit>,
+    block_tracking: block::tracking::Tracking<Permit>,
 
     /// Logger resource
     log: slog::Logger,
@@ -612,8 +612,8 @@ impl PciNvme {
         Arc::new_cyclic(|weak| PciNvme {
             state: Mutex::new(state),
             pci_state,
-            block_attach: block::device::Attachment::new(),
-            block_tracking: block::device::Tracking::new(
+            block_attach: block::DeviceAttachment::new(),
+            block_tracking: block::tracking::Tracking::new(
                 weak.clone() as Weak<dyn block::Device>
             ),
             log,

--- a/lib/propolis/src/hw/nvme/requests.rs
+++ b/lib/propolis/src/hw/nvme/requests.rs
@@ -33,11 +33,11 @@ mod probes {
 }
 
 impl block::Device for PciNvme {
-    fn attachment(&self) -> &block::device::Attachment {
+    fn attachment(&self) -> &block::DeviceAttachment {
         &self.block_attach
     }
 
-    fn attach(&self, info: block::DeviceInfo) {
+    fn on_attach(&self, info: block::DeviceInfo) {
         self.state.lock().unwrap().update_block_info(info);
     }
 

--- a/lib/propolis/src/hw/virtio/block.rs
+++ b/lib/propolis/src/hw/virtio/block.rs
@@ -35,8 +35,8 @@ pub struct PciVirtioBlock {
     virtio_state: PciVirtioState,
     pci_state: pci::DeviceState,
 
-    block_attach: block::device::Attachment,
-    block_tracking: block::device::Tracking<CompletionPayload>,
+    block_attach: block::DeviceAttachment,
+    block_tracking: block::tracking::Tracking<CompletionPayload>,
 }
 impl PciVirtioBlock {
     pub fn new(queue_size: u16) -> Arc<Self> {
@@ -60,8 +60,8 @@ impl PciVirtioBlock {
         Arc::new_cyclic(|weak| Self {
             pci_state,
             virtio_state,
-            block_attach: block::device::Attachment::new(),
-            block_tracking: block::device::Tracking::new(
+            block_attach: block::DeviceAttachment::new(),
+            block_tracking: block::tracking::Tracking::new(
                 weak.clone() as Weak<dyn block::Device>
             ),
         })
@@ -236,7 +236,7 @@ impl PciVirtio for PciVirtioBlock {
     }
 }
 impl block::Device for PciVirtioBlock {
-    fn attachment(&self) -> &block::device::Attachment {
+    fn attachment(&self) -> &block::DeviceAttachment {
         &self.block_attach
     }
 

--- a/lib/propolis/src/lib.rs
+++ b/lib/propolis/src/lib.rs
@@ -16,6 +16,7 @@ extern crate bitflags;
 
 pub mod accessors;
 pub mod api_version;
+pub mod attachment;
 pub mod block;
 pub mod chardev;
 pub mod common;


### PR DESCRIPTION
The frontend/backend attachment pattern will be more useful for other device types (chardev, viona, etc).  While those new consumers are not yet built, we can abstract out the bits most likely to be common.

Fixes #671