### PR TITLE
Enable clippy warnings for lossless casts

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -850,7 +850,7 @@ impl<'a> MachineInitializer<'a> {
         fwcfg
             .add_legacy(
                 fwcfg::LegacyId::SmpCpuCount,
-                fwcfg::FixedItem::new_u32(cpus as u32),
+                fwcfg::FixedItem::new_u32(u32::from(cpus)),
             )
             .unwrap();
 

--- a/bin/propolis-standalone/src/config.rs
+++ b/bin/propolis-standalone/src/config.rs
@@ -258,7 +258,8 @@ fn create_crucible_backend(
     // what block size the downstairs is using. A lot of things
     // default to 512, but it's best not to assume it'll always be
     // that way.
-    let block_size = opts.block_size.expect("block_size is provided") as u64;
+    let block_size =
+        u64::from(opts.block_size.expect("block_size is provided"));
     let read_only = opts.read_only.unwrap_or(false);
 
     #[derive(Deserialize)]

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -1050,7 +1050,7 @@ fn setup_instance(
     fwcfg
         .add_legacy(
             hw::qemu::fwcfg::LegacyId::SmpCpuCount,
-            hw::qemu::fwcfg::FixedItem::new_u32(cpus as u32),
+            hw::qemu::fwcfg::FixedItem::new_u32(u32::from(cpus)),
         )
         .map_err(|err| Error::new(ErrorKind::Other, err))?;
 

--- a/bin/propolis-utils/src/bin/cpuid-gen.rs
+++ b/bin/propolis-utils/src/bin/cpuid-gen.rs
@@ -172,10 +172,10 @@ fn collect_cpuid(
             }
             0xd if xsave_supported => {
                 // XSAVE
-                let xcr0_bits = data.eax as u64 | data.edx as u64;
+                let xcr0_bits = u64::from(data.eax) | u64::from(data.edx);
                 results.insert(CpuidKey::SubLeaf(eax, 0), data);
                 let data = query_cpuid(eax, 1)?;
-                let xss_bits = data.ecx as u64 | data.edx as u64;
+                let xss_bits = u64::from(data.ecx) | u64::from(data.edx);
                 results.insert(CpuidKey::SubLeaf(eax, 1), data);
 
                 // Fetch all the 2:63 sub-leaf entries which are valid

--- a/lib/propolis/src/block/crucible.rs
+++ b/lib/propolis/src/block/crucible.rs
@@ -172,11 +172,11 @@ impl CrucibleBackend {
     ) -> io::Result<Arc<Self>> {
         let rt = tokio::runtime::Handle::current();
         rt.block_on(async move {
-            let block_size = opts.block_size.ok_or_else(|| {
+            let block_size = u64::from(opts.block_size.ok_or_else(|| {
                 CrucibleError::GenericError(
                     "block_size is required parameter".into(),
                 )
-            })? as u64;
+            })?);
             // Allocate and construct the volume.
             let mem_disk = Arc::new(crucible::InMemoryBlockIO::new(
                 Uuid::new_v4(),

--- a/lib/propolis/src/block/file.rs
+++ b/lib/propolis/src/block/file.rs
@@ -177,7 +177,7 @@ impl FileBackend {
 
         let info = block::DeviceInfo {
             block_size,
-            total_size: len / block_size as u64,
+            total_size: len / u64::from(block_size),
             read_only,
         };
         let skip_flush = opts.skip_flush.unwrap_or(false);

--- a/lib/propolis/src/block/in_memory.rs
+++ b/lib/propolis/src/block/in_memory.rs
@@ -108,7 +108,7 @@ impl InMemoryBackend {
                 bytes: Mutex::new(bytes),
                 info: block::DeviceInfo {
                     block_size,
-                    total_size: len as u64 / block_size as u64,
+                    total_size: len as u64 / u64::from(block_size),
                     read_only: opts.read_only.unwrap_or(false),
                 },
             }),

--- a/lib/propolis/src/block/mem_async.rs
+++ b/lib/propolis/src/block/mem_async.rs
@@ -104,7 +104,7 @@ impl MemAsyncBackend {
 
         if size == 0 {
             return Err(Error::new(ErrorKind::Other, "size cannot be 0"));
-        } else if (size % block_size as u64) != 0 {
+        } else if (size % u64::from(block_size)) != 0 {
             return Err(Error::new(
                 ErrorKind::Other,
                 format!(
@@ -121,7 +121,7 @@ impl MemAsyncBackend {
                 attachment: block::backend::Attachment::new(),
                 info: block::DeviceInfo {
                     block_size,
-                    total_size: size / block_size as u64,
+                    total_size: size / u64::from(block_size),
                     read_only: opts.read_only.unwrap_or(false),
                 },
                 seg,

--- a/lib/propolis/src/cpuid.rs
+++ b/lib/propolis/src/cpuid.rs
@@ -263,7 +263,7 @@ impl Specializer {
                     ent.edx |= (0x1 << 28);
                     // bits 23:16 contain max IDs for logical CPUs in package
                     ent.ebx &= !0xff0000;
-                    ent.ebx |= (num_vcpu.get() as u32) << 16;
+                    ent.ebx |= u32::from(num_vcpu.get()) << 16;
                 }
             }
         }
@@ -291,7 +291,7 @@ impl Specializer {
                         0b011 => {
                             // L3 shared by all vCPUs
                             // TODO: segregate by sockets, if configured
-                            num as u32
+                            u32::from(num)
                         }
                         _ => {
                             // unceremonious handling of unexpected cache levels
@@ -320,7 +320,7 @@ impl Specializer {
             let num_vcpu = self
                 .num_vcpu
                 .ok_or(SpecializeError::MissingVcpuCount)
-                .map(|n| n.get() as u32)?;
+                .map(|n| u32::from(n.get()))?;
 
             match topo {
                 TopoKind::StdB => {

--- a/lib/propolis/src/hw/chipset/i440fx.rs
+++ b/lib/propolis/src/hw/chipset/i440fx.rs
@@ -849,11 +849,11 @@ impl Piix3PM {
                 let regs = self.regs.lock().unwrap();
 
                 // LSB hardwired to 1 to indicate PMBase in IO space
-                ro.write_u32(regs.pm_base as u32 | 0x1);
+                ro.write_u32(u32::from(regs.pm_base) | 0x1);
             }
             PmCfg::SmbusBase => {
                 // LSB hardwired to 1 to indicate PMBase in IO space
-                ro.write_u32(SMBBASE_DEFAULT as u32 | 0x1);
+                ro.write_u32(u32::from(SMBBASE_DEFAULT) | 0x1);
             }
             PmCfg::DevResA => {
                 ro.write_u32(DevResA::KBC_EN_DEV11.bits());

--- a/lib/propolis/src/hw/nvme/cmds.rs
+++ b/lib/propolis/src/hw/nvme/cmds.rs
@@ -271,7 +271,7 @@ impl GetLogPageCmd {
     /// The expected size of the memory covered by the PRPs is defined by
     /// `NUMD`, stored as bytes (rather than number Dwords) in [`Self::len`]
     pub fn data<'a>(&self, mem: &'a MemCtx) -> PrpIter<'a> {
-        PrpIter::new(self.len as u64, self.prp1, self.prp2, mem)
+        PrpIter::new(u64::from(self.len), self.prp1, self.prp2, mem)
     }
 }
 
@@ -569,7 +569,7 @@ impl From<u32> for FeatVolatileWriteCache {
 }
 impl From<FeatVolatileWriteCache> for u32 {
     fn from(value: FeatVolatileWriteCache) -> Self {
-        value.wce as u32
+        u32::from(value.wce)
     }
 }
 
@@ -608,8 +608,8 @@ impl TryFrom<u32> for FeatNumberQueues {
 impl From<FeatNumberQueues> for u32 {
     fn from(value: FeatNumberQueues) -> Self {
         // Convert to 0's based DW0
-        (value.ncq.saturating_sub(1) as u32) << 16
-            | value.nsq.saturating_sub(1) as u32
+        u32::from(value.ncq.saturating_sub(1)) << 16
+            | u32::from(value.nsq.saturating_sub(1))
     }
 }
 
@@ -626,7 +626,7 @@ impl From<u32> for FeatInterruptVectorConfig {
 }
 impl From<FeatInterruptVectorConfig> for u32 {
     fn from(value: FeatInterruptVectorConfig) -> Self {
-        value.iv as u32 | (value.cd as u32) << 16
+        u32::from(value.iv) | u32::from(value.cd) << 16
     }
 }
 
@@ -655,14 +655,14 @@ impl NvmCmd {
         let cmd = match raw.opcode() {
             bits::NVM_OPC_FLUSH => NvmCmd::Flush,
             bits::NVM_OPC_WRITE => NvmCmd::Write(WriteCmd {
-                slba: (raw.cdw11 as u64) << 32 | raw.cdw10 as u64,
+                slba: u64::from(raw.cdw11) << 32 | u64::from(raw.cdw10),
                 // Convert from 0's based value
                 nlb: raw.cdw12 as u16 + 1,
                 prp1: raw.prp1,
                 prp2: raw.prp2,
             }),
             bits::NVM_OPC_READ => NvmCmd::Read(ReadCmd {
-                slba: (raw.cdw11 as u64) << 32 | raw.cdw10 as u64,
+                slba: u64::from(raw.cdw11) << 32 | u64::from(raw.cdw10),
                 // Convert from 0's based value
                 nlb: raw.cdw12 as u16 + 1,
                 prp1: raw.prp1,
@@ -876,7 +876,7 @@ impl PrpIter<'_> {
             }
             PrpNext::List(base, idx) => {
                 assert!(idx <= PRP_LIST_MAX);
-                let entry_addr = base + (idx as u64) * 8;
+                let entry_addr = base + u64::from(idx) * 8;
                 let entry: u64 = self
                     .mem
                     .read(GuestAddr(entry_addr))

--- a/lib/propolis/src/hw/nvme/mod.rs
+++ b/lib/propolis/src/hw/nvme/mod.rs
@@ -179,7 +179,7 @@ impl NvmeCtrl {
             0,
             GuestAddr(self.ctrl.admin_cq_base),
             // Convert from 0's based
-            self.ctrl.aqa.acqs() as u32 + 1,
+            u32::from(self.ctrl.aqa.acqs()) + 1,
             mem,
         )?;
         self.create_sq(
@@ -187,7 +187,7 @@ impl NvmeCtrl {
             queue::ADMIN_QUEUE_ID,
             GuestAddr(self.ctrl.admin_sq_base),
             // Convert from 0's based
-            self.ctrl.aqa.asqs() as u32 + 1,
+            u32::from(self.ctrl.aqa.asqs()) + 1,
             mem,
         )?;
         Ok(())
@@ -848,7 +848,12 @@ impl PciNvme {
 
                 // 32-bit register but ignore reserved top 16-bits
                 let val = wo.read_u32() as u16;
-                probes::nvme_doorbell!(|| (off as u64, qid, is_cq as u8, val));
+                probes::nvme_doorbell!(|| (
+                    off as u64,
+                    qid,
+                    u8::from(is_cq),
+                    val
+                ));
                 if is_cq {
                     // Completion Queue y Head Doorbell
                     let cq = state.get_cq(qid)?;

--- a/lib/propolis/src/hw/nvme/queue.rs
+++ b/lib/propolis/src/hw/nvme/queue.rs
@@ -108,10 +108,10 @@ impl<QS: Debug> QueueState<QS> {
 }
 
 fn wrap_add(size: u32, idx: u16, off: u16) -> u16 {
-    debug_assert!((idx as u32) < size);
-    debug_assert!((off as u32) < size);
+    debug_assert!(u32::from(idx) < size);
+    debug_assert!(u32::from(off) < size);
 
-    let res = idx as u32 + off as u32;
+    let res = u32::from(idx) + u32::from(off);
     if res >= size {
         (res - size) as u16
     } else {
@@ -119,11 +119,11 @@ fn wrap_add(size: u32, idx: u16, off: u16) -> u16 {
     }
 }
 fn wrap_sub(size: u32, idx: u16, off: u16) -> u16 {
-    debug_assert!((idx as u32) < size);
-    debug_assert!((off as u32) < size);
+    debug_assert!(u32::from(idx) < size);
+    debug_assert!(u32::from(off) < size);
 
     if off > idx {
-        ((idx as u32 + size) - off as u32) as u16
+        ((u32::from(idx) + size) - u32::from(off)) as u16
     } else {
         idx - off
     }
@@ -232,7 +232,7 @@ impl<'a> QueueGuard<'a, CompQueueState> {
     /// Conceptually this method indicates some entries have been consumed
     /// from the queue.
     fn pop_head_to(&mut self, idx: u16) -> Result<(), QueueUpdateError> {
-        if idx as u32 >= *self.size {
+        if u32::from(idx) >= *self.size {
             return Err(QueueUpdateError::InvalidEntry);
         }
         let pop_count = self.idx_sub(idx, self.state.head);
@@ -260,7 +260,7 @@ impl<'a> QueueGuard<'a, CompQueueState> {
     fn release_avail(&mut self) {
         if let Some(avail) = self.state.inner.avail.checked_add(1) {
             assert!(
-                (avail as u32) < *self.size,
+                u32::from(avail) < *self.size,
                 "attempted to overflow CQ available size"
             );
             self.state.inner.avail = avail;
@@ -326,7 +326,7 @@ impl<'a> QueueGuard<'a, SubQueueState> {
     /// Conceptually this method indicates new entries have been added to the
     /// queue.
     fn push_tail_to(&mut self, idx: u16) -> Result<(), QueueUpdateError> {
-        if idx as u32 >= *self.size {
+        if u32::from(idx) >= *self.size {
             return Err(QueueUpdateError::InvalidEntry);
         }
         let push_count = self.idx_sub(idx, self.state.tail);
@@ -620,7 +620,7 @@ impl CompQueue {
             .push_tail()
             .expect("CQ should have available space for assigned permit");
 
-        probes::nvme_cqe!(|| (self.id, idx, phase as u8));
+        probes::nvme_cqe!(|| (self.id, idx, u8::from(phase)));
 
         // The only definite indicator that a CQE has become valid is the phase
         // bit being toggled.  Since the interface for writing to guest memory

--- a/lib/propolis/src/hw/nvme/requests.rs
+++ b/lib/propolis/src/hw/nvme/requests.rs
@@ -72,10 +72,10 @@ impl PciNvme {
                 probes::nvme_raw_cmd!(|| {
                     (
                         qid,
-                        sub.cdw0 as u64 | ((sub.nsid as u64) << 32),
+                        u64::from(sub.cdw0) | (u64::from(sub.nsid) << 32),
                         sub.prp1,
                         sub.prp2,
-                        (sub.cdw10 as u64 | ((sub.cdw11 as u64) << 32)),
+                        (u64::from(sub.cdw10) | (u64::from(sub.cdw11) << 32)),
                     )
                 });
                 let cid = sub.cid();

--- a/lib/propolis/src/hw/pci/bar.rs
+++ b/lib/propolis/src/hw/pci/bar.rs
@@ -30,8 +30,8 @@ impl BarDefine {
     /// Get the size of the BAR definition, regardless of type
     pub fn size(&self) -> u64 {
         match self {
-            BarDefine::Pio(sz) => *sz as u64,
-            BarDefine::Mmio(sz) => *sz as u64,
+            BarDefine::Pio(sz) => u64::from(*sz),
+            BarDefine::Mmio(sz) => u64::from(*sz),
             BarDefine::Mmio64(sz) => *sz,
         }
     }
@@ -103,7 +103,9 @@ impl Bars {
         let ent = self.entries[idx];
         match ent.kind {
             EntryKind::Empty => 0,
-            EntryKind::Pio(_) => (ent.value as u16) as u32 | bits::BAR_TYPE_IO,
+            EntryKind::Pio(_) => {
+                u32::from(ent.value as u16) | bits::BAR_TYPE_IO
+            }
             EntryKind::Mmio(_) => ent.value as u32 | bits::BAR_TYPE_MEM,
             EntryKind::Mmio64(_) => ent.value as u32 | bits::BAR_TYPE_MEM64,
             EntryKind::Mmio64High => {
@@ -125,22 +127,22 @@ impl Bars {
         let (def, old, new) = match ent.kind {
             EntryKind::Empty => return None,
             EntryKind::Pio(size) => {
-                let mask = !(size - 1) as u32;
+                let mask = u32::from(!(size - 1));
                 let old = ent.value;
-                ent.value = (val & mask) as u64;
+                ent.value = u64::from(val & mask);
                 (BarDefine::Pio(size), old, ent.value)
             }
             EntryKind::Mmio(size) => {
                 let mask = !(size - 1);
                 let old = ent.value;
-                ent.value = (val & mask) as u64;
+                ent.value = u64::from(val & mask);
                 (BarDefine::Mmio(size), old, ent.value)
             }
             EntryKind::Mmio64(size) => {
                 let old = ent.value;
                 let mask = !(size - 1) as u32;
                 let low = val & mask;
-                ent.value = (old & (0xffffffff << 32)) | low as u64;
+                ent.value = (old & (0xffffffff << 32)) | u64::from(low);
                 (BarDefine::Mmio64(size), old, ent.value)
             }
             EntryKind::Mmio64High => {
@@ -152,7 +154,7 @@ impl Bars {
                 };
                 let mask = !(size - 1);
                 let old = ent.value;
-                let high = (((val as u64) << 32) & mask) & 0xffffffff00000000;
+                let high = ((u64::from(val) << 32) & mask) & 0xffffffff00000000;
                 ent.value = high | (old & 0xffffffff);
                 (BarDefine::Mmio64(size), old, ent.value)
             }
@@ -183,11 +185,11 @@ impl Bars {
                 panic!("high BAR bits not to be set directly")
             }
             EntryKind::Pio(_) => {
-                assert!(value <= u16::MAX as u64);
+                assert!(value <= u64::from(u16::MAX));
                 ent.value = value;
             }
             EntryKind::Mmio(_) => {
-                assert!(value <= u32::MAX as u64);
+                assert!(value <= u64::from(u32::MAX));
             }
             EntryKind::Mmio64(_) => {}
         }
@@ -198,12 +200,12 @@ impl Bars {
         let entries = self.entries.map(|entry| match entry.kind {
             EntryKind::Pio(sz) => migrate::BarEntryV1 {
                 kind: migrate::BarKindV1::Pio,
-                size: sz as u64,
+                size: u64::from(sz),
                 value: entry.value,
             },
             EntryKind::Mmio(sz) => migrate::BarEntryV1 {
                 kind: migrate::BarKindV1::Mmio,
-                size: sz as u64,
+                size: u64::from(sz),
                 value: entry.value,
             },
             EntryKind::Mmio64(sz) => migrate::BarEntryV1 {

--- a/lib/propolis/src/hw/pci/device.rs
+++ b/lib/propolis/src/hw/pci/device.rs
@@ -727,7 +727,7 @@ impl MsixEntry {
     }
     fn send(&self) {
         if let Some(acc) = self.acc_msi.as_ref() {
-            let _ = acc.send(self.addr, self.data as u64);
+            let _ = acc.send(self.addr, u64::from(self.data));
         }
     }
     fn reset(&mut self) {
@@ -917,10 +917,12 @@ impl MsixCfg {
                         }
                         MsixCapReg::TableOff => {
                             // table always at offset 0 for now
-                            ro.write_u32(self.bar as u8 as u32);
+                            ro.write_u32(u32::from(self.bar as u8));
                         }
                         MsixCapReg::PbaOff => {
-                            ro.write_u32(self.pba_off | self.bar as u8 as u32);
+                            ro.write_u32(
+                                self.pba_off | u32::from(self.bar as u8),
+                            );
                         }
                     }
                 }

--- a/lib/propolis/src/hw/qemu/fwcfg.rs
+++ b/lib/propolis/src/hw/qemu/fwcfg.rs
@@ -369,7 +369,7 @@ struct AccessState {
 }
 impl AccessState {
     fn dma_addr(&self) -> u64 {
-        (self.addr_high as u64) << 32 | self.addr_low as u64
+        u64::from(self.addr_high) << 32 | u64::from(self.addr_low)
     }
 }
 
@@ -415,7 +415,7 @@ impl FwCfg {
                 RWOp::Write(wo) => {
                     match wo.len() {
                         2 => state.selector = wo.read_u16(),
-                        1 => state.selector = wo.read_u8() as u16,
+                        1 => state.selector = u16::from(wo.read_u8()),
                         _ => {}
                     }
                     state.offset = 0;
@@ -621,7 +621,7 @@ impl FwCfg {
         // write zeroes for everything past the end of the data
         if written < len {
             mem.write_byte(
-                GuestAddr(addr + written as u64),
+                GuestAddr(addr + u64::from(written)),
                 0,
                 (len - written) as usize,
             );

--- a/lib/propolis/src/hw/uart/uart16550.rs
+++ b/lib/propolis/src/hw/uart/uart16550.rs
@@ -119,12 +119,12 @@ impl Uart {
                 );
             }
             None => {
-                probes::uart_ign_read!(|| (offset, is_dlab as u8));
+                probes::uart_ign_read!(|| (offset, u8::from(is_dlab)));
                 0
             }
         };
 
-        probes::uart_reg_read!(|| (offset, is_dlab as u8, val));
+        probes::uart_reg_read!(|| (offset, u8::from(is_dlab), val));
 
         val
     }
@@ -133,7 +133,7 @@ impl Uart {
     pub fn reg_write(&mut self, offset: u8, data: u8) {
         let is_dlab = self.is_dlab();
 
-        probes::uart_reg_write!(|| (offset, is_dlab as u8, data));
+        probes::uart_reg_write!(|| (offset, u8::from(is_dlab), data));
         match UartReg::for_write(offset, is_dlab) {
             Some(UartReg::DivisorLow) => {
                 self.reg_div_low = data;
@@ -196,7 +196,7 @@ impl Uart {
                 );
             }
             None => {
-                probes::uart_ign_read!(|| (offset, is_dlab as u8, data));
+                probes::uart_ign_read!(|| (offset, u8::from(is_dlab), data));
             }
         }
     }

--- a/lib/propolis/src/hw/virtio/block.rs
+++ b/lib/propolis/src/hw/virtio/block.rs
@@ -70,7 +70,7 @@ impl PciVirtioBlock {
     fn block_cfg_read(&self, id: &BlockReg, ro: &mut ReadOp) {
         let info = self.block_attach.info().unwrap_or_else(Default::default);
 
-        let total_bytes = info.total_size * info.block_size as u64;
+        let total_bytes = info.total_size * u64::from(info.block_size);
         match id {
             BlockReg::Capacity => {
                 ro.write_u64(total_bytes / SECTOR_SZ as u64);

--- a/lib/propolis/src/hw/virtio/pci.rs
+++ b/lib/propolis/src/hw/virtio/pci.rs
@@ -329,7 +329,7 @@ impl PciVirtioState {
                 let pfn = wo.read_u32();
                 if let Some(queue) = self.queues.get(state.queue_sel) {
                     let qs_old = queue.get_state();
-                    let new_addr = (pfn as u64) << PAGE_SHIFT;
+                    let new_addr = u64::from(pfn) << PAGE_SHIFT;
                     queue.map_legacy(new_addr);
 
                     if qs_old.mapping.desc_addr != new_addr {

--- a/lib/propolis/src/hw/virtio/queue.rs
+++ b/lib/propolis/src/hw/virtio/queue.rs
@@ -118,7 +118,7 @@ impl VqUsed {
         self.used_idx += Wrapping(1);
         let desc_addr = self.gpa_ring.offset::<VqdUsed>(idx as usize);
 
-        let used = VqdUsed { id: id as u32, len };
+        let used = VqdUsed { id: u32::from(id), len };
         mem.write(desc_addr, &used);
 
         fence(Ordering::Release);
@@ -658,7 +658,7 @@ impl Chain {
                 continue;
             }
             assert!(stat.pos_off < len);
-            let off_addr = GuestAddr(addr.0 + stat.pos_off as u64);
+            let off_addr = GuestAddr(addr.0 + u64::from(stat.pos_off));
             let off_len = (len - stat.pos_off) as usize;
             let (consumed, do_more) = f(off_addr, off_len);
             assert!(consumed <= off_len);

--- a/lib/propolis/src/hw/virtio/viona.rs
+++ b/lib/propolis/src/hw/virtio/viona.rs
@@ -603,7 +603,7 @@ impl VionaHdl {
             rm_index: idx,
             _pad: [0; 3],
             rm_addr: addr,
-            rm_msg: msg as u64,
+            rm_msg: u64::from(msg),
         };
         unsafe {
             self.0.ioctl(viona_api::VNA_IOC_RING_SET_MSI, &mut vna_ring_msi)?;

--- a/lib/propolis/src/mmio.rs
+++ b/lib/propolis/src/mmio.rs
@@ -57,7 +57,7 @@ impl MmioBus {
             addr as u64,
             bytes,
             val,
-            handled.is_ok() as u8
+            u8::from(handled.is_ok())
         ));
         handled
     }
@@ -76,7 +76,12 @@ impl MmioBus {
         });
 
         let val = LE::read_u64(&buf);
-        probes::mmio_read!(|| (addr as u64, bytes, val, handled.is_ok() as u8));
+        probes::mmio_read!(|| (
+            addr as u64,
+            bytes,
+            val,
+            u8::from(handled.is_ok())
+        ));
         handled.map(|_| val)
     }
 

--- a/lib/propolis/src/pio.rs
+++ b/lib/propolis/src/pio.rs
@@ -52,7 +52,7 @@ impl PioBus {
             let mut wo = WriteOp::from_buf(o as usize, data);
             func(a, RWOp::Write(&mut wo))
         });
-        probes::pio_out!(|| (port, bytes, val, handled.is_ok() as u8));
+        probes::pio_out!(|| (port, bytes, val, u8::from(handled.is_ok())));
         handled
     }
 
@@ -70,7 +70,7 @@ impl PioBus {
         });
 
         let val = LE::read_u32(&buf);
-        probes::pio_in!(|| (port, bytes, val, handled.is_ok() as u8));
+        probes::pio_in!(|| (port, bytes, val, u8::from(handled.is_ok())));
         handled.map(|_| val)
     }
 

--- a/lib/propolis/src/vcpu.rs
+++ b/lib/propolis/src/vcpu.rs
@@ -924,17 +924,17 @@ pub mod migrate {
             vcpu.set_run_state(self.run_state, Some(self.sipi_vector))?;
             vcpu.set_reg(
                 vm_reg_name::VM_REG_GUEST_INTR_SHADOW,
-                self.intr_shadow as u64,
+                u64::from(self.intr_shadow),
             )?;
 
             let ents = [
                 vdi_field_entry_v1::new(
                     bhyve_api::VAI_PEND_NMI,
-                    self.pending_nmi as u64,
+                    u64::from(self.pending_nmi),
                 ),
                 vdi_field_entry_v1::new(
                     bhyve_api::VAI_PEND_EXTINT,
-                    self.pending_extint as u64,
+                    u64::from(self.pending_extint),
                 ),
                 vdi_field_entry_v1::new(
                     bhyve_api::VAI_PEND_EXCP,

--- a/lib/propolis/src/vmm/hdl.rs
+++ b/lib/propolis/src/vmm/hdl.rs
@@ -208,7 +208,7 @@ impl VmmHdl {
             segid,
             segoff: segoff as i64,
             len,
-            prot: prot.bits() as i32,
+            prot: i32::from(prot.bits()),
             flags: 0,
         };
         unsafe { self.ioctl(bhyve_api::VM_MMAP_MEMSEG, &mut map) }
@@ -300,13 +300,14 @@ impl VmmHdl {
     }
     /// Writes to the registers within the RTC device.
     pub fn rtc_write(&self, offset: u8, value: u8) -> Result<()> {
-        let mut data = bhyve_api::vm_rtc_data { offset: offset as i32, value };
+        let mut data =
+            bhyve_api::vm_rtc_data { offset: i32::from(offset), value };
         unsafe { self.ioctl(bhyve_api::VM_RTC_WRITE, &mut data) }
     }
     /// Reads from the registers within the RTC device.
     pub fn rtc_read(&self, offset: u8) -> Result<u8> {
         let mut data =
-            bhyve_api::vm_rtc_data { offset: offset as i32, value: 0 };
+            bhyve_api::vm_rtc_data { offset: i32::from(offset), value: 0 };
         unsafe {
             self.ioctl(bhyve_api::VM_RTC_READ, &mut data)?;
         }
@@ -323,8 +324,8 @@ impl VmmHdl {
         ioapic_irq: Option<u8>,
     ) -> Result<()> {
         let mut data = bhyve_api::vm_isa_irq {
-            atpic_irq: pic_irq as i32,
-            ioapic_irq: ioapic_irq.map(|x| x as i32).unwrap_or(-1),
+            atpic_irq: i32::from(pic_irq),
+            ioapic_irq: ioapic_irq.map(i32::from).unwrap_or(-1),
         };
         unsafe { self.ioctl(bhyve_api::VM_ISA_ASSERT_IRQ, &mut data) }
     }
@@ -335,8 +336,8 @@ impl VmmHdl {
         ioapic_irq: Option<u8>,
     ) -> Result<()> {
         let mut data = bhyve_api::vm_isa_irq {
-            atpic_irq: pic_irq as i32,
-            ioapic_irq: ioapic_irq.map(|x| x as i32).unwrap_or(-1),
+            atpic_irq: i32::from(pic_irq),
+            ioapic_irq: ioapic_irq.map(i32::from).unwrap_or(-1),
         };
         unsafe { self.ioctl(bhyve_api::VM_ISA_DEASSERT_IRQ, &mut data) }
     }
@@ -347,8 +348,8 @@ impl VmmHdl {
         ioapic_irq: Option<u8>,
     ) -> Result<()> {
         let mut data = bhyve_api::vm_isa_irq {
-            atpic_irq: pic_irq as i32,
-            ioapic_irq: ioapic_irq.map(|x| x as i32).unwrap_or(-1),
+            atpic_irq: i32::from(pic_irq),
+            ioapic_irq: ioapic_irq.map(i32::from).unwrap_or(-1),
         };
         unsafe { self.ioctl(bhyve_api::VM_ISA_PULSE_IRQ, &mut data) }
     }
@@ -359,7 +360,7 @@ impl VmmHdl {
         level_mode: bool,
     ) -> Result<()> {
         let mut data = bhyve_api::vm_isa_irq_trigger {
-            atpic_irq: vec as i32,
+            atpic_irq: i32::from(vec),
             trigger: if level_mode { 1 } else { 0 },
         };
         unsafe { self.ioctl(bhyve_api::VM_ISA_SET_IRQ_TRIGGER, &mut data) }
@@ -367,17 +368,17 @@ impl VmmHdl {
 
     #[allow(unused)]
     pub fn ioapic_assert_irq(&self, irq: u8) -> Result<()> {
-        let mut data = bhyve_api::vm_ioapic_irq { irq: irq as i32 };
+        let mut data = bhyve_api::vm_ioapic_irq { irq: i32::from(irq) };
         unsafe { self.ioctl(bhyve_api::VM_IOAPIC_ASSERT_IRQ, &mut data) }
     }
     #[allow(unused)]
     pub fn ioapic_deassert_irq(&self, irq: u8) -> Result<()> {
-        let mut data = bhyve_api::vm_ioapic_irq { irq: irq as i32 };
+        let mut data = bhyve_api::vm_ioapic_irq { irq: i32::from(irq) };
         unsafe { self.ioctl(bhyve_api::VM_IOAPIC_DEASSERT_IRQ, &mut data) }
     }
     #[allow(unused)]
     pub fn ioapic_pulse_irq(&self, irq: u8) -> Result<()> {
-        let mut data = bhyve_api::vm_ioapic_irq { irq: irq as i32 };
+        let mut data = bhyve_api::vm_ioapic_irq { irq: i32::from(irq) };
         unsafe { self.ioctl(bhyve_api::VM_IOAPIC_PULSE_IRQ, &mut data) }
     }
     #[allow(unused)]
@@ -458,7 +459,7 @@ impl VmmHdl {
     pub fn set_autodestruct(&self, enable_autodestruct: bool) -> Result<()> {
         self.ioctl_usize(
             bhyve_api::VM_SET_AUTODESTRUCT,
-            enable_autodestruct as usize,
+            usize::from(enable_autodestruct),
         )
     }
 

--- a/lib/propolis/src/vmm/machine.rs
+++ b/lib/propolis/src/vmm/machine.rs
@@ -246,7 +246,7 @@ impl Builder {
             .map(|id| {
                 Vcpu::new(
                     hdl.clone(),
-                    id as i32,
+                    i32::from(id),
                     bus_mmio.clone(),
                     bus_pio.clone(),
                 )

--- a/lib/propolis/src/vmm/mem.rs
+++ b/lib/propolis/src/vmm/mem.rs
@@ -1053,9 +1053,9 @@ pub mod tests {
 
     #[test]
     fn memory_protections_match_libc() {
-        assert_eq!(Prot::READ.bits() as i32, libc::PROT_READ);
-        assert_eq!(Prot::WRITE.bits() as i32, libc::PROT_WRITE);
-        assert_eq!(Prot::EXEC.bits() as i32, libc::PROT_EXEC);
+        assert_eq!(i32::from(Prot::READ.bits()), libc::PROT_READ);
+        assert_eq!(i32::from(Prot::WRITE.bits()), libc::PROT_WRITE);
+        assert_eq!(i32::from(Prot::EXEC.bits()), libc::PROT_EXEC);
     }
 
     #[test]

--- a/lib/propolis/src/vmm/time.rs
+++ b/lib/propolis/src/vmm/time.rs
@@ -269,7 +269,7 @@ pub fn adjust_time_data(
             guest_tsc: new_guest_tsc,
             hrtime: dst_hrt,
             hres_sec: dst_wc.as_secs(),
-            hres_ns: dst_wc.subsec_nanos() as u64,
+            hres_ns: u64::from(dst_wc.subsec_nanos()),
             boot_hrtime: new_boot_hrtime,
         },
         VmTimeDataAdjustments {
@@ -378,7 +378,7 @@ fn calc_tsc_delta(
     let mut tsc_adjust: u128 = 0;
 
     let upper: u128 =
-        delta_ns.checked_mul(guest_hz as u128).ok_or_else(|| {
+        delta_ns.checked_mul(u128::from(guest_hz)).ok_or_else(|| {
             TimeAdjustError::TscAdjustOverflow {
                 desc: "migrate_delta * guest_hz",
                 migrate_delta,
@@ -387,15 +387,16 @@ fn calc_tsc_delta(
             }
         })?;
 
-    tsc_adjust = upper.checked_div(NS_PER_SEC as u128).ok_or_else(|| {
-        TimeAdjustError::TscAdjustOverflow {
-            desc: "upper / NS_PER_SEC",
-            migrate_delta,
-            guest_hz,
-            tsc_adjust,
-        }
-    })?;
-    if tsc_adjust > u64::MAX as u128 {
+    tsc_adjust =
+        upper.checked_div(u128::from(NS_PER_SEC)).ok_or_else(|| {
+            TimeAdjustError::TscAdjustOverflow {
+                desc: "upper / NS_PER_SEC",
+                migrate_delta,
+                guest_hz,
+                tsc_adjust,
+            }
+        })?;
+    if tsc_adjust > u128::from(u64::MAX) {
         return Err(TimeAdjustError::TscAdjustOverflow {
             desc: "tsc_adjust > 64-bits",
             migrate_delta,

--- a/xtask/src/task_clippy.rs
+++ b/xtask/src/task_clippy.rs
@@ -21,6 +21,10 @@ pub(crate) fn cmd_clippy(strict: bool, quiet: bool) -> Result<()> {
 
         // no-deps and subsequent options must follow `--`
         cmd.args(["--", "--no-deps"]);
+
+        // be more strict about lossless casts
+        cmd.args(["--warn", "clippy::cast_lossless"]);
+
         if strict {
             cmd.arg("-Dwarnings");
         }


### PR DESCRIPTION
Following in the footsteps of oxidecomputer/omicron#5544, propolis could be more rigorous about its casts.