### PR TITLE
Generate SMBIOS tables guest consumption

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -859,7 +859,9 @@ impl<'a> MachineInitializer<'a> {
         let smb_type0 = smbios::table::Type0 {
             vendor: "Oxide".try_into().unwrap(),
             bios_version: "v0.8".try_into().unwrap(),
-            bios_release_date: "35 Discord, 3185 YOLD".try_into().unwrap(),
+            bios_release_date: "The Aftermath 30, 3185 YOLD"
+                .try_into()
+                .unwrap(),
             bios_rom_size: ((rom_size / (64 * 1024)) - 1) as u8,
             // Characteristics-not-supported
             bios_characteristics: 0x8,
@@ -957,10 +959,10 @@ impl<'a> MachineInitializer<'a> {
             ..Default::default()
         };
         smb_type16.set_max_capacity(memsize_bytes);
+        let phys_mem_array_handle = 0x1600.into();
 
         let mut smb_type17 = smbios::table::Type17 {
-            // handle for type16 assigned below
-            phys_mem_array_handle: 0x1600.into(),
+            phys_mem_array_handle,
             // Unknown
             form_factor: 0x2,
             // Unknown
@@ -971,11 +973,16 @@ impl<'a> MachineInitializer<'a> {
 
         let smb_type32 = smbios::table::Type32::default();
 
+        // With "only" types 0, 1, 4, 16, 17, and 32, we are technically missing
+        // some (types 3, 7, 9, 19) of the data required by the 2.7 spec.  The
+        // data provided here were what we determined was a reasonable
+        // collection to start with.  Should further requirements arise, we may
+        // expand on it.
         let mut smb_tables = smbios::Tables::new(0x7f00.into());
         smb_tables.add(0x0000.into(), &smb_type0).unwrap();
         smb_tables.add(0x0100.into(), &smb_type1).unwrap();
         smb_tables.add(0x0300.into(), &smb_type4).unwrap();
-        smb_tables.add(0x1600.into(), &smb_type16).unwrap();
+        smb_tables.add(phys_mem_array_handle, &smb_type16).unwrap();
         smb_tables.add(0x1700.into(), &smb_type17).unwrap();
         smb_tables.add(0x3200.into(), &smb_type32).unwrap();
 

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -17,9 +17,11 @@ use anyhow::{Context, Result};
 use crucible_client_types::VolumeConstructionRequest;
 pub use nexus_client::Client as NexusClient;
 use oximeter::types::ProducerRegistry;
+
 use propolis::block;
 use propolis::chardev::{self, BlockingSource, Source};
-use propolis::common::{Lifecycle, PAGE_SIZE};
+use propolis::common::{Lifecycle, GB, MB, PAGE_SIZE};
+use propolis::firmware::smbios;
 use propolis::hw::bhyve::BhyveHpet;
 use propolis::hw::chipset::{i440fx, Chipset};
 use propolis::hw::ibmpc;
@@ -32,14 +34,13 @@ use propolis::hw::{nvme, virtio};
 use propolis::intr_pins;
 use propolis::vmm::{self, Builder, Machine};
 use propolis_api_types::instance_spec::{self, v0::InstanceSpecV0};
+use propolis_api_types::InstanceProperties;
 use slog::info;
 
 // Arbitrary ROM limit for now
 const MAX_ROM_SIZE: usize = 0x20_0000;
 
 fn get_spec_guest_ram_limits(spec: &InstanceSpecV0) -> (usize, usize) {
-    const MB: usize = 1024 * 1024;
-    const GB: usize = 1024 * 1024 * 1024;
     let memsize = spec.devices.board.memory_mb as usize * MB;
     let lowmem = memsize.min(3 * GB);
     let highmem = memsize.saturating_sub(3 * GB);
@@ -101,6 +102,11 @@ struct StorageBackendInstance {
     crucible: Option<(uuid::Uuid, Arc<block::CrucibleBackend>)>,
 }
 
+#[derive(Default)]
+pub struct MachineInitializerState {
+    rom_size_bytes: Option<usize>,
+}
+
 pub struct MachineInitializer<'a> {
     pub(crate) log: slog::Logger,
     pub(crate) machine: &'a Machine,
@@ -108,7 +114,9 @@ pub struct MachineInitializer<'a> {
     pub(crate) block_backends: BlockBackendMap,
     pub(crate) crucible_backends: CrucibleBackendMap,
     pub(crate) spec: &'a InstanceSpecV0,
+    pub(crate) properties: &'a InstanceProperties,
     pub(crate) producer_registry: Option<ProducerRegistry>,
+    pub(crate) state: MachineInitializerState,
 }
 
 impl<'a> MachineInitializer<'a> {
@@ -147,6 +155,7 @@ impl<'a> MachineInitializer<'a> {
             // TODO: Handle short read
             return Err(Error::new(ErrorKind::InvalidData, "short read"));
         }
+        self.state.rom_size_bytes = Some(rom_len);
         Ok(())
     }
 
@@ -842,6 +851,141 @@ impl<'a> MachineInitializer<'a> {
         Ok(())
     }
 
+    fn generate_smbios(&self) -> smbios::TableBytes {
+        use propolis::cpuid;
+
+        let rom_size =
+            self.state.rom_size_bytes.expect("ROM is already populated");
+        let smb_type0 = smbios::table::Type0 {
+            vendor: "Oxide".try_into().unwrap(),
+            bios_version: "v0.8".try_into().unwrap(),
+            bios_release_date: "35 Discord, 3185 YOLD".try_into().unwrap(),
+            bios_rom_size: ((rom_size / (64 * 1024)) - 1) as u8,
+            // Characteristics-not-supported
+            bios_characteristics: 0x8,
+            // ACPI + UEFI + IsVM
+            bios_ext_characteristics: 0x1801,
+            ..Default::default()
+        };
+
+        let smb_type1 = smbios::table::Type1 {
+            manufacturer: "Oxide".try_into().unwrap(),
+            product_name: "OxVM".try_into().unwrap(),
+
+            serial_number: self
+                .properties
+                .id
+                .to_string()
+                .try_into()
+                .unwrap_or_default(),
+            uuid: self.properties.id.to_bytes_le(),
+
+            // power switch
+            wake_up_type: 0x06,
+            ..Default::default()
+        };
+
+        // Once CPUID profiles are integrated, these will need to take that into
+        // account, rather than blindly querying from the host
+        let cpuid_vendor = cpuid::host_query(cpuid::Ident(0x0, None));
+        let cpuid_ident = cpuid::host_query(cpuid::Ident(0x1, None));
+        let cpuid_procname = [
+            cpuid::host_query(cpuid::Ident(0x8000_0002, None)),
+            cpuid::host_query(cpuid::Ident(0x8000_0003, None)),
+            cpuid::host_query(cpuid::Ident(0x8000_0004, None)),
+        ];
+
+        let family = match cpuid_ident.eax & 0xf00 {
+            // If family ID is 0xf, extended family is added to it
+            0xf00 => (cpuid_ident.eax >> 20 & 0xff) + 0xf,
+            // ... otherwise base family ID is used
+            base => base >> 8,
+        };
+
+        let vendor = cpuid::VendorKind::try_from(cpuid_vendor);
+        let proc_manufacturer = match vendor {
+            Ok(cpuid::VendorKind::Intel) => "Intel",
+            Ok(cpuid::VendorKind::Amd) => "Advanced Micro Devices, Inc.",
+            _ => "",
+        }
+        .try_into()
+        .unwrap();
+        let proc_family = match (vendor, family) {
+            // Explicitly match for Zen-based CPUs
+            //
+            // Although this family identifier is not valid in SMBIOS 2.7,
+            // having been defined in 3.x, we pass it through anyways.
+            (Ok(cpuid::VendorKind::Amd), family) if family >= 0x17 => 0x6b,
+
+            // Emit Unknown for everything else
+            _ => 0x2,
+        };
+        let proc_id =
+            u64::from(cpuid_ident.eax) | u64::from(cpuid_ident.edx) << 32;
+        let proc_version =
+            cpuid::parse_brand_string(cpuid_procname).unwrap_or("".to_string());
+
+        let smb_type4 = smbios::table::Type4 {
+            // central processor
+            proc_type: 0x03,
+            proc_family,
+            proc_manufacturer,
+            proc_id,
+            proc_version: proc_version.try_into().unwrap_or_default(),
+            // cpu enabled, socket populated
+            status: 0x41,
+            // unknown
+            proc_upgrade: 0x2,
+            // make core and thread counts equal for now
+            core_count: self.properties.vcpus,
+            core_enabled: self.properties.vcpus,
+            thread_count: self.properties.vcpus,
+            // 64-bit capable, multicore
+            proc_characteristics: 0xc,
+            ..Default::default()
+        };
+
+        let memsize_bytes = (self.properties.memory as usize) * MB;
+        let mut smb_type16 = smbios::table::Type16 {
+            // system board
+            location: 0x3,
+            // system memory
+            array_use: 0x3,
+            // unknown
+            error_correction: 0x2,
+            num_mem_devices: 1,
+            ..Default::default()
+        };
+        smb_type16.set_max_capacity(memsize_bytes);
+
+        let mut smb_type17 = smbios::table::Type17 {
+            // handle for type16 assigned below
+            phys_mem_array_handle: 0x1600.into(),
+            // Unknown
+            form_factor: 0x2,
+            // Unknown
+            memory_type: 0x2,
+            ..Default::default()
+        };
+        smb_type17.set_size(Some(memsize_bytes));
+
+        let smb_type32 = smbios::table::Type32::default();
+
+        let mut smb_tables = smbios::Tables::new(0x7f00.into());
+        smb_tables.add(0x0000.into(), &smb_type0).unwrap();
+        smb_tables.add(0x0100.into(), &smb_type1).unwrap();
+        smb_tables.add(0x0300.into(), &smb_type4).unwrap();
+        smb_tables.add(0x1600.into(), &smb_type16).unwrap();
+        smb_tables.add(0x1700.into(), &smb_type17).unwrap();
+        smb_tables.add(0x3200.into(), &smb_type32).unwrap();
+
+        smb_tables.commit()
+    }
+
+    /// Initialize qemu `fw_cfg` device, and populate it with data including CPU
+    /// count, SMBIOS tables, and attached RAM-FB device.
+    ///
+    /// Should not be called before [`Self::initialize_rom()`].
     pub fn initialize_fwcfg(
         &mut self,
         cpus: u8,
@@ -851,6 +995,21 @@ impl<'a> MachineInitializer<'a> {
             .add_legacy(
                 fwcfg::LegacyId::SmpCpuCount,
                 fwcfg::FixedItem::new_u32(u32::from(cpus)),
+            )
+            .unwrap();
+
+        let smbios::TableBytes { entry_point, structure_table } =
+            self.generate_smbios();
+        fwcfg
+            .add_named(
+                "etc/smbios/smbios-tables",
+                fwcfg::FixedItem::new_raw(structure_table),
+            )
+            .unwrap();
+        fwcfg
+            .add_named(
+                "etc/smbios/smbios-anchor",
+                fwcfg::FixedItem::new_raw(entry_point),
             )
             .unwrap();
 

--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -62,7 +62,9 @@ use tokio_tungstenite::WebSocketStream;
 use uuid::Uuid;
 
 use crate::{
-    initializer::{build_instance, MachineInitializer},
+    initializer::{
+        build_instance, MachineInitializer, MachineInitializerState,
+    },
     migrate::{self, MigrateError},
     serial::Serial,
     server::{BlockBackendMap, CrucibleBackendMap, DeviceMap, StaticConfig},
@@ -453,7 +455,9 @@ impl VmController {
             block_backends: BlockBackendMap::new(),
             crucible_backends: CrucibleBackendMap::new(),
             spec: v0_spec,
+            properties: &properties,
             producer_registry,
+            state: MachineInitializerState::default(),
         };
 
         init.initialize_rom(bootrom.as_path())?;

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -815,7 +815,7 @@ fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
     let smb_type0 = smbios::table::Type0 {
         vendor: "Oxide".try_into().unwrap(),
         bios_version: "v0.0.1 alpha1".try_into().unwrap(),
-        bios_release_date: "40 Discord, 3190 YOLD".try_into().unwrap(),
+        bios_release_date: "Bureaucracy 41, 3186 YOLD".try_into().unwrap(),
         bios_rom_size: ((params.rom_size / (64 * 1024)) - 1) as u8,
         // Characteristics-not-supported
         bios_characteristics: 0x8,
@@ -905,10 +905,10 @@ fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
         ..Default::default()
     };
     smb_type16.set_max_capacity(params.memory_size);
+    let phys_mem_array_handle = 0x1600.into();
 
     let mut smb_type17 = smbios::table::Type17 {
-        // handle for type16 assigned below
-        phys_mem_array_handle: 0x1600.into(),
+        phys_mem_array_handle,
         // Unknown
         form_factor: 0x2,
         // Unknown
@@ -923,11 +923,10 @@ fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
     smb_tables.add(0x0000.into(), &smb_type0).unwrap();
     smb_tables.add(0x0100.into(), &smb_type1).unwrap();
     smb_tables.add(0x0300.into(), &smb_type4).unwrap();
-    smb_tables.add(0x1600.into(), &smb_type16).unwrap();
+    smb_tables.add(phys_mem_array_handle, &smb_type16).unwrap();
     smb_tables.add(0x1700.into(), &smb_type17).unwrap();
     smb_tables.add(0x3200.into(), &smb_type32).unwrap();
 
-    //let (smb_ep_bytes, smb_table_bytes) = smb_tables.commit();
     Ok(smb_tables.commit())
 }
 

--- a/bin/propolis-standalone/src/snapshot.rs
+++ b/bin/propolis-standalone/src/snapshot.rs
@@ -25,7 +25,7 @@ use bhyve_api::{
 };
 use propolis::{
     chardev::UDSock,
-    common::{GuestAddr, GuestRegion},
+    common::{GuestAddr, GuestRegion, GB},
     migrate::{
         MigrateCtx, Migrator, PayloadOffer, PayloadOffers, PayloadOutputs,
     },
@@ -160,7 +160,6 @@ pub(crate) fn save(
 
     // TODO(luqmana) clean this up. make mem_bounds do the lo/hi calc? or just
     // use config values?
-    const GB: usize = 1024 * 1024 * 1024;
     let mem_bounds = memctx
         .mem_bounds()
         .ok_or_else(|| anyhow::anyhow!("Failed to get VM RAM bounds"))?;

--- a/lib/propolis/src/common.rs
+++ b/lib/propolis/src/common.rs
@@ -378,6 +378,15 @@ pub fn round_up_p2(val: usize, to: usize) -> usize {
     val.checked_add(to - 1).unwrap() & !(to - 1)
 }
 
+/// Bytes per KiB
+pub const KB: usize = 1024;
+/// Bytes per MiB
+pub const MB: usize = 1024 * 1024;
+/// Bytes per GiB
+pub const GB: usize = 1024 * 1024 * 1024;
+/// Bytes per TiB
+pub const TB: usize = 1024 * 1024 * 1024 * 1024;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/propolis/src/firmware/mod.rs
+++ b/lib/propolis/src/firmware/mod.rs
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+pub mod smbios;

--- a/lib/propolis/src/firmware/smbios/bits.rs
+++ b/lib/propolis/src/firmware/smbios/bits.rs
@@ -1,0 +1,377 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::mem::size_of;
+
+const ANCHOR: [u8; 4] = [b'_', b'S', b'M', b'_'];
+const IANCHOR: [u8; 5] = [b'_', b'D', b'M', b'I', b'_'];
+
+/// Each SMBIOS table is expected to terminate with a double-NUL
+pub const TABLE_TERMINATOR: [u8; 2] = [0, 0];
+
+/// SMBIOS Structure Table Entry Point
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+pub(crate) struct EntryPoint {
+    /// Anchor String (_SM_)
+    pub anchor: [u8; 4],
+    /// Entry Point Structure Checksum
+    pub ep_checksum: u8,
+    /// Entry Point Length
+    pub ep_length: u8,
+    /// SMBIOS Major Version
+    pub major_version: u8,
+    /// SMBIOS Minor Version
+    pub minor_version: u8,
+    /// Maximum Structure Size
+    pub max_struct_sz: u16,
+    /// Entry Point Revision
+    pub ep_revision: u8,
+    /// Formatted Area
+    pub formatted_area: [u8; 5],
+    /// Intermediate Anchor (_DMI_)
+    pub intermed_anchor: [u8; 5],
+    /// Intermediate Checksum
+    pub intermed_checksum: u8,
+    /// Structure Table Length
+    pub table_length: u16,
+    /// Structure Table Address
+    pub table_address: u32,
+    /// Number of SMBIOS Structures
+    pub num_structs: u16,
+    /// SMBIOS BCD Revision
+    pub bcd_revision: u8,
+}
+impl EntryPoint {
+    pub(crate) fn new() -> Self {
+        Self {
+            anchor: ANCHOR,
+            ep_checksum: 0,
+            ep_length: 0,
+            major_version: 0,
+            minor_version: 0,
+            max_struct_sz: 0,
+            ep_revision: 0,
+            formatted_area: [0, 0, 0, 0, 0],
+            intermed_anchor: IANCHOR,
+            intermed_checksum: 0,
+            table_length: 0,
+            table_address: 0,
+            num_structs: 0,
+            bcd_revision: 0,
+        }
+    }
+    pub(crate) fn update_cksums(&mut self) {
+        self.ep_checksum = 0;
+        self.intermed_checksum = 0;
+        let isum = self.to_raw_bytes()[0x10..]
+            .iter()
+            .fold(0u8, |sum, item| sum.wrapping_add(*item));
+        self.intermed_checksum = (!isum).wrapping_add(1);
+
+        let sum = self
+            .to_raw_bytes()
+            .iter()
+            .fold(0u8, |sum, item| sum.wrapping_add(*item));
+        self.ep_checksum = (!sum).wrapping_add(1);
+    }
+    pub(crate) fn to_raw_bytes(&self) -> &[u8] {
+        unsafe {
+            std::slice::from_raw_parts(
+                self as *const Self as *const u8,
+                size_of::<Self>(),
+            )
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+pub(crate) struct StructureHeader {
+    pub stype: u8,
+    pub length: u8,
+    pub handle: u16,
+}
+
+macro_rules! raw_table_impl {
+    ($type_name:ident, $type_val:literal) => {
+        unsafe impl RawTable for $type_name {
+            const TYPE: u8 = $type_val;
+            fn header_mut(&mut self) -> &mut StructureHeader {
+                &mut self.header
+            }
+        }
+    };
+}
+
+/// Type 0 (BIOS Information) - Version 2.7
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+pub(crate) struct Type0 {
+    pub header: StructureHeader,
+    pub vendor: u8,
+    pub bios_version: u8,
+    pub bios_starting_seg_addr: u16,
+    pub bios_release_date: u8,
+    pub bios_rom_size: u8,
+    pub bios_characteristics: u64,
+    pub bios_ext_characteristics: u16,
+    pub bios_major_release: u8,
+    pub bios_minor_release: u8,
+    pub ec_firmware_major_rel: u8,
+    pub ec_firmware_minor_rel: u8,
+}
+raw_table_impl!(Type0, 0);
+
+/// Type 1 (System Information) - Version 2.7
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+pub(crate) struct Type1 {
+    pub header: StructureHeader,
+    pub manufacturer: u8,
+    pub product_name: u8,
+    pub version: u8,
+    pub serial_number: u8,
+    pub uuid: [u8; 16],
+    pub wake_up_type: u8,
+    pub sku_number: u8,
+    pub family: u8,
+}
+raw_table_impl!(Type1, 1);
+
+/// Type 2 (Baseboard Information)
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+pub(crate) struct Type2 {
+    pub header: StructureHeader,
+    pub manufacturer: u8,
+    pub product: u8,
+    pub version: u8,
+    pub serial_number: u8,
+    pub asset_tag: u8,
+    pub feature_flags: u8,
+    pub location_in_chassis: u8,
+    pub chassis_handle: u16,
+    pub board_type: u8,
+    pub number_obj_handles: u8,
+    pub obj_handles: [u16; 0],
+}
+raw_table_impl!(Type2, 2);
+
+/// Type 3 (System Enclosure) - Version 2.7
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+pub(crate) struct Type3 {
+    pub header: StructureHeader,
+    pub manufacturer: u8,
+    pub stype: u8,
+    pub version: u8,
+    pub serial_number: u8,
+    pub asset_tag: u8,
+    pub bootup_state: u8,
+    pub psu_state: u8,
+    pub thermal_state: u8,
+    pub security_status: u8,
+    pub oem_defined: u32,
+    pub height: u8,
+    pub num_cords: u8,
+    pub contained_elem_count: u8,
+    pub contained_elem_len: u8,
+}
+raw_table_impl!(Type3, 3);
+
+/// Type 4 (Processor Information) - Version 2.7
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+pub(crate) struct Type4 {
+    pub header: StructureHeader,
+    pub socket_designation: u8,
+    pub proc_type: u8,
+    pub proc_family: u8,
+    pub proc_manufacturer: u8,
+    pub proc_id: u64,
+    pub proc_version: u8,
+    pub voltage: u8,
+    pub external_clock: u16,
+    pub max_speed: u16,
+    pub current_speed: u16,
+    pub status: u8,
+    pub proc_upgrade: u8,
+    pub l1_cache_handle: u16,
+    pub l2_cache_handle: u16,
+    pub l3_cache_handle: u16,
+    pub serial_number: u8,
+    pub asset_tag: u8,
+    pub part_number: u8,
+    pub core_count: u8,
+    pub core_enabled: u8,
+    pub thread_count: u8,
+    pub proc_characteristics: u16,
+    pub proc_family2: u16,
+}
+raw_table_impl!(Type4, 4);
+
+/// Type 16 (Physical Memory Array) - Version 2.7
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+pub(crate) struct Type16 {
+    pub header: StructureHeader,
+    pub location: u8,
+    pub array_use: u8,
+    pub error_correction: u8,
+    pub max_capacity: u32,
+    pub error_info_handle: u16,
+    pub num_mem_devices: u16,
+    pub extended_max_capacity: u64,
+}
+raw_table_impl!(Type16, 16);
+
+/// Type 17 (Memory Device) - Version 2.7
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+pub(crate) struct Type17 {
+    pub header: StructureHeader,
+    pub phys_mem_array_handle: u16,
+    pub mem_err_info_handle: u16,
+    pub total_width: u16,
+    pub data_width: u16,
+    pub size: u16,
+    pub form_factor: u8,
+    pub device_set: u8,
+    pub device_locator: u8,
+    pub bank_locator: u8,
+    pub memory_type: u8,
+    pub type_detail: u16,
+    pub speed: u16,
+    pub manufacturer: u8,
+    pub serial_number: u8,
+    pub asset_tag: u8,
+    pub part_number: u8,
+    pub attributes: u8,
+    pub extended_size: u32,
+    pub cfgd_mem_clock_speed: u16,
+    pub min_voltage: u16,
+    pub max_voltage: u16,
+    pub cfgd_voltage: u16,
+}
+raw_table_impl!(Type17, 17);
+
+/// Type 32 (System Boot Information) - Version 2.7
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+pub(crate) struct Type32 {
+    pub header: StructureHeader,
+    pub reserved: [u8; 6],
+    pub boot_status: [u8; 0],
+}
+raw_table_impl!(Type32, 32);
+
+/// Type 127 (End-of-Table)
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+pub(crate) struct Type127 {
+    pub header: StructureHeader,
+}
+raw_table_impl!(Type127, 127);
+
+pub(crate) unsafe trait RawTable: Sized {
+    const TYPE: u8;
+
+    fn new(handle: u16) -> Self {
+        // Safety: All of these structs are repr(C,packed) with no padding,
+        // and thus safe to initialize as zeroed.
+        let mut data =
+            unsafe { std::mem::MaybeUninit::<Self>::zeroed().assume_init() };
+
+        let header = data.header_mut();
+        header.stype = Self::TYPE;
+        header.length = size_of::<Self>() as u8;
+        header.handle = handle;
+
+        data
+    }
+
+    fn header_mut(&mut self) -> &mut StructureHeader;
+
+    fn to_raw_bytes(&self) -> &[u8] {
+        unsafe {
+            std::slice::from_raw_parts(
+                self as *const Self as *const u8,
+                size_of::<Self>(),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::mem::size_of;
+
+    #[test]
+    fn entry_point() {
+        assert_eq!(size_of::<EntryPoint>(), 0x1f);
+    }
+    #[test]
+    fn struct_header() {
+        assert_eq!(size_of::<StructureHeader>(), 0x4);
+    }
+
+    #[test]
+    fn bios_information() {
+        assert_eq!(size_of::<Type0>(), 0x18);
+        let data = Type0::new(0xfffe);
+        let data_raw = data.to_raw_bytes();
+        assert_eq!(data_raw[0], 0, "type byte incorrect")
+    }
+    #[test]
+    fn system_information() {
+        assert_eq!(size_of::<Type1>(), 0x1b);
+        let data = Type1::new(0xfffe);
+        let data_raw = data.to_raw_bytes();
+        assert_eq!(data_raw[0], 1, "type byte incorrect")
+    }
+    #[test]
+    fn baseboard_information() {
+        assert_eq!(size_of::<Type2>(), 0xf);
+        let data = Type2::new(0xfffe);
+        let data_raw = data.to_raw_bytes();
+        assert_eq!(data_raw[0], 2, "type byte incorrect")
+    }
+    #[test]
+    fn system_enclosure() {
+        assert_eq!(size_of::<Type3>(), 0x15);
+        let data = Type2::new(0xfffe);
+        let data_raw = data.to_raw_bytes();
+        assert_eq!(data_raw[0], 2, "type byte incorrect")
+    }
+    #[test]
+    fn processor_information() {
+        assert_eq!(size_of::<Type4>(), 0x2a);
+        let data = Type3::new(0xfffe);
+        let data_raw = data.to_raw_bytes();
+        assert_eq!(data_raw[0], 3, "type byte incorrect")
+    }
+    #[test]
+    fn physical_memory_array() {
+        assert_eq!(size_of::<Type16>(), 0x17);
+        let data = Type16::new(0xfffe);
+        let data_raw = data.to_raw_bytes();
+        assert_eq!(data_raw[0], 16, "type byte incorrect")
+    }
+    #[test]
+    fn memory_device() {
+        assert_eq!(size_of::<Type17>(), 0x28);
+        let data = Type17::new(0xfffe);
+        let data_raw = data.to_raw_bytes();
+        assert_eq!(data_raw[0], 17, "type byte incorrect")
+    }
+    #[test]
+    fn system_boot_information() {
+        assert_eq!(size_of::<Type32>(), 0xa);
+        let data = Type32::new(0xfffe);
+        let data_raw = data.to_raw_bytes();
+        assert_eq!(data_raw[0], 32, "type byte incorrect")
+    }
+}

--- a/lib/propolis/src/firmware/smbios/mod.rs
+++ b/lib/propolis/src/firmware/smbios/mod.rs
@@ -121,7 +121,7 @@ impl Handle {
 }
 impl fmt::Display for Handle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.0, f)
+        fmt::LowerHex::fmt(&self.0, f)
     }
 }
 /// Default to the Unknown handle

--- a/lib/propolis/src/firmware/smbios/mod.rs
+++ b/lib/propolis/src/firmware/smbios/mod.rs
@@ -1,0 +1,198 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use table::{Table, Type127};
+
+mod bits;
+pub mod table;
+
+/// Collection of SMBIOS [table](table) instances, which will be rendered out
+/// into two blocks of raw bytes representing the SMBIOS Entry Point and
+/// SMBIOS Structure Table.
+pub struct Tables {
+    tables: BTreeMap<Handle, Vec<u8>>,
+    total_size: usize,
+    max_single_size: usize,
+    eot_handle: Handle,
+}
+impl Tables {
+    /// Create a new [Tables] collection.
+    ///
+    /// # Arguments
+    /// - `eot_handle`: [Handle] for the automatically-added
+    /// [end-of-table](table::Type127) structure, which must terminate the
+    /// Structure Table.
+    pub fn new(eot_handle: Handle) -> Self {
+        let mut this = Self {
+            tables: BTreeMap::new(),
+            total_size: 0,
+            max_single_size: 0,
+            eot_handle,
+        };
+        this.add(eot_handle, &Type127::default()).unwrap();
+
+        this
+    }
+
+    /// Add a [Table] to this collection
+    ///
+    /// # Arguments
+    /// - `handle`: SMBIOS [Handle] to identify this table
+    /// - `table`: [Table] to be added
+    pub fn add(
+        &mut self,
+        handle: Handle,
+        table: &dyn Table,
+    ) -> Result<(), TableError> {
+        let table_bytes = table.render(handle);
+        let table_size = table_bytes.len();
+        assert!(table_size != 0, "table should not be zero-length");
+
+        if let Some(conflict) = self.tables.insert(handle, table_bytes) {
+            // replace the item which we conflicted with in the first place
+            let _ = self.tables.insert(handle, conflict);
+            Err(TableError::HandleConflict(handle))
+        } else {
+            self.total_size += table_size;
+            self.max_single_size = usize::max(self.max_single_size, table_size);
+            Ok(())
+        }
+    }
+
+    /// Build Entry Point structure.  Emits the raw-byte values of both the
+    /// Entry Point and the associated Structure Table data.
+    pub fn commit(self) -> TableBytes {
+        let mut data = bits::EntryPoint::new();
+        // hardcode to version 2.7 for now
+        data.major_version = 2;
+        data.minor_version = 7;
+        data.bcd_revision = 0x27;
+        data.table_length = self.total_size as u16;
+        data.num_structs = self.tables.len() as u16;
+        data.max_struct_sz = self.max_single_size as u16;
+        data.update_cksums();
+
+        let mut table_data = Vec::with_capacity(self.total_size);
+        for (handle, table) in self.tables.iter() {
+            // copy all non-EoT tables
+            if *handle != self.eot_handle {
+                table_data.extend_from_slice(table);
+            }
+        }
+        // end-of-table goes at the end
+        table_data.extend_from_slice(
+            self.tables.get(&self.eot_handle).expect("EoT entry is present"),
+        );
+
+        TableBytes {
+            entry_point: data.to_raw_bytes().to_vec(),
+            structure_table: table_data,
+        }
+    }
+}
+
+pub struct TableBytes {
+    pub entry_point: Vec<u8>,
+    pub structure_table: Vec<u8>,
+}
+
+/// Possible errors when adding [Table] entries to [Tables]
+#[derive(thiserror::Error, Debug)]
+pub enum TableError {
+    #[error("Conflicting handle {0}")]
+    HandleConflict(Handle),
+}
+
+/// Structure Handle
+///
+/// A 16-bit number used to uniquely identify a single structure in a collection
+/// of SMBIOS tables.
+///
+/// Defaults to 0xffff, which is considered "Unknown" in most SMBIOS tables.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Ord, PartialOrd)]
+#[repr(transparent)]
+pub struct Handle(pub u16);
+impl Handle {
+    pub const UNKNOWN: Self = Self(0xffff);
+}
+impl fmt::Display for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+/// Default to the Unknown handle
+impl Default for Handle {
+    fn default() -> Self {
+        Self::UNKNOWN
+    }
+}
+impl From<u16> for Handle {
+    fn from(value: u16) -> Self {
+        Self(value)
+    }
+}
+impl From<Handle> for u16 {
+    fn from(value: Handle) -> Self {
+        value.0
+    }
+}
+
+/// SMBIOS-compatible string
+///
+/// Strings associated with an SMBIOS table are NUL-terminated, and concatenated
+/// together directly following the formatted area of the table.  The
+/// [tables](table) string data accept this type in order to expedite proper
+/// formatting when they are rendered to raw bytes.
+#[derive(Default, Clone)]
+pub struct SmbString(Vec<u8>);
+impl SmbString {
+    pub const fn empty() -> Self {
+        Self(Vec::new())
+    }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+impl AsRef<[u8]> for SmbString {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+impl TryFrom<Vec<u8>> for SmbString {
+    type Error = SmbStringNulError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        if value.iter().any(|b| *b == 0) {
+            Err(SmbStringNulError())
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+impl TryFrom<&str> for SmbString {
+    type Error = SmbStringNulError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::try_from(value.to_owned().into_bytes())
+    }
+}
+impl TryFrom<String> for SmbString {
+    type Error = SmbStringNulError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_from(value.into_bytes())
+    }
+}
+
+/// Error emitted when attempting to convert data bearing a NUL into a
+/// [SmbString]
+#[derive(thiserror::Error, Debug)]
+#[error("String contains NUL byte")]
+pub struct SmbStringNulError();

--- a/lib/propolis/src/firmware/smbios/table.rs
+++ b/lib/propolis/src/firmware/smbios/table.rs
@@ -1,0 +1,374 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::common::*;
+use crate::firmware::smbios::bits::{self, RawTable};
+use crate::firmware::smbios::{Handle, SmbString};
+
+pub trait Table {
+    fn render(&self, handle: Handle) -> Vec<u8>;
+}
+
+#[derive(Default)]
+pub struct Type0 {
+    pub vendor: SmbString,
+    pub bios_version: SmbString,
+    pub bios_starting_seg_addr: u16,
+    pub bios_release_date: SmbString,
+    pub bios_rom_size: u8,
+    pub bios_characteristics: u64,
+    pub bios_ext_characteristics: u16,
+    pub bios_major_release: u8,
+    pub bios_minor_release: u8,
+    pub ec_firmware_major_rel: u8,
+    pub ec_firmware_minor_rel: u8,
+}
+impl Table for Type0 {
+    fn render(&self, handle: Handle) -> Vec<u8> {
+        let mut stab = StringTable::new();
+        let data = bits::Type0 {
+            vendor: stab.add(&self.vendor),
+            bios_version: stab.add(&self.bios_version),
+            bios_starting_seg_addr: self.bios_starting_seg_addr,
+            bios_release_date: stab.add(&self.bios_release_date),
+            bios_rom_size: self.bios_rom_size,
+            bios_characteristics: self.bios_characteristics,
+            bios_ext_characteristics: self.bios_ext_characteristics,
+            bios_major_release: self.bios_major_release,
+            bios_minor_release: self.bios_minor_release,
+            ec_firmware_major_rel: self.ec_firmware_major_rel,
+            ec_firmware_minor_rel: self.ec_firmware_minor_rel,
+            ..bits::Type0::new(handle.into())
+        };
+
+        render_table(data, None, Some(stab))
+    }
+}
+
+#[derive(Default)]
+pub struct Type1 {
+    pub manufacturer: SmbString,
+    pub product_name: SmbString,
+    pub version: SmbString,
+    pub serial_number: SmbString,
+    pub uuid: [u8; 16],
+    pub wake_up_type: u8,
+    pub sku_number: SmbString,
+    pub family: SmbString,
+}
+impl Table for Type1 {
+    fn render(&self, handle: Handle) -> Vec<u8> {
+        let mut stab = StringTable::new();
+        let data = bits::Type1 {
+            manufacturer: stab.add(&self.manufacturer),
+            product_name: stab.add(&self.product_name),
+            version: stab.add(&self.version),
+            serial_number: stab.add(&self.serial_number),
+            uuid: self.uuid,
+            wake_up_type: self.wake_up_type,
+            sku_number: stab.add(&self.sku_number),
+            family: stab.add(&self.family),
+            ..bits::Type1::new(handle.into())
+        };
+
+        render_table(data, None, Some(stab))
+    }
+}
+
+#[derive(Default)]
+pub struct Type4 {
+    pub socket_designation: SmbString,
+    pub proc_type: u8,
+    pub proc_family: u8,
+    pub proc_manufacturer: SmbString,
+    pub proc_id: u64,
+    pub proc_version: SmbString,
+    pub voltage: u8,
+    pub external_clock: u16,
+    pub max_speed: u16,
+    pub current_speed: u16,
+    pub status: u8,
+    pub proc_upgrade: u8,
+    pub l1_cache_handle: Handle,
+    pub l2_cache_handle: Handle,
+    pub l3_cache_handle: Handle,
+    pub serial_number: SmbString,
+    pub asset_tag: SmbString,
+    pub part_number: SmbString,
+    pub core_count: u8,
+    pub core_enabled: u8,
+    pub thread_count: u8,
+    pub proc_characteristics: u16,
+    pub proc_family2: u16,
+}
+impl Type4 {
+    pub fn set_family(&mut self, family: u16) {
+        if family > 0xff {
+            self.proc_family = 0xfe;
+            self.proc_family2 = family;
+        } else {
+            self.proc_family = family as u8;
+            self.proc_family2 = 0;
+        }
+    }
+}
+impl Table for Type4 {
+    fn render(&self, handle: Handle) -> Vec<u8> {
+        let mut stab = StringTable::new();
+        let data = bits::Type4 {
+            socket_designation: stab.add(&self.socket_designation),
+            proc_type: self.proc_type,
+            proc_family: self.proc_family,
+            proc_manufacturer: stab.add(&self.proc_manufacturer),
+            proc_id: self.proc_id,
+            proc_version: stab.add(&self.proc_version),
+            voltage: self.voltage,
+            external_clock: self.external_clock,
+            max_speed: self.max_speed,
+            current_speed: self.current_speed,
+            status: self.status,
+            proc_upgrade: self.proc_upgrade,
+            l1_cache_handle: self.l1_cache_handle.into(),
+            l2_cache_handle: self.l2_cache_handle.into(),
+            l3_cache_handle: self.l3_cache_handle.into(),
+            serial_number: stab.add(&self.serial_number),
+            asset_tag: stab.add(&self.asset_tag),
+            part_number: stab.add(&self.part_number),
+            core_count: self.core_count,
+            core_enabled: self.core_enabled,
+            thread_count: self.thread_count,
+            proc_characteristics: self.proc_characteristics,
+            proc_family2: self.proc_family2,
+            ..bits::Type4::new(handle.into())
+        };
+        render_table(data, None, Some(stab))
+    }
+}
+
+#[derive(Default)]
+pub struct Type16 {
+    pub location: u8,
+    pub array_use: u8,
+    pub error_correction: u8,
+    pub max_capacity: u32,
+    pub error_info_handle: Handle,
+    pub num_mem_devices: u16,
+    pub extended_max_capacity: u64,
+}
+impl Type16 {
+    pub fn set_max_capacity(&mut self, capacity_bytes: usize) {
+        let capacity_kib = capacity_bytes / KB;
+
+        if capacity_bytes >= (2 * TB) {
+            self.max_capacity = 0x8000_0000;
+            self.extended_max_capacity = capacity_kib as u64;
+        } else {
+            self.max_capacity = capacity_kib as u32;
+        }
+    }
+}
+impl Table for Type16 {
+    fn render(&self, handle: Handle) -> Vec<u8> {
+        let data = bits::Type16 {
+            location: self.location,
+            array_use: self.array_use,
+            error_correction: self.error_correction,
+            max_capacity: self.max_capacity,
+            error_info_handle: self.error_info_handle.into(),
+            num_mem_devices: self.num_mem_devices,
+            extended_max_capacity: self.extended_max_capacity,
+            ..bits::Type16::new(handle.into())
+        };
+        render_table(data, None, None)
+    }
+}
+
+#[derive(Default)]
+pub struct Type17 {
+    pub phys_mem_array_handle: Handle,
+    pub mem_err_info_handle: Handle,
+    pub total_width: u16,
+    pub data_width: u16,
+    pub size: u16,
+    pub form_factor: u8,
+    pub device_set: u8,
+    pub device_locator: SmbString,
+    pub bank_locator: SmbString,
+    pub memory_type: u8,
+    pub type_detail: u16,
+    pub speed: u16,
+    pub manufacturer: SmbString,
+    pub serial_number: SmbString,
+    pub asset_tag: SmbString,
+    pub part_number: SmbString,
+    pub attributes: u8,
+    pub extended_size: u32,
+    pub cfgd_mem_clock_speed: u16,
+    pub min_voltage: u16,
+    pub max_voltage: u16,
+    pub cfgd_voltage: u16,
+}
+impl Type17 {
+    pub fn set_size(&mut self, size_bytes: Option<usize>) {
+        match size_bytes {
+            None => {
+                self.size = 0xffff;
+                self.extended_size = 0;
+            }
+            // size <= 32GiB - 1MiB does not need extended_size
+            Some(n) if n < (32767 * MB) => {
+                self.size = (n / MB) as u16;
+            }
+            Some(n) => {
+                self.size = 0x7fff;
+                self.extended_size = (n / MB) as u32;
+            }
+        }
+    }
+}
+impl Table for Type17 {
+    fn render(&self, handle: Handle) -> Vec<u8> {
+        let mut stab = StringTable::new();
+        let data = bits::Type17 {
+            phys_mem_array_handle: self.phys_mem_array_handle.into(),
+            mem_err_info_handle: self.mem_err_info_handle.into(),
+            total_width: self.total_width,
+            data_width: self.data_width,
+            size: self.size,
+            form_factor: self.form_factor,
+            device_set: self.device_set,
+            device_locator: stab.add(&self.device_locator),
+            bank_locator: stab.add(&self.bank_locator),
+            memory_type: self.memory_type,
+            type_detail: self.type_detail,
+            speed: self.speed,
+            manufacturer: stab.add(&self.manufacturer),
+            serial_number: stab.add(&self.serial_number),
+            asset_tag: stab.add(&self.asset_tag),
+            part_number: stab.add(&self.part_number),
+            attributes: self.attributes,
+            extended_size: self.extended_size,
+            cfgd_mem_clock_speed: self.cfgd_mem_clock_speed,
+            min_voltage: self.min_voltage,
+            max_voltage: self.max_voltage,
+            cfgd_voltage: self.cfgd_voltage,
+            ..bits::Type17::new(handle.into())
+        };
+
+        render_table(data, None, Some(stab))
+    }
+}
+
+#[derive(Default)]
+pub struct Type32();
+impl Table for Type32 {
+    fn render(&self, handle: Handle) -> Vec<u8> {
+        let data = bits::Type32::new(handle.into());
+
+        // Boot status code for "no errors detected"
+        let boot_status = [0u8];
+
+        render_table(data, Some(&boot_status), None)
+    }
+}
+
+#[derive(Default)]
+pub struct Type127();
+impl Table for Type127 {
+    fn render(&self, handle: Handle) -> Vec<u8> {
+        bits::Type127::new(handle.into()).to_raw_bytes().into()
+    }
+}
+
+/// Render all components of a SMBIOS table into raw bytes
+///
+/// # Arguments
+/// - `raw_table`: [RawTable] instance representing the structure
+/// - `extra_data`: Any data belonging in the formatted area of the structure
+///   which is not already covered by its fields (variable length additions)
+/// - `stab`: [StringTable] of any associated strings
+fn render_table(
+    mut raw_table: impl RawTable,
+    extra_data: Option<&[u8]>,
+    stab: Option<StringTable>,
+) -> Vec<u8> {
+    let extra_data = extra_data.unwrap_or(&[]);
+
+    if extra_data.len() > 0 {
+        let header = raw_table.header_mut();
+        header.length = header
+            .length
+            .checked_add(extra_data.len() as u8)
+            .expect("extra data does not overflow length");
+    }
+    let raw_data = raw_table.to_raw_bytes();
+
+    // non-generic render, for when raw_table has been turned into bytes
+    fn _render_table(
+        raw_data: &[u8],
+        extra_data: &[u8],
+        stab: Option<StringTable>,
+    ) -> Vec<u8> {
+        let stab_data = stab.and_then(|stab| stab.render());
+
+        let term_len = stab_data
+            .as_ref()
+            .map(|s| s.len())
+            .unwrap_or(bits::TABLE_TERMINATOR.len());
+
+        let mut buf =
+            Vec::with_capacity(raw_data.len() + extra_data.len() + term_len);
+        buf.extend_from_slice(raw_data);
+        buf.extend_from_slice(extra_data);
+        if let Some(stab) = stab_data {
+            buf.extend_from_slice(&stab);
+        } else {
+            buf.extend_from_slice(&bits::TABLE_TERMINATOR);
+        }
+        buf
+    }
+
+    _render_table(raw_data, extra_data, stab)
+}
+
+struct StringTable<'a> {
+    strings: Vec<&'a SmbString>,
+    len_with_nulls: usize,
+}
+impl<'a> StringTable<'a> {
+    fn new() -> Self {
+        Self { strings: Vec::new(), len_with_nulls: 0 }
+    }
+    /// Add a [SmbString] to the [StringTable], emitting its index value for
+    /// inclusion in the structure to which it is being associated.
+    fn add(&mut self, data: &'a SmbString) -> u8 {
+        if data.is_empty() {
+            0u8
+        } else {
+            assert!(self.strings.len() < 254);
+            self.len_with_nulls += data.len() + 1;
+            self.strings.push(data);
+            let idx = self.strings.len() as u8;
+
+            idx
+        }
+    }
+    /// Render associated strings raw bytes, properly formatted to be appended
+    /// to an associated SMBIOS table.  Returns `None` if no strings were added
+    /// to the table.
+    fn render(mut self) -> Option<Vec<u8>> {
+        if self.strings.is_empty() {
+            None
+        } else {
+            let mut out = Vec::with_capacity(self.len_with_nulls + 1);
+            for string in self.strings.drain(..) {
+                out.extend_from_slice(string.as_ref());
+                out.push(b'\0');
+            }
+            // table expected to end with double-NUL
+            out.push(b'\0');
+            Some(out)
+        }
+    }
+}

--- a/lib/propolis/src/lib.rs
+++ b/lib/propolis/src/lib.rs
@@ -21,6 +21,7 @@ pub mod chardev;
 pub mod common;
 pub mod cpuid;
 pub mod exits;
+pub mod firmware;
 pub mod hw;
 pub mod intr_pins;
 pub mod lifecycle;


### PR DESCRIPTION
This adds an initial set of SMBIOS tables to be exposed to the guest via fw_cfg and the OVMF ROM.  The generated data is somewhat sparse at the moment, leaving room to expand or improve upon it in the future.

Fixes #628