### PR TITLE
migration: refrain from offering all pages when possible

### DIFF
--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -457,7 +457,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SourceProtocol<T> {
             // says to offer all pages. This ensures that pages that are
             // transferred now and not touched again will not be offered again
             // by a subsequent phase.
-            self.track_dirty(GuestAddr(start_gpa), &mut bits)?;
+            self.track_dirty(GuestAddr(gpa), &mut bits)?;
 
             match offer_discipline {
                 RamOfferDiscipline::OfferAll => {

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -678,10 +678,14 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SourceProtocol<T> {
         let step = bits.len() * 8 * PAGE_SIZE;
         for gpa in (vmm_range.start().0..vmm_range.end().0).step_by(step) {
             self.track_dirty(GuestAddr(gpa), &mut bits).unwrap();
-            assert!(
-                bits.iter().all(|&b| b == 0),
-                "dirty memory left behind in the range starting at {:#x}",
-                gpa
+            let pages_left_behind =
+                BitSlice::<_, Lsb0>::from_slice(&bits).count_ones() as u64;
+            assert_eq!(
+                0,
+                pages_left_behind,
+                "{pages_left_behind} dirty pages left behind between {:#x}..{:#x}",
+                gpa,
+                gpa + step as u64,
             );
         }
 

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -555,7 +555,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SourceProtocol<T> {
         self.vm_controller
             .machine()
             .hdl
-            .track_dirty_pages(start_gpa.0, bits)
+            .track_dirty_pages(start_gpa.0, bits, true)
             .map_err(|_| MigrateError::InvalidInstanceState)
     }
 

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -9,7 +9,8 @@ use propolis::migrate::{
     MigrateCtx, MigrateStateError, Migrator, PayloadOutputs,
 };
 use propolis::vmm;
-use slog::{error, info, trace};
+use slog::{debug, error, info, trace};
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::io;
 use std::ops::{Range, RangeInclusive};
@@ -168,7 +169,7 @@ pub async fn migrate<T: AsyncRead + AsyncWrite + Unpin + Send>(
                 // dirty bits, as we won't be using them any longer.
                 break;
             } else {
-                info!(proto.log(), "re-dirtied pages at {gpa:#x}",);
+                debug!(proto.log(), "re-dirtied pages at {gpa:#x}",);
             }
         }
 
@@ -226,11 +227,11 @@ struct SourceProtocol<T: AsyncRead + AsyncWrite + Unpin + Send> {
     ///
     /// Otherwise, we must fall back to always offering all pages in the initial
     /// pre-pause RAM push phase.
-    dirt: Option<std::collections::HashMap<GuestAddr, PageBitmap>>,
+    dirt: Option<HashMap<GuestAddr, PageBitmap>>,
 }
 
-type PageBitmap = [u8; PAGE_BITMAP_SIZE];
 const PAGE_BITMAP_SIZE: usize = 4096;
+type PageBitmap = [u8; PAGE_BITMAP_SIZE];
 
 impl<T: AsyncRead + AsyncWrite + Unpin + Send> SourceProtocol<T> {
     fn new(

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -678,7 +678,11 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SourceProtocol<T> {
         let step = bits.len() * 8 * PAGE_SIZE;
         for gpa in (vmm_range.start().0..vmm_range.end().0).step_by(step) {
             self.track_dirty(GuestAddr(gpa), &mut bits).unwrap();
-            assert!(bits.iter().all(|&b| b == 0));
+            assert!(
+                bits.iter().all(|&b| b == 0),
+                "dirty memory left behind in the range starting at {:#x}",
+                gpa
+            );
         }
 
         Ok(())

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -555,7 +555,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SourceProtocol<T> {
         self.vm_controller
             .machine()
             .hdl
-            .track_dirty_pages(start_gpa.0, bits, true)
+            .take_dirty_pages(start_gpa.0, bits)
             .map_err(|_| MigrateError::InvalidInstanceState)
     }
 

--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -36,7 +36,7 @@ use std::{
     fmt::Debug,
     net::SocketAddr,
     pin::Pin,
-    sync::{Arc, Condvar, Mutex, Weak},
+    sync::{Arc, Condvar, Mutex, MutexGuard, Weak},
     task::{Context, Poll},
     thread::JoinHandle,
     time::Duration,
@@ -565,7 +565,7 @@ impl VmController {
 
     pub(crate) fn migration_src_state(
         &self,
-    ) -> std::sync::MutexGuard<'_, migrate::source::PersistentState> {
+    ) -> MutexGuard<'_, migrate::source::PersistentState> {
         self.migration_src_state.lock().unwrap()
     }
 

--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -63,7 +63,7 @@ use uuid::Uuid;
 
 use crate::{
     initializer::{build_instance, MachineInitializer},
-    migrate::MigrateError,
+    migrate::{self, MigrateError},
     serial::Serial,
     server::{BlockBackendMap, CrucibleBackendMap, DeviceMap, StaticConfig},
     vm::request_queue::ExternalRequest,
@@ -300,6 +300,9 @@ pub struct VmController {
     /// (e.g. migration tasks).
     runtime_hdl: tokio::runtime::Handle,
 
+    /// Migration source state persisted across multiple migration attempts.
+    migration_src_state: Mutex<migrate::source::PersistentState>,
+
     /// A weak reference to this controller, suitable for upgrading and passing
     /// to tasks the controller spawns.
     this: Weak<Self>,
@@ -511,6 +514,7 @@ impl VmController {
             },
             worker_state,
             worker_thread: Mutex::new(None),
+            migration_src_state: Default::default(),
             log: log.new(slog::o!("component" => "vm_controller")),
             runtime_hdl: runtime_hdl.clone(),
             this: this.clone(),
@@ -557,6 +561,12 @@ impl VmController {
             .machine
             .as_ref()
             .expect("VM controller always has a valid machine")
+    }
+
+    pub(crate) fn migration_src_state(
+        &self,
+    ) -> std::sync::MutexGuard<'_, migrate::source::PersistentState> {
+        self.migration_src_state.lock().unwrap()
     }
 
     pub async fn instance_spec(

--- a/lib/propolis/src/common.rs
+++ b/lib/propolis/src/common.rs
@@ -336,7 +336,7 @@ impl RWOp<'_, '_> {
 }
 
 /// An address within a guest VM.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct GuestAddr(pub u64);
 
 impl GuestAddr {

--- a/lib/propolis/src/vmm/hdl.rs
+++ b/lib/propolis/src/vmm/hdl.rs
@@ -227,52 +227,57 @@ impl VmmHdl {
         Ok(devoff.offset as usize)
     }
 
-    /// Tracks dirty pages in the guest's physical address space.
+    /// Tracks dirty pages in the guest's physical address space, without
+    /// resetting the dirty bit in the guest's page table entries.
+    ///
+    /// This method is only supported with bhyve [`ApiVersion::V17`] or later.
     ///
     /// # Arguments:
     /// - `start_gpa`: The start of the guest physical address range to track.
     /// Must be page aligned.
     /// - `bitmap`: A mutable bitmap of dirty pages, one bit per guest PFN
     /// relative to `start_gpa`.
-    /// - `reset`: If `true`, any dirty bits in the guest's page-table entries
-    ///   will be reset after the call to `track_dirty_pages`. If `false`, and
-    ///   if the kernel's bhyve version is v17 or later, the dirty bit will remain set.
-    ///   Otherwise, with an earlier kernel version, this method will return an
-    ///   error.
     pub fn track_dirty_pages(
         &self,
         start_gpa: u64,
         bitmap: &mut [u8],
-        reset: bool,
     ) -> Result<()> {
-        let len = bitmap.len() * 8 * PAGE_SIZE;
-
-        // If the caller requested that dirty bits not be cleared, we need to
-        // use the `VM_NPT_OPERATION` ioctl added in bhyve v17, rather than
-        // `VM_TRACK_DIRTY_PAGES`, which always clears those bits.
-        if !reset {
-            if self.api_version()? < bhyve_api::ApiVersion::V17 {
-                return Err(Error::new(
-                    ErrorKind::Unsupported,
-                    "VmmHdl::track_dirty_pages(..., reset: false) requires bhyve v17 or later",
-                ));
-            }
-
-            let mut npt_op = bhyve_api::vm_npt_operation {
-                vno_gpa: start_gpa,
-                vno_len: len as u64,
-                vno_bitmap: bitmap.as_mut_ptr(),
-                vno_operation: bhyve_api::VNO_OP_GET_DIRTY
-                    | bhyve_api::VNO_FLAG_BITMAP_OUT,
-            };
-            return unsafe {
-                self.ioctl(bhyve_api::VM_NPT_OPERATION, &mut npt_op)
-            };
+        if self.api_version()? < bhyve_api::ApiVersion::V17 {
+            return Err(Error::new(
+                ErrorKind::Unsupported,
+                "VmmHdl::track_dirty_pages requires bhyve v17 or later",
+            ));
         }
 
+        let mut npt_op = bhyve_api::vm_npt_operation {
+            vno_gpa: start_gpa,
+            vno_len: page_bitmap_len(bitmap) as u64,
+            vno_bitmap: bitmap.as_mut_ptr(),
+            vno_operation: bhyve_api::VNO_OP_GET_DIRTY
+                | bhyve_api::VNO_FLAG_BITMAP_OUT,
+        };
+        unsafe { self.ioctl(bhyve_api::VM_NPT_OPERATION, &mut npt_op) }
+    }
+
+    /// Tracks dirty pages in the guest's physical address space, resetting any
+    /// dirty bits in the guest's page table entries.
+    ///
+    /// For a version of this method that does not clear the dirty bit, see
+    /// [`VmmHdl::track_dirty_pages`].
+    ///
+    /// # Arguments:
+    /// - `start_gpa`: The start of the guest physical address range to track.
+    /// Must be page aligned.
+    /// - `bitmap`: A mutable bitmap of dirty pages, one bit per guest PFN
+    /// relative to `start_gpa`.
+    pub fn take_dirty_pages(
+        &self,
+        start_gpa: u64,
+        bitmap: &mut [u8],
+    ) -> Result<()> {
         let mut tracker = bhyve_api::vmm_dirty_tracker {
             vdt_start_gpa: start_gpa,
-            vdt_len: len,
+            vdt_len: page_bitmap_len(bitmap),
             vdt_pfns: bitmap.as_mut_ptr() as *mut c_void,
         };
         unsafe { self.ioctl(bhyve_api::VM_TRACK_DIRTY_PAGES, &mut tracker) }
@@ -474,4 +479,8 @@ pub fn query_reservoir() -> Result<bhyve_api::vmm_resv_query> {
     let mut data = bhyve_api::vmm_resv_query::default();
     let _ = unsafe { ctl.ioctl(bhyve_api::VMM_RESV_QUERY, &mut data) }?;
     Ok(data)
+}
+
+fn page_bitmap_len(bitmap: &[u8]) -> usize {
+    bitmap.len() * 8 * PAGE_SIZE
 }

--- a/lib/propolis/src/vmm/hdl.rs
+++ b/lib/propolis/src/vmm/hdl.rs
@@ -234,14 +234,45 @@ impl VmmHdl {
     /// Must be page aligned.
     /// - `bitmap`: A mutable bitmap of dirty pages, one bit per guest PFN
     /// relative to `start_gpa`.
+    /// - `reset`: If `true`, any dirty bits in the guest's page-table entries
+    ///   will be reset after the call to `track_dirty_pages`. If `false`, and
+    ///   if the kernel's bhyve version is v17 or later, the dirty bit will remain set.
+    ///   Otherwise, with an earlier kernel version, this method will return an
+    ///   error.
     pub fn track_dirty_pages(
         &self,
         start_gpa: u64,
         bitmap: &mut [u8],
+        reset: bool,
     ) -> Result<()> {
+        let len = bitmap.len() * 8 * PAGE_SIZE;
+
+        // If the caller requested that dirty bits not be cleared, we need to
+        // use the `VM_NPT_OPERATION` ioctl added in bhyve v17, rather than
+        // `VM_TRACK_DIRTY_PAGES`, which always clears those bits.
+        if !reset {
+            if self.api_version()? < bhyve_api::ApiVersion::V17 {
+                return Err(Error::new(
+                    ErrorKind::Unsupported,
+                    "VmmHdl::track_dirty_pages(..., reset: false) requires bhyve v17 or later",
+                ));
+            }
+
+            let mut npt_op = bhyve_api::vm_npt_operation {
+                vno_gpa: start_gpa,
+                vno_len: len as u64,
+                vno_bitmap: bitmap.as_mut_ptr(),
+                vno_operation: bhyve_api::VNO_OP_GET_DIRTY
+                    | bhyve_api::VNO_FLAG_BITMAP_OUT,
+            };
+            return unsafe {
+                self.ioctl(bhyve_api::VM_NPT_OPERATION, &mut npt_op)
+            };
+        }
+
         let mut tracker = bhyve_api::vmm_dirty_tracker {
             vdt_start_gpa: start_gpa,
-            vdt_len: bitmap.len() * 8 * PAGE_SIZE,
+            vdt_len: len,
             vdt_pfns: bitmap.as_mut_ptr() as *mut c_void,
         };
         unsafe { self.ioctl(bhyve_api::VM_TRACK_DIRTY_PAGES, &mut tracker) }

--- a/lib/propolis/src/vmm/hdl.rs
+++ b/lib/propolis/src/vmm/hdl.rs
@@ -227,69 +227,66 @@ impl VmmHdl {
         Ok(devoff.offset as usize)
     }
 
-    /// Tracks dirty pages in the guest's physical address space.
-    ///
-    /// # Resetting Dirty Bits
-    ///
-    /// On versions of Bhyve prior to [`bhyve_api::ApiVersion::V17`], the
+    /// Tracks dirty pages in the guest's physical address space, clearing any
+    /// dirty bits set on pages in the tracked range.
     ///
     /// # Arguments:
     /// - `start_gpa`: The start of the guest physical address range to track.
     /// Must be page aligned.
     /// - `bitmap`: A mutable bitmap of dirty pages, one bit per guest PFN
     /// relative to `start_gpa`.
-    /// - `reset`: If `true`, the dirty bits in each guest page table entry in
-    ///   the tracked range will be cleared as part of this operation. If
-    ///   `false`, and the bhyve API version is at least
-    ///   [`bhyve_api::ApiVersion::V17`], the tracked pages will remain marked
-    ///   as dirty. If the bhyve API version is less than [`ApiVersion::V17`],
-    ///   only `true` is supported.
     pub fn track_dirty_pages(
         &self,
         start_gpa: u64,
         bitmap: &mut [u8],
-        reset: bool,
     ) -> Result<()> {
-        if self.api_version()? >= bhyve_api::ApiVersion::V17 {
-            // If the bhyve version is v17 or greater, always use the
-            // `VM_NPT_OPERATION` ioctl rather than `VM_TRACK_DIRTY_PAGES`.
-            let mut vno_operation =
-                bhyve_api::VNO_OP_GET_DIRTY | bhyve_api::VNO_FLAG_BITMAP_OUT;
-            if reset {
-                vno_operation |= bhyve_api::VNO_OP_RESET_DIRTY;
-            }
-            let mut npt_op = bhyve_api::vm_npt_operation {
-                vno_gpa: start_gpa,
-                vno_len: (bitmap.len() * 8 * PAGE_SIZE) as u64,
-                vno_bitmap: bitmap.as_mut_ptr(),
-                vno_operation,
-            };
-            return unsafe {
-                self.ioctl(bhyve_api::VM_NPT_OPERATION, &mut npt_op)
-            };
-        } else if !reset {
-            // We were asked not to reset dirty bits, but this is only possible
-            // on bhyve versions that support `VM_NPT_OPERATION``.
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "VmmHdl::track_dirty_pages(..., reset: false) is only supported on bhyve v17 or later",
-            ));
-        }
-
         let mut tracker = bhyve_api::vmm_dirty_tracker {
             vdt_start_gpa: start_gpa,
-            vdt_len: bitmap.len() * 8 * PAGE_SIZE,
+            vdt_len: page_bitmap_len(&bitmap),
             vdt_pfns: bitmap.as_mut_ptr() as *mut c_void,
         };
         unsafe { self.ioctl(bhyve_api::VM_TRACK_DIRTY_PAGES, &mut tracker) }
     }
 
-    /// Returns whether or not the [`VmmHdl::track_dirty_pages`] must reset the
-    /// dirty bit in the guest's page table entries.
+    /// Set the dirty bits on pages in the guest's physical address space.
     ///
-    /// If this method returns `true`, then calls to
-    /// [`VmmHdl::track_dirty_pages`] must set the `reset` argument to `true`.
-    pub fn must_reset_dirty_pages(&self) -> bool {
+    /// This method takes a bitmap in which each bit represents a page. For each
+    /// bit that's set in the bitmap, the corresponding guest page will have its
+    /// dirty bit set.
+    ///
+    /// # Arguments:
+    /// - `start_gpa`: The start of the guest physical address range to track.
+    ///   Must be page aligned.
+    /// - `bitmap`: A bitmap indicating which pages to set dirty bits for, one
+    ///   bit per guest PFN relative to `start_gpa`.
+    ///
+    /// # Supported Bhyve Versions
+    ///
+    /// This method is only available on bhyve [v17](bhyve_api::ApiVersion::V17)
+    /// and later. If the bhyve API version is older than that, this method will
+    /// return an error. The [`VmmHdl::can_npt_operate`] method returns `true`
+    /// if this method is supported.
+    pub fn set_dirty_pages(&self, start_gpa: u64, bitmap: &[u8]) -> Result<()> {
+        if !self.can_npt_operate() {
+            return Err(Error::new(
+                ErrorKind::Unsupported,
+                "VmmHdl::set_dirty_pages requires bhyve v17 or later",
+            ));
+        }
+
+        let mut npt_op = bhyve_api::vm_npt_operation {
+            vno_gpa: start_gpa,
+            vno_len: page_bitmap_len(bitmap) as u64,
+            vno_operation: bhyve_api::VNO_OP_SET_DIRTY
+                | bhyve_api::VNO_FLAG_BITMAP_IN,
+            vno_bitmap: bitmap.as_ptr() as *mut _,
+        };
+        unsafe { self.ioctl(bhyve_api::VM_NPT_OPERATION, &mut npt_op) }
+    }
+
+    /// Returns `true` if  the current bhyve version supports the
+    /// `VM_NPT_OPERATION` ioctl, used by [`VmmHdl::set_dirty_pages`] method.
+    pub fn can_npt_operate(&self) -> bool {
         self.api_version()
             .map(|v| v >= bhyve_api::ApiVersion::V17)
             // If we couldn't read the Bhyve API version, assume the operation
@@ -493,4 +490,8 @@ pub fn query_reservoir() -> Result<bhyve_api::vmm_resv_query> {
     let mut data = bhyve_api::vmm_resv_query::default();
     let _ = unsafe { ctl.ioctl(bhyve_api::VMM_RESV_QUERY, &mut data) }?;
     Ok(data)
+}
+
+fn page_bitmap_len(bitmap: &[u8]) -> usize {
+    bitmap.len() * 8 * PAGE_SIZE
 }

--- a/lib/propolis/src/vmm/hdl.rs
+++ b/lib/propolis/src/vmm/hdl.rs
@@ -259,6 +259,20 @@ impl VmmHdl {
         unsafe { self.ioctl(bhyve_api::VM_NPT_OPERATION, &mut npt_op) }
     }
 
+    /// Returns whether the VMM can track dirty pages in place using the
+    /// [`VmmHdl::track_dirty_pages`] method.
+    ///
+    /// If this method returns `true`, that operation is supported. If this
+    /// method returns `false`, calls to [`VmmHdl::track_dirty_pages`] will
+    /// never succeed.
+    pub fn can_track_dirty_pages_in_place(&self) -> bool {
+        self.api_version()
+            .map(|v| v >= bhyve_api::ApiVersion::V17)
+            // If we couldn't read the Bhyve API version, assume the operation
+            // is unsupported.
+            .unwrap_or(false)
+    }
+
     /// Tracks dirty pages in the guest's physical address space, resetting any
     /// dirty bits in the guest's page table entries.
     ///


### PR DESCRIPTION
Presently, when transferring guest RAM as part of a migration, Propolis will
always offer *all* guest pages in the initial pre-pause RAM transfer phase.
After the guest is paused, Propolis will then offer any pages which were marked
as dirty since the pre-pause RAM transfer, ensuring the most recent guest memory
is transferred. In the initial pre-pause RAM push, however, we cannot offer only
dirty RAM, because tracking which pages are dirty using the
`VM_TRACK_DIRTY_PAGES` ioctl clears the dirty bit, and we may need to perform a
subsequent migration should this one fail. That subsequent migration will have a
bad time if it only offers dirty pages and we have cleared the dirty bits on any
pages that were touched only prior to the previous failed migration. This is a
shame, because we may end up transferring a bunch of pages that the guest has
never actually touched and doesn't care about.

Now, thanks to @pfmooney's upstream work in [illumos-gate#3266], we can
be more efficient about what pages are transferred in the initial push, without
dropping a bunch of pages on the ground if we retry a failed migration. Using
the `VNO_OP_SET_DIRTY` operation performed by the `VM_NPT_OPERATION` ioctl that
Patrick has added to bhyve, we can put back any dirty bits that were cleared
during a failed migration, allowing a subsequent migration to also offer only
dirty pages. Since this ioctl is only available with the latest bhyve (v17), we
will still fall back to the previous behavior of offering all guest RAM if
 `VM_NPT_OPERATION` is unavailable.

Initially, I had planned to just change this code to use the `VNO_OP_GET_DIRTY`
operation, which accesses but does not clear the dirty bits. This way, I
figured, we could just always transfer all dirty pages. However, we *do*
actually want to be clearing dirty bits initially, because we want the
post-pause RAM push to only have to transfer pages that have been touched
_since_ the pre-pause RAM push phase. If we used `VNO_OP_GET_DIRTY` to read the
dirty bits without clearing them for the initial pre-pause RAM push, the
post-pause RAM push would offer all the same pages, which defeats the purpose of
splitting the RAM push into two pages in the first place. Thus, instead, we do
clear the dirty bits, but we store which pages were dirty and put them back
using `VNO_OP_SET_DIRTY` should the migration fail.

The PHD tests I added way back in #623 test retrying a failed migration with
running processes, which should exercise this change. I've run the tests on
`atrium`, which has an Illumos kernel that includes Patrick's bhyve changes:

<details open>

<summary>bhyve version on `atrium`</summary>

```console
eliza@atrium ~ $ pkg info system/bhyve
             Name: system/bhyve
          Summary: BSD hypervisor
      Description: BSD hypervisor
         Category: System/Virtualization
            State: Installed (Manually installed)
        Publisher: helios-dev
          Version: 0.5.11
           Branch: 2.0.22550
   Packaging Date: Wed Mar  6 17:51:32 2024
Last Install Time: Thu Dec  2 05:52:30 2021
 Last Update Time: Thu Mar  7 17:31:21 2024
             Size: 1.48 MB
             FMRI: pkg://helios-dev/system/bhyve@0.5.11-2.0.22550:20240306T175132Z
```

</details>
<details>
<summary>We can see the first RAM push for the first migration, which will fail:</summary>

```log
23:37:54.890Z INFO propolis-server (vm_controller): ram_push (RamPushPrePause): got query for range 0x0..0xffffffffffffffff, vm range GuestAddr(
        0x0,
    )..=GuestAddr(
        0x1fffffff,
    )
23:37:54.890Z INFO propolis-server (vm_controller): offering ram
    can_redirty_pages = true
    discipline = OfferDirty
23:37:54.895Z INFO propolis-server (vm_controller): ram_push: offering 16041 pages between 0x0 and 0x8000000
23:37:54.898Z INFO propolis-server (vm_controller): ram_push: offering 0 pages between 0x8000000 and 0x10000000
23:37:54.901Z INFO propolis-server (vm_controller): ram_push: offering 0 pages between 0x10000000 and 0x18000000
23:37:54.904Z INFO propolis-server (vm_controller): ram_push: offering 0 pages between 0x18000000 and 0x20000000
23:37:54.904Z INFO propolis-server (vm_controller): ram_push: xfer RAM between 0x0 and 0x8000000
23:37:56.312Z INFO propolis-server (vm_controller): ram_push: done sending ram
23:37:56.313Z INFO propolis-server (vm_controller): Pausing devices
23:37:56.313Z INFO propolis-server (vcpu_tasks): vCPU paused
    vcpu = 0
23:37:56.313Z INFO propolis-server (vcpu_tasks): vCPU paused
    vcpu = 1
23:37:56.313Z INFO propolis-server (vm_controller): Sending pause request to com1
23:37:56.313Z INFO propolis-server (vm_controller): Sending pause request to lpc-bhyve-hpet
23:37:56.313Z INFO propolis-server (vm_controller): Sending pause request to lpc-ps2ctrl
23:37:56.313Z INFO propolis-server (vm_controller): Sending pause request to pci-i440fx-hb
23:37:56.313Z INFO propolis-server (vm_controller): Sending pause request to pci-nvme-0.4.0
23:37:56.313Z INFO propolis-server (vm_controller): Sending pause request to pci-piix3-lpc
23:37:56.313Z INFO propolis-server (vm_controller): Sending pause request to pci-piix3-pm
23:37:56.313Z INFO propolis-server (vm_controller): Sending pause request to qemu-fwcfg
23:37:56.313Z INFO propolis-server (vm_controller): Sending pause request to qemu-lpc-debug
23:37:56.313Z INFO propolis-server (vm_controller): Sending pause request to qemu-ramfb
23:37:56.313Z INFO propolis-server (vm_controller): Sending pause request to test-migration-failure
23:37:56.313Z INFO propolis-server (vm_controller): Sending pause request to vcpu-0
23:37:56.313Z INFO propolis-server (vm_controller): Sending pause request to vcpu-1
23:37:56.313Z INFO propolis-server (vm_controller): Waiting for devices to pause
23:37:56.313Z INFO propolis-server (vm_controller): Got paused future from dev com1
23:37:56.313Z INFO propolis-server (vm_controller): Got paused future from dev lpc-bhyve-hpet
23:37:56.313Z INFO propolis-server (vm_controller): Got paused future from dev lpc-ps2ctrl
23:37:56.313Z INFO propolis-server (vm_controller): Got paused future from dev pci-i440fx-hb
23:37:56.313Z INFO propolis-server (vm_controller): Got paused future from dev pci-nvme-0.4.0
23:37:56.313Z INFO propolis-server (vm_controller): Got paused future from dev pci-piix3-lpc
23:37:56.313Z INFO propolis-server (vm_controller): Got paused future from dev pci-piix3-pm
23:37:56.313Z INFO propolis-server (vm_controller): Got paused future from dev qemu-fwcfg
23:37:56.313Z INFO propolis-server (vm_controller): Got paused future from dev qemu-lpc-debug
23:37:56.313Z INFO propolis-server (vm_controller): Got paused future from dev qemu-ramfb
23:37:56.313Z INFO propolis-server (vm_controller): Got paused future from dev test-migration-failure
23:37:56.313Z INFO propolis-server (vm_controller): Got paused future from dev vcpu-0
23:37:56.313Z INFO propolis-server (vm_controller): Got paused future from dev vcpu-1
23:37:56.313Z INFO propolis-server (vm_controller): dev com1 completed pause
23:37:56.313Z INFO propolis-server (vm_controller): dev lpc-bhyve-hpet completed pause
23:37:56.313Z INFO propolis-server (vm_controller): dev lpc-ps2ctrl completed pause
23:37:56.313Z INFO propolis-server (vm_controller): dev pci-i440fx-hb completed pause
23:37:56.313Z INFO propolis-server (vm_controller): dev pci-nvme-0.4.0 completed pause
23:37:56.313Z INFO propolis-server (vm_controller): dev pci-piix3-lpc completed pause
23:37:56.313Z INFO propolis-server (vm_controller): dev pci-piix3-pm completed pause
23:37:56.313Z INFO propolis-server (vm_controller): dev qemu-fwcfg completed pause
23:37:56.313Z INFO propolis-server (vm_controller): dev qemu-lpc-debug completed pause
23:37:56.313Z INFO propolis-server (vm_controller): dev qemu-ramfb completed pause
23:37:56.313Z INFO propolis-server (vm_controller): dev test-migration-failure completed pause
23:37:56.313Z INFO propolis-server (vm_controller): dev vcpu-0 completed pause
23:37:56.313Z INFO propolis-server (vm_controller): dev vcpu-1 completed pause
23:37:56.313Z INFO propolis-server (vm_controller): all devices paused
23:37:56.313Z INFO propolis-server (vm_controller): Pausing kernel VMM resources
23:37:56.313Z INFO propolis-server (vm_controller): ram_push (RamPushPostPause): got query for range 0x0..0xffffffffffffffff, vm range GuestAddr(
        0x0,
    )..=GuestAddr(
        0x1fffffff,
    )
23:37:56.314Z INFO propolis-server (vm_controller): offering ram
    can_redirty_pages = true
    discipline = OfferDirty
23:37:56.317Z INFO propolis-server (vm_controller): ram_push: offering 95 pages between 0x0 and 0x8000000
23:37:56.321Z INFO propolis-server (vm_controller): ram_push: offering 0 pages between 0x8000000 and 0x10000000
23:37:56.326Z INFO propolis-server (vm_controller): ram_push: offering 0 pages between 0x10000000 and 0x18000000
23:37:56.330Z INFO propolis-server (vm_controller): ram_push: offering 0 pages between 0x18000000 and 0x20000000
23:37:56.330Z INFO propolis-server (vm_controller): ram_push: xfer RAM between 0x0 and 0x8000000
23:37:56.339Z INFO propolis-server (vm_controller): ram_push: done sending ram
```
</details>
<summary>The test migration failure device fails to be imported, so the
source Propolis gives up on the migration, and we put back the dirty bits:
</summary>

```log
23:37:56.381Z ERRO propolis-server (vm_controller): remote error: failed to migrate device state: failed to apply deserialized device state: you have no chance to survive, make your time
23:37:56.383Z INFO propolis-server (vm_controller): re-dirtied 16136 pages at 0x0
23:37:56.383Z ERRO propolis-server (vm_controller): Migration task failed: Destination migration instance encountered error: failed to migrate device state: failed to apply deserialized device state: you have no chance to survive, make your time
23:37:56.383Z INFO propolis-server (vm_state_worker): Migration source task exited: Err(RemoteError(Destination, "failed to migrate device state: failed to apply deserialized device state: you have no chance to survive, make your time"))
23:37:56.383Z INFO propolis-server (vm_controller): Resuming kernel VMM resources
```
</details>
<details>
<summary>
A second migration attempt transfers all the expected pages:
</summary>

```log
23:37:57.759Z INFO propolis-server (vm_controller): offering ram
    can_redirty_pages = true
    discipline = OfferDirty
23:37:57.767Z INFO propolis-server (vm_controller): ram_push: offering 16041 pages between 0x0 and 0x8000000
23:37:57.774Z INFO propolis-server (vm_controller): ram_push: offering 0 pages between 0x8000000 and 0x10000000
23:37:57.777Z INFO propolis-server (vm_controller): ram_push: offering 0 pages between 0x10000000 and 0x18000000
23:37:57.780Z INFO propolis-server (vm_controller): ram_push: offering 0 pages between 0x18000000 and 0x20000000
23:37:57.780Z INFO propolis-server (vm_controller): ram_push: xfer RAM between 0x0 and 0x8000000
23:37:59.187Z INFO propolis-server (vm_controller): ram_push: done sending ram
23:37:59.187Z INFO propolis-server (vm_controller): Pausing devices
23:37:59.187Z INFO propolis-server (vcpu_tasks): vCPU paused
    vcpu = 0
23:37:59.188Z INFO propolis-server (vcpu_tasks): vCPU paused
    vcpu = 1
23:37:59.188Z INFO propolis-server (vm_controller): Sending pause request to com1
23:37:59.188Z INFO propolis-server (vm_controller): Sending pause request to lpc-bhyve-hpet
23:37:59.188Z INFO propolis-server (vm_controller): Sending pause request to lpc-ps2ctrl
23:37:59.188Z INFO propolis-server (vm_controller): Sending pause request to pci-i440fx-hb
23:37:59.188Z INFO propolis-server (vm_controller): Sending pause request to pci-nvme-0.4.0
23:37:59.188Z INFO propolis-server (vm_controller): Sending pause request to pci-piix3-lpc
23:37:59.188Z INFO propolis-server (vm_controller): Sending pause request to pci-piix3-pm
23:37:59.188Z INFO propolis-server (vm_controller): Sending pause request to qemu-fwcfg
23:37:59.188Z INFO propolis-server (vm_controller): Sending pause request to qemu-lpc-debug
23:37:59.188Z INFO propolis-server (vm_controller): Sending pause request to qemu-ramfb
23:37:59.188Z INFO propolis-server (vm_controller): Sending pause request to test-migration-failure
23:37:59.188Z INFO propolis-server (vm_controller): Sending pause request to vcpu-0
23:37:59.188Z INFO propolis-server (vm_controller): Sending pause request to vcpu-1
23:37:59.188Z INFO propolis-server (vm_controller): Waiting for devices to pause
23:37:59.188Z INFO propolis-server (vm_controller): Got paused future from dev com1
23:37:59.188Z INFO propolis-server (vm_controller): Got paused future from dev lpc-bhyve-hpet
23:37:59.188Z INFO propolis-server (vm_controller): Got paused future from dev lpc-ps2ctrl
23:37:59.188Z INFO propolis-server (vm_controller): Got paused future from dev pci-i440fx-hb
23:37:59.188Z INFO propolis-server (vm_controller): Got paused future from dev pci-nvme-0.4.0
23:37:59.188Z INFO propolis-server (vm_controller): Got paused future from dev pci-piix3-lpc
23:37:59.188Z INFO propolis-server (vm_controller): Got paused future from dev pci-piix3-pm
23:37:59.188Z INFO propolis-server (vm_controller): Got paused future from dev qemu-fwcfg
23:37:59.188Z INFO propolis-server (vm_controller): Got paused future from dev qemu-lpc-debug
23:37:59.188Z INFO propolis-server (vm_controller): Got paused future from dev qemu-ramfb
23:37:59.188Z INFO propolis-server (vm_controller): Got paused future from dev test-migration-failure
23:37:59.188Z INFO propolis-server (vm_controller): Got paused future from dev vcpu-0
23:37:59.188Z INFO propolis-server (vm_controller): Got paused future from dev vcpu-1
23:37:59.188Z INFO propolis-server (vm_controller): dev com1 completed pause
23:37:59.188Z INFO propolis-server (vm_controller): dev lpc-bhyve-hpet completed pause
23:37:59.188Z INFO propolis-server (vm_controller): dev lpc-ps2ctrl completed pause
23:37:59.188Z INFO propolis-server (vm_controller): dev pci-i440fx-hb completed pause
23:37:59.188Z INFO propolis-server (vm_controller): dev pci-nvme-0.4.0 completed pause
23:37:59.188Z INFO propolis-server (vm_controller): dev pci-piix3-lpc completed pause
23:37:59.188Z INFO propolis-server (vm_controller): dev pci-piix3-pm completed pause
23:37:59.188Z INFO propolis-server (vm_controller): dev qemu-fwcfg completed pause
23:37:59.188Z INFO propolis-server (vm_controller): dev qemu-lpc-debug completed pause
23:37:59.188Z INFO propolis-server (vm_controller): dev qemu-ramfb completed pause
23:37:59.188Z INFO propolis-server (vm_controller): dev test-migration-failure completed pause
23:37:59.188Z INFO propolis-server (vm_controller): dev vcpu-0 completed pause
23:37:59.188Z INFO propolis-server (vm_controller): dev vcpu-1 completed pause
23:37:59.188Z INFO propolis-server (vm_controller): all devices paused
23:37:59.189Z INFO propolis-server (vm_controller): Pausing kernel VMM resources
23:37:59.189Z INFO propolis-server (vm_controller): ram_push (RamPushPostPause): got query for range 0x0..0xffffffffffffffff, vm range GuestAddr(
        0x0,
    )..=GuestAddr(
        0x1fffffff,
    )
23:37:59.189Z INFO propolis-server (vm_controller): offering ram
    can_redirty_pages = true
    discipline = OfferDirty
23:37:59.191Z INFO propolis-server (vm_controller): ram_push: offering 89 pages between 0x0 and 0x8000000
23:37:59.194Z INFO propolis-server (vm_controller): ram_push: offering 0 pages between 0x8000000 and 0x10000000
23:37:59.197Z INFO propolis-server (vm_controller): ram_push: offering 0 pages between 0x10000000 and 0x18000000
23:37:59.200Z INFO propolis-server (vm_controller): ram_push: offering 0 pages between 0x18000000 and 0x20000000
23:37:59.200Z INFO propolis-server (vm_controller): ram_push: xfer RAM between 0x0 and 0x8000000
23:37:59.208Z INFO propolis-server (vm_controller): ram_push: done sending ram
```
</details>

Closes #387

[illumos-gate#3266] https://code.illumos.org/c/illumos-gate/+/3266