### PR TITLE
use for_internal_error for 500 error

### DIFF
--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -573,11 +573,7 @@ async fn instance_ensure_common(
         vm_hdl.await.unwrap()
     }
     .map_err(|e| {
-        HttpError::for_client_error(
-            Some(api::ErrorCode::CreateFailed.to_string()),
-            http::status::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to create instance: {e}"),
-        )
+        HttpError::for_internal_error(format!("failed to create instance: {e}"))
     })?;
 
     if let Some(ramfb) = vm.framebuffer() {


### PR DESCRIPTION
Calling `HttpError::for_client_error` on an error that is not a client error causes an assertion failure in dropshot. This patch fixes this by calling `HttpError::for_internal_error` instead.