### PR TITLE
smbios: add enums/bitflags types for some SMBIOS fields

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -853,7 +853,7 @@ impl<'a> MachineInitializer<'a> {
 
     fn generate_smbios(&self) -> smbios::TableBytes {
         use propolis::cpuid;
-        use smbios::table::{type0, type4};
+        use smbios::table::{type0, type1, type4};
 
         let rom_size =
             self.state.rom_size_bytes.expect("ROM is already populated");
@@ -885,7 +885,7 @@ impl<'a> MachineInitializer<'a> {
             uuid: self.properties.id.to_bytes_le(),
 
             // power switch
-            wake_up_type: 0x06,
+            wake_up_type: type1::WakeUpType::PowerSwitch,
             ..Default::default()
         };
 

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -865,7 +865,7 @@ impl<'a> MachineInitializer<'a> {
                 .unwrap(),
             bios_rom_size: ((rom_size / (64 * 1024)) - 1) as u8,
             // Characteristics-not-supported
-            bios_characteristics: type0::BiosCharacteristics::UNKNOWN,
+            bios_characteristics: type0::BiosCharacteristics::UNSUPPORTED,
             bios_ext_characteristics: type0::BiosExtCharacteristics::ACPI
                 | type0::BiosExtCharacteristics::UEFI
                 | type0::BiosExtCharacteristics::IS_VM,

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -853,7 +853,7 @@ impl<'a> MachineInitializer<'a> {
 
     fn generate_smbios(&self) -> smbios::TableBytes {
         use propolis::cpuid;
-        use smbios::table::{type0, type1, type4};
+        use smbios::table::{type0, type1, type16, type4};
 
         let rom_size =
             self.state.rom_size_bytes.expect("ROM is already populated");
@@ -953,11 +953,9 @@ impl<'a> MachineInitializer<'a> {
         let memsize_bytes = (self.properties.memory as usize) * MB;
         let mut smb_type16 = smbios::table::Type16 {
             // system board
-            location: 0x3,
+            location: type16::Location::SystemBoard,
             // system memory
-            array_use: 0x3,
-            // unknown
-            error_correction: 0x2,
+            array_use: type16::ArrayUse::System,
             num_mem_devices: 1,
             ..Default::default()
         };

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -883,7 +883,6 @@ impl<'a> MachineInitializer<'a> {
                 .unwrap_or_default(),
             uuid: self.properties.id.to_bytes_le(),
 
-            // power switch
             wake_up_type: type1::WakeUpType::PowerSwitch,
             ..Default::default()
         };

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -864,7 +864,6 @@ impl<'a> MachineInitializer<'a> {
                 .try_into()
                 .unwrap(),
             bios_rom_size: ((rom_size / (64 * 1024)) - 1) as u8,
-            // Characteristics-not-supported
             bios_characteristics: type0::BiosCharacteristics::UNSUPPORTED,
             bios_ext_characteristics: type0::BiosExtCharacteristics::ACPI
                 | type0::BiosExtCharacteristics::UEFI
@@ -930,13 +929,11 @@ impl<'a> MachineInitializer<'a> {
             cpuid::parse_brand_string(cpuid_procname).unwrap_or("".to_string());
 
         let smb_type4 = smbios::table::Type4 {
-            // central processor
-            proc_type: type4::ProcType::Cpu,
+            proc_type: type4::ProcType::Central,
             proc_family,
             proc_manufacturer,
             proc_id,
             proc_version: proc_version.try_into().unwrap_or_default(),
-            // cpu enabled, socket populated
             status: type4::ProcStatus::Enabled,
             // unknown
             proc_upgrade: 0x2,
@@ -944,7 +941,6 @@ impl<'a> MachineInitializer<'a> {
             core_count: self.properties.vcpus,
             core_enabled: self.properties.vcpus,
             thread_count: self.properties.vcpus,
-            // 64-bit capable, multicore
             proc_characteristics: type4::Characteristics::IS_64_BIT
                 | type4::Characteristics::MULTI_CORE,
             ..Default::default()
@@ -952,10 +948,9 @@ impl<'a> MachineInitializer<'a> {
 
         let memsize_bytes = (self.properties.memory as usize) * MB;
         let mut smb_type16 = smbios::table::Type16 {
-            // system board
             location: type16::Location::SystemBoard,
-            // system memory
             array_use: type16::ArrayUse::System,
+            error_correction: type16::ErrorCorrection::Unknown,
             num_mem_devices: 1,
             ..Default::default()
         };

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -22,6 +22,9 @@ use propolis::block;
 use propolis::chardev::{self, BlockingSource, Source};
 use propolis::common::{Lifecycle, GB, MB, PAGE_SIZE};
 use propolis::firmware::smbios;
+use propolis::firmware::smbios::table::{
+    BiosCharacteristics, BiosExtCharacteristics,
+};
 use propolis::hw::bhyve::BhyveHpet;
 use propolis::hw::chipset::{i440fx, Chipset};
 use propolis::hw::ibmpc;
@@ -864,9 +867,10 @@ impl<'a> MachineInitializer<'a> {
                 .unwrap(),
             bios_rom_size: ((rom_size / (64 * 1024)) - 1) as u8,
             // Characteristics-not-supported
-            bios_characteristics: 0x8,
-            // ACPI + UEFI + IsVM
-            bios_ext_characteristics: 0x1801,
+            bios_characteristics: BiosCharacteristics::UNKNOWN,
+            bios_ext_characteristics: BiosExtCharacteristics::ACPI
+                | BiosExtCharacteristics::UEFI
+                | BiosExtCharacteristics::IS_VM,
             ..Default::default()
         };
 

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -23,6 +23,9 @@ use tokio::runtime;
 use propolis::chardev::{BlockingSource, Sink, Source, UDSock};
 use propolis::common::{GB, MB};
 use propolis::firmware::smbios;
+use propolis::firmware::smbios::table::{
+    BiosCharacteristics, BiosExtCharacteristics,
+};
 use propolis::hw::chipset::{i440fx, Chipset};
 use propolis::hw::ps2::ctrl::PS2Ctrl;
 use propolis::hw::uart::LpcUart;
@@ -818,9 +821,10 @@ fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
         bios_release_date: "Bureaucracy 41, 3186 YOLD".try_into().unwrap(),
         bios_rom_size: ((params.rom_size / (64 * 1024)) - 1) as u8,
         // Characteristics-not-supported
-        bios_characteristics: 0x8,
-        // ACPI + UEFI + IsVM
-        bios_ext_characteristics: 0x1801,
+        bios_characteristics: BiosCharacteristics::UNKNOWN,
+        bios_ext_characteristics: BiosExtCharacteristics::ACPI
+            | BiosExtCharacteristics::UEFI
+            | BiosExtCharacteristics::IS_VM,
         ..Default::default()
     };
 

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -878,13 +878,11 @@ fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
         .unwrap_or("".to_string());
 
     let smb_type4 = smbios::table::Type4 {
-        // central processor
-        proc_type: type4::ProcType::Cpu,
+        proc_type: type4::ProcType::Central,
         proc_family,
         proc_manufacturer,
         proc_id,
         proc_version: proc_version.as_str().try_into().unwrap_or_default(),
-        // cpu enabled, socket populated
         status: type4::ProcStatus::Enabled,
         // unknown
         proc_upgrade: 0x2,
@@ -892,18 +890,14 @@ fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
         core_count: params.num_cpus,
         core_enabled: params.num_cpus,
         thread_count: params.num_cpus,
-        // 64-bit capable, multicore
         proc_characteristics: type4::Characteristics::IS_64_BIT
             | type4::Characteristics::MULTI_CORE,
         ..Default::default()
     };
 
     let mut smb_type16 = smbios::table::Type16 {
-        // system board
         location: type16::Location::SystemBoard,
-        // system memory
         array_use: type16::ArrayUse::System,
-        // unknown
         error_correction: type16::ErrorCorrection::Unknown,
         num_mem_devices: 1,
         ..Default::default()

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -812,7 +812,7 @@ struct SmbiosParams {
     cpuid_procname: Option<[cpuid::Entry; 3]>,
 }
 fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
-    use smbios::table::{type0, type1, type4};
+    use smbios::table::{type0, type1, type16, type4};
 
     let smb_type0 = smbios::table::Type0 {
         vendor: "Oxide".try_into().unwrap(),
@@ -900,11 +900,11 @@ fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
 
     let mut smb_type16 = smbios::table::Type16 {
         // system board
-        location: 0x3,
+        location: type16::Location::SystemBoard,
         // system memory
-        array_use: 0x3,
+        array_use: type16::ArrayUse::System,
         // unknown
-        error_correction: 0x2,
+        error_correction: type16::ErrorCorrection::Unknown,
         num_mem_devices: 1,
         ..Default::default()
     };

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -819,7 +819,6 @@ fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
         bios_version: "v0.0.1 alpha1".try_into().unwrap(),
         bios_release_date: "Bureaucracy 41, 3186 YOLD".try_into().unwrap(),
         bios_rom_size: ((params.rom_size / (64 * 1024)) - 1) as u8,
-        // Characteristics-not-supported
         bios_characteristics: type0::BiosCharacteristics::UNSUPPORTED,
         bios_ext_characteristics: type0::BiosExtCharacteristics::ACPI
             | type0::BiosExtCharacteristics::UEFI
@@ -830,7 +829,6 @@ fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
     let smb_type1 = smbios::table::Type1 {
         manufacturer: "Oxide".try_into().unwrap(),
         product_name: "OxVM".try_into().unwrap(),
-        // power switch
         wake_up_type: type1::WakeUpType::PowerSwitch,
         ..Default::default()
     };

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -812,7 +812,7 @@ struct SmbiosParams {
     cpuid_procname: Option<[cpuid::Entry; 3]>,
 }
 fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
-    use smbios::table::{type0, type4};
+    use smbios::table::{type0, type1, type4};
 
     let smb_type0 = smbios::table::Type0 {
         vendor: "Oxide".try_into().unwrap(),
@@ -831,7 +831,7 @@ fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
         manufacturer: "Oxide".try_into().unwrap(),
         product_name: "OxVM".try_into().unwrap(),
         // power switch
-        wake_up_type: 0x06,
+        wake_up_type: type1::WakeUpType::PowerSwitch,
         ..Default::default()
     };
 

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -820,7 +820,7 @@ fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
         bios_release_date: "Bureaucracy 41, 3186 YOLD".try_into().unwrap(),
         bios_rom_size: ((params.rom_size / (64 * 1024)) - 1) as u8,
         // Characteristics-not-supported
-        bios_characteristics: type0::BiosCharacteristics::UNKNOWN,
+        bios_characteristics: type0::BiosCharacteristics::UNSUPPORTED,
         bios_ext_characteristics: type0::BiosExtCharacteristics::ACPI
             | type0::BiosExtCharacteristics::UEFI
             | type0::BiosExtCharacteristics::IS_VM,

--- a/lib/propolis/src/firmware/smbios/table.rs
+++ b/lib/propolis/src/firmware/smbios/table.rs
@@ -208,7 +208,7 @@ pub struct Type1 {
     pub version: SmbString,
     pub serial_number: SmbString,
     pub uuid: [u8; 16],
-    pub wake_up_type: u8,
+    pub wake_up_type: type1::WakeUpType,
     pub sku_number: SmbString,
     pub family: SmbString,
 }
@@ -221,13 +221,44 @@ impl Table for Type1 {
             version: stab.add(&self.version),
             serial_number: stab.add(&self.serial_number),
             uuid: self.uuid,
-            wake_up_type: self.wake_up_type,
+            wake_up_type: self.wake_up_type as u8,
             sku_number: stab.add(&self.sku_number),
             family: stab.add(&self.family),
             ..bits::Type1::new(handle.into())
         };
 
         render_table(data, None, Some(stab))
+    }
+}
+
+pub mod type1 {
+    /// Wake-up type.
+    ///
+    /// See Table 12 in section 7.2.2 of [the SMBIOS Reference
+    /// Specification][DSP0136] for details.
+    ///
+    /// [DSP0136]:
+    ///     https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+    #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+    #[repr(u8)]
+    pub enum WakeUpType {
+        /// Other
+        Other = 0x01,
+        /// Unknown
+        #[default]
+        Unknown = 0x02,
+        /// APM Timer
+        ApmTimer = 0x03,
+        /// Modem Ring
+        ModemRing = 0x04,
+        /// LAN Remote
+        LanRemote = 0x05,
+        /// Power Switch
+        PowerSwitch = 0x06,
+        /// PCI PME#
+        PciPme = 0x07,
+        /// AC Power Restored
+        AcPowerRestored = 0x08,
     }
 }
 

--- a/lib/propolis/src/firmware/smbios/table.rs
+++ b/lib/propolis/src/firmware/smbios/table.rs
@@ -33,8 +33,8 @@ pub struct Type0 {
 impl Table for Type0 {
     fn render(&self, handle: Handle) -> Vec<u8> {
         let bios_characteristics = {
-            let low = self.bios_characteristics.bits() as u64;
-            let high = (self.bios_characteristics_reserved as u64) << 32;
+            let low = u64::from(self.bios_characteristics.bits());
+            let high = u64::from(self.bios_characteristics_reserved) << 32;
             low | high
         };
         let mut stab = StringTable::new();

--- a/lib/propolis/src/firmware/smbios/table.rs
+++ b/lib/propolis/src/firmware/smbios/table.rs
@@ -136,7 +136,7 @@ pub mod type0 {
 
     impl Default for BiosCharacteristics {
         fn default() -> Self {
-            BiosCharacteristics::empty() | BiosCharacteristics::UNKNOWN
+            BiosCharacteristics::UNKNOWN
         }
     }
 

--- a/lib/propolis/src/firmware/smbios/table.rs
+++ b/lib/propolis/src/firmware/smbios/table.rs
@@ -436,9 +436,9 @@ pub mod type4 {
 
 #[derive(Default)]
 pub struct Type16 {
-    pub location: u8,
-    pub array_use: u8,
-    pub error_correction: u8,
+    pub location: type16::Location,
+    pub array_use: type16::ArrayUse,
+    pub error_correction: type16::ErrorCorrection,
     pub max_capacity: u32,
     pub error_info_handle: Handle,
     pub num_mem_devices: u16,
@@ -459,9 +459,9 @@ impl Type16 {
 impl Table for Type16 {
     fn render(&self, handle: Handle) -> Vec<u8> {
         let data = bits::Type16 {
-            location: self.location,
-            array_use: self.array_use,
-            error_correction: self.error_correction,
+            location: self.location as u8,
+            array_use: self.array_use as u8,
+            error_correction: self.error_correction as u8,
             max_capacity: self.max_capacity,
             error_info_handle: self.error_info_handle.into(),
             num_mem_devices: self.num_mem_devices,
@@ -469,6 +469,105 @@ impl Table for Type16 {
             ..bits::Type16::new(handle.into())
         };
         render_table(data, None, None)
+    }
+}
+
+pub mod type16 {
+    /// Memory array location.
+    ///
+    /// See Table 72 in section 7.17.1 of [the SMBIOS Reference
+    /// Specification][DSP0136] for details.
+    ///
+    /// [DSP0136]:
+    ///     https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+    #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+    #[repr(u8)]
+    pub enum Location {
+        /// Other
+        Other = 0x01,
+        /// Unknown
+        #[default]
+        Unknown = 0x02,
+        /// System board or motherboard
+        SystemBoard = 0x03,
+        /// ISA add-on card
+        IsaCard = 0x04,
+        /// EISA add-on card
+        EisaCard = 0x05,
+        /// PCI add-on card
+        PciCard = 0x06,
+        /// MCA add-on card
+        McaCard = 0x07,
+        /// PCMCIA add-on card
+        PcmciaCard = 0x08,
+        /// Proprietary add-on card
+        ProprietaryCard = 0x09,
+        /// NuBus
+        NuBus = 0x0A,
+        /// PC-98/C20 add-on card
+        Pc98C20Card = 0xA0,
+        /// PC-98/C24 add-on card
+        Pc98C24Card = 0xA1,
+        /// PC-98/E  add-on card
+        Pc98ECard = 0xA2,
+        /// PC-98/Local bus add-on card
+        Pc98LocalCard = 0xA3,
+        // CXL add-on card
+        CxlCard = 0xA4,
+    }
+
+    /// Memory array use field.
+    ///
+    /// See Table 73 in section 7.17.2 of [the SMBIOS Reference
+    /// Specification][DSP0136] for details.
+    ///
+    /// [DSP0136]:
+    ///     https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+    #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+    #[repr(u8)]
+    pub enum ArrayUse {
+        /// Other
+        Other = 0x1,
+        /// Unknown
+        #[default]
+        Unknown = 0x2,
+        /// System memory
+        System = 0x3,
+        /// Video memory
+        Video = 0x4,
+        /// Flash memory
+        Flash = 0x5,
+        /// Non-volatile RAM
+        NonVolatile = 0x6,
+        /// Cache memory
+        Cache = 0x7,
+    }
+
+    /// Memory array error correction field.
+    ///
+    /// See Table 74 in section 7.17.3 of [the SMBIOS Reference
+    /// Specification][DSP0136] for details.
+    ///
+    /// [DSP0136]:
+    ///     https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+    #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+    #[repr(u8)]
+    pub enum ErrorCorrection {
+        /// Other
+        Other = 0x1,
+        /// Unknown
+        #[default]
+        Unknown = 0x2,
+        /// No error correction.
+        None = 0x3,
+        /// Parity
+        Parity = 0x4,
+        /// Single-bit ECC
+        SingleBitEcc = 0x5,
+        /// Multi-bit ECC
+        MultiBitEcc = 0x6,
+        /// CRC
+        Crc = 0x7,
     }
 }
 

--- a/lib/propolis/src/firmware/smbios/table.rs
+++ b/lib/propolis/src/firmware/smbios/table.rs
@@ -2,6 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+//! SMBIOS tables.
+//!
+//! The values of the types in this module are defined by [DSP0136], the _SMBIOS Reference
+//! Specification_. Refer to that document for details.
+//!
+//! [DSP0136]:
+//!     https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+
 use crate::common::*;
 use crate::firmware::smbios::bits::{self, RawTable};
 use crate::firmware::smbios::{Handle, SmbString};
@@ -384,11 +392,7 @@ pub mod type1 {
 
     /// Wake-up type.
     ///
-    /// See Table 12 in section 7.2.2 of [the SMBIOS Reference
-    /// Specification][DSP0136] for details.
-    ///
-    /// [DSP0136]:
-    ///     https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+    /// See Table 12 in section 7.2.2 of DSP0136 for details.
     #[derive(
         Debug, Default, Copy, Clone, PartialEq, Eq, FromRepr, VariantArray,
     )]
@@ -505,11 +509,7 @@ pub mod type4 {
 
     /// Processor type.
     ///
-    /// See Table 21 in section 7.5 of [the SMBIOS Reference
-    /// Specification][DSP0136] for details.
-    ///
-    /// [DSP0136]:
-    ///     https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+    /// See Table 21 in section 7.5 of DSP0136 for details.
     #[derive(
         Debug, Default, Copy, Clone, PartialEq, Eq, FromRepr, VariantArray,
     )]
@@ -532,11 +532,7 @@ pub mod type4 {
 
     /// Processor status.
     ///
-    /// See Table 21 in section 7.5 of [the SMBIOS Reference
-    /// Specification][DSP0136] for details.
-    ///
-    /// [DSP0136]:
-    ///     https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+    /// See Table 21 in section 7.5 of DSP0136 for details.
     #[derive(
         Debug, Default, Copy, Clone, PartialEq, Eq, FromRepr, VariantArray,
     )]
@@ -674,11 +670,7 @@ pub mod type16 {
     use super::*;
     /// Memory array location.
     ///
-    /// See Table 72 in section 7.17.1 of [the SMBIOS Reference
-    /// Specification][DSP0136] for details.
-    ///
-    /// [DSP0136]:
-    ///     https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+    /// See Table 72 in section 7.17.1 of DSP0136 for details.
     #[derive(
         Debug, Default, Copy, Clone, PartialEq, Eq, FromRepr, VariantArray,
     )]
@@ -718,11 +710,7 @@ pub mod type16 {
     }
     /// Memory array use field.
     ///
-    /// See Table 73 in section 7.17.2 of [the SMBIOS Reference
-    /// Specification][DSP0136] for details.
-    ///
-    /// [DSP0136]:
-    ///     https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+    /// See Table 73 in section 7.17.2 of DSP0136 for details.
     #[derive(
         Debug, Default, Copy, Clone, PartialEq, Eq, FromRepr, VariantArray,
     )]
@@ -747,11 +735,7 @@ pub mod type16 {
 
     /// Memory array error correction field.
     ///
-    /// See Table 74 in section 7.17.3 of [the SMBIOS Reference
-    /// Specification][DSP0136] for details.
-    ///
-    /// [DSP0136]:
-    ///     https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+    /// See Table 74 in section 7.17.3 of DSP0136 for details.
     #[derive(
         Debug, Default, Copy, Clone, PartialEq, Eq, FromRepr, VariantArray,
     )]

--- a/lib/propolis/src/firmware/smbios/table.rs
+++ b/lib/propolis/src/firmware/smbios/table.rs
@@ -513,7 +513,7 @@ pub mod type4 {
             #[default]
             Unknown = 0x02,
             /// Central Processor
-            Cpu = 0x03,
+            Central = 0x03,
             /// Math Processor
             Math = 0x04,
             /// DSP Processor

--- a/lib/propolis/src/firmware/smbios/table.rs
+++ b/lib/propolis/src/firmware/smbios/table.rs
@@ -5,7 +5,6 @@
 use crate::common::*;
 use crate::firmware::smbios::bits::{self, RawTable};
 use crate::firmware::smbios::{Handle, SmbString};
-use bitflags::bitflags;
 
 pub trait Table {
     fn render(&self, handle: Handle) -> Vec<u8>;
@@ -20,11 +19,11 @@ pub struct Type0 {
     pub bios_rom_size: u8,
     /// The low 32 bits of the BIOS characteristics field is a set of bitflags
     /// that describes the BIOS.
-    pub bios_characteristics: BiosCharacteristics,
+    pub bios_characteristics: type0::BiosCharacteristics,
     /// The high 32 bits of the 64-bit BIOS characteristics field is reserved
     /// for the BIOS vendor.
     pub bios_characteristics_reserved: u32,
-    pub bios_ext_characteristics: BiosExtCharacteristics,
+    pub bios_ext_characteristics: type0::BiosExtCharacteristics,
     pub bios_major_release: u8,
     pub bios_minor_release: u8,
     pub ec_firmware_major_rel: u8,
@@ -58,149 +57,150 @@ impl Table for Type0 {
     }
 }
 
-bitflags! {
-    /// BIOS Characteristics flags.
-    ///
-    /// See Table 7 in section 7.1.1 of [the SMBIOS Reference
-    /// Specification][DSP0136] for details.
-    ///
-    /// [DSP0136]: https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
-    #[repr(transparent)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct BiosCharacteristics: u32 {
-        // Bits 0-1 are reserved.
+pub mod type0 {
+    bitflags! {
+        /// BIOS Characteristics flags.
+        ///
+        /// See Table 7 in section 7.1.1 of [the SMBIOS Reference
+        /// Specification][DSP0136] for details.
+        ///
+        /// [DSP0136]: https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+        #[repr(transparent)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub struct BiosCharacteristics: u32 {
+            // Bits 0-1 are reserved.
 
-        /// BIOS characteristics are unknown.
-        const UNKNOWN = 1 << 2;
-        /// BIOS characteristics are not supported.
-        const UNSUPPORTED = 1 << 3;
-        /// ISA is supported
-        const ISA = 1 << 4;
-        /// MCA is supported.
-        const MCA = 1 << 5;
-        /// EISA is supported.
-        const EISA = 1 << 6;
-        /// PCI is supported.
-        const PCI = 1 << 7;
-        /// PC card (PCMCIA) is supported.
-        const PCMCIA = 1 << 8;
-        /// Plug and Play is supported.
-        const PLUG_AND_PLAY = 1 << 9;
-        /// APM is supported.
-        const APM = 1 << 10;
-        /// BIOS is upgradeable (flash).
-        const UPGRADEABLE = 1 << 11;
-        /// BIOS shadowing is allowed.
-        const SHADOWING = 1 << 12;
-        /// VL-VESA is supported.
-        const VL_VESA = 1 << 13;
-        /// ESCD support is available.
-        const ESCD = 1 << 14;
-        /// Boot from CD is supported.
-        const BOOT_FROM_CD = 1 << 15;
-        /// Selectable boot is supported.
-        const BOOT_SELECTABLE = 1 << 16;
-        /// BIOS ROM is socketed (e.g. PLCC or SOP socket).
-        const ROM_SOCKETED = 1 << 17;
-        /// Boot from PC card (PCMCIA) is supported.
-        const BOOT_FROM_PCMCIA = 1 << 18;
-        /// EDD specification is supported.
-        const EDD = 1 << 19;
-        /// INT 0x13 --- Japanese floppy for NEC 9800 1.2 MB (3.5”, 1K
-        /// bytes/sector, 360 RPM) is supported.
-        const FLOPPY_NEC_9800 = 1 << 20;
-        /// INT 0x13 --- Japanese floppy for Toshiba 1.2 MB (3.5”, 360
-        const FLOPPY_TOSHIBA= 1 << 21;
-        /// INT 0x13 --- 5.25”/360 KB floppy services are supported.
-        const FLOPPY_5_25_IN_360KB = 1 << 22;
-        /// INT 0x13 --- 5.25”/1.2 MB floppy services are supported.
-        const FLOPPY_5_25_IN_1_2MB = 1 << 23;
-        /// INT 0x13 --- 3.5”/720 KB floppy services are supported.
-        const FLOPPY_3_5_IN_720KB = 1 << 24;
-        /// INT 0x13 --- 3.5”/2.88 MB floppy services are supported.
-        const FLOPPY_3_5_IN_2_88MB = 1 << 25;
-        /// INT 0x5, print screen service is supported.
-        const PRINT_SCREEN = 1 << 26;
-        /// INT 0x9, 8042 keyboard services are supported.
-        const KEYBOARD_8042 = 1 << 27;
-        /// INT 0x14, serial services are supported.
-        const SERIAL = 1 << 28;
-        /// INT 0x17, printer services are supported.
-        const PRINTER = 1 << 29;
-        /// INT 0x10, CGA/mono video services are supported.
-        const VIDEO_CGA_MONO = 1 << 30;
-        /// NEC PC-98
-        const NEC_PC_98 = 1 << 31;
+            /// BIOS characteristics are unknown.
+            const UNKNOWN = 1 << 2;
+            /// BIOS characteristics are not supported.
+            const UNSUPPORTED = 1 << 3;
+            /// ISA is supported
+            const ISA = 1 << 4;
+            /// MCA is supported.
+            const MCA = 1 << 5;
+            /// EISA is supported.
+            const EISA = 1 << 6;
+            /// PCI is supported.
+            const PCI = 1 << 7;
+            /// PC card (PCMCIA) is supported.
+            const PCMCIA = 1 << 8;
+            /// Plug and Play is supported.
+            const PLUG_AND_PLAY = 1 << 9;
+            /// APM is supported.
+            const APM = 1 << 10;
+            /// BIOS is upgradeable (flash).
+            const UPGRADEABLE = 1 << 11;
+            /// BIOS shadowing is allowed.
+            const SHADOWING = 1 << 12;
+            /// VL-VESA is supported.
+            const VL_VESA = 1 << 13;
+            /// ESCD support is available.
+            const ESCD = 1 << 14;
+            /// Boot from CD is supported.
+            const BOOT_FROM_CD = 1 << 15;
+            /// Selectable boot is supported.
+            const BOOT_SELECTABLE = 1 << 16;
+            /// BIOS ROM is socketed (e.g. PLCC or SOP socket).
+            const ROM_SOCKETED = 1 << 17;
+            /// Boot from PC card (PCMCIA) is supported.
+            const BOOT_FROM_PCMCIA = 1 << 18;
+            /// EDD specification is supported.
+            const EDD = 1 << 19;
+            /// INT 0x13 --- Japanese floppy for NEC 9800 1.2 MB (3.5”, 1K
+            /// bytes/sector, 360 RPM) is supported.
+            const FLOPPY_NEC_9800 = 1 << 20;
+            /// INT 0x13 --- Japanese floppy for Toshiba 1.2 MB (3.5”, 360
+            const FLOPPY_TOSHIBA= 1 << 21;
+            /// INT 0x13 --- 5.25”/360 KB floppy services are supported.
+            const FLOPPY_5_25_IN_360KB = 1 << 22;
+            /// INT 0x13 --- 5.25”/1.2 MB floppy services are supported.
+            const FLOPPY_5_25_IN_1_2MB = 1 << 23;
+            /// INT 0x13 --- 3.5”/720 KB floppy services are supported.
+            const FLOPPY_3_5_IN_720KB = 1 << 24;
+            /// INT 0x13 --- 3.5”/2.88 MB floppy services are supported.
+            const FLOPPY_3_5_IN_2_88MB = 1 << 25;
+            /// INT 0x5, print screen service is supported.
+            const PRINT_SCREEN = 1 << 26;
+            /// INT 0x9, 8042 keyboard services are supported.
+            const KEYBOARD_8042 = 1 << 27;
+            /// INT 0x14, serial services are supported.
+            const SERIAL = 1 << 28;
+            /// INT 0x17, printer services are supported.
+            const PRINTER = 1 << 29;
+            /// INT 0x10, CGA/mono video services are supported.
+            const VIDEO_CGA_MONO = 1 << 30;
+            /// NEC PC-98
+            const NEC_PC_98 = 1 << 31;
+        }
+    }
+
+    impl Default for BiosCharacteristics {
+        fn default() -> Self {
+            BiosCharacteristics::empty() | BiosCharacteristics::UNKNOWN
+        }
+    }
+
+    bitflags! {
+        /// BIOS Characteristics Extension flags.
+        ///
+        /// See Tables 8 and 9 in section 7.1.1 of [the SMBIOS Reference
+        /// Specification][DSP0136] for details.
+        ///
+        /// [DSP0136]: https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+        #[repr(transparent)]
+        #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub struct BiosExtCharacteristics: u16 {
+            /// ACPI is supported
+            const ACPI = 1 << 0;
+            /// USB Legacy is supported.
+            const USB_LEGACY = 1 << 1;
+            /// AGP is supported.
+            const AGP = 1 << 2;
+            /// I2O boot is supported.
+            const BOOT_I2O = 1 << 3;
+            /// LS-120 SuperDisk boot is supported.
+            const BOOT_LS_120_SUPERDISK = 1 << 4;
+            /// ATAPI ZIP drive boot is supported.
+            const BOOT_ATAPI_ZIP = 1 << 5;
+            /// 1394 boot is supported.
+            const BOOT_1394 = 1 << 6;
+            /// Smart battery is supported.
+            const SMART_BATTERY = 1 << 7;
+            /// BIOS boot specification is supported.
+            const BIOS_BOOT_SPEC = 1 << 8;
+            /// Function key-initiated network service boot is supported.
+            ///
+            /// When function key-uninitiated network service boot is not supported,
+            /// a network adapter option ROM may choose to offer this functionality
+            /// on its own, thus offering this capability to legacy systems. When
+            /// the function is supported, the network adapter option ROM shall not
+            /// offer this capability.
+            const NETBOOT_FN_KEY = 1 << 9;
+            /// Enable targeted content distribution.
+            ///
+            /// The manufacturer has ensured that the SMBIOS data is useful in
+            /// identifying the computer for targeted delivery of model-specific
+            /// software and firmware content through third-party content
+            /// distribution services.
+            const TARGETED_CONTENT_DIST = 1 << 10;
+            /// UEFI specification is supported.
+            const UEFI = 1 << 11;
+            /// SMBIOS table describes a virtual machine.
+            ///
+            /// If this bit is not set, no inference can be made about the
+            /// virtuality of the system.
+            const IS_VM = 1 << 12;
+            /// Manufacturing mode is *supported*.
+            ///
+            /// Manufacturing mode is a special boot mode, not normally available to
+            /// end users, that modifies BIOS features and settings for use while
+            /// the computer is being manufactured and tested.
+            const HAS_MFG_MODE = 1 << 13;
+            /// Manufacturing mode is *enabled*.
+            const IN_MFG_MODE = 1 << 14;
+        }
     }
 }
-
-impl Default for BiosCharacteristics {
-    fn default() -> Self {
-        BiosCharacteristics::empty() | BiosCharacteristics::UNKNOWN
-    }
-}
-
-bitflags! {
-    /// BIOS Characteristics Extension flags.
-    ///
-    /// See Tables 8 and 9 in section 7.1.1 of [the SMBIOS Reference
-    /// Specification][DSP0136] for details.
-    ///
-    /// [DSP0136]: https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
-    #[repr(transparent)]
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct BiosExtCharacteristics: u16 {
-        /// ACPI is supported
-        const ACPI = 1 << 0;
-        /// USB Legacy is supported.
-        const USB_LEGACY = 1 << 1;
-        /// AGP is supported.
-        const AGP = 1 << 2;
-        /// I2O boot is supported.
-        const BOOT_I2O = 1 << 3;
-        /// LS-120 SuperDisk boot is supported.
-        const BOOT_LS_120_SUPERDISK = 1 << 4;
-        /// ATAPI ZIP drive boot is supported.
-        const BOOT_ATAPI_ZIP = 1 << 5;
-        /// 1394 boot is supported.
-        const BOOT_1394 = 1 << 6;
-        /// Smart battery is supported.
-        const SMART_BATTERY = 1 << 7;
-        /// BIOS boot specification is supported.
-        const BIOS_BOOT_SPEC = 1 << 8;
-        /// Function key-initiated network service boot is supported.
-        ///
-        /// When function key-uninitiated network service boot is not supported,
-        /// a network adapter option ROM may choose to offer this functionality
-        /// on its own, thus offering this capability to legacy systems. When
-        /// the function is supported, the network adapter option ROM shall not
-        /// offer this capability.
-        const NETBOOT_FN_KEY = 1 << 9;
-        /// Enable targeted content distribution.
-        ///
-        /// The manufacturer has ensured that the SMBIOS data is useful in
-        /// identifying the computer for targeted delivery of model-specific
-        /// software and firmware content through third-party content
-        /// distribution services.
-        const TARGETED_CONTENT_DIST = 1 << 10;
-        /// UEFI specification is supported.
-        const UEFI = 1 << 11;
-        /// SMBIOS table describes a virtual machine.
-        ///
-        /// If this bit is not set, no inference can be made about the
-        /// virtuality of the system.
-        const IS_VM = 1 << 12;
-        /// Manufacturing mode is *supported*.
-        ///
-        /// Manufacturing mode is a special boot mode, not normally available to
-        /// end users, that modifies BIOS features and settings for use while
-        /// the computer is being manufactured and tested.
-        const HAS_MFG_MODE = 1 << 13;
-        /// Manufacturing mode is *enabled*.
-        const IN_MFG_MODE = 1 << 14;
-    }
-}
-
 #[derive(Default)]
 pub struct Type1 {
     pub manufacturer: SmbString,
@@ -234,7 +234,7 @@ impl Table for Type1 {
 #[derive(Default)]
 pub struct Type4 {
     pub socket_designation: SmbString,
-    pub proc_type: u8,
+    pub proc_type: type4::ProcType,
     pub proc_family: u8,
     pub proc_manufacturer: SmbString,
     pub proc_id: u64,
@@ -243,7 +243,7 @@ pub struct Type4 {
     pub external_clock: u16,
     pub max_speed: u16,
     pub current_speed: u16,
-    pub status: u8,
+    pub status: type4::ProcStatus,
     pub proc_upgrade: u8,
     pub l1_cache_handle: Handle,
     pub l2_cache_handle: Handle,
@@ -254,7 +254,7 @@ pub struct Type4 {
     pub core_count: u8,
     pub core_enabled: u8,
     pub thread_count: u8,
-    pub proc_characteristics: u16,
+    pub proc_characteristics: type4::Characteristics,
     pub proc_family2: u16,
 }
 impl Type4 {
@@ -273,7 +273,7 @@ impl Table for Type4 {
         let mut stab = StringTable::new();
         let data = bits::Type4 {
             socket_designation: stab.add(&self.socket_designation),
-            proc_type: self.proc_type,
+            proc_type: self.proc_type as u8,
             proc_family: self.proc_family,
             proc_manufacturer: stab.add(&self.proc_manufacturer),
             proc_id: self.proc_id,
@@ -282,7 +282,7 @@ impl Table for Type4 {
             external_clock: self.external_clock,
             max_speed: self.max_speed,
             current_speed: self.current_speed,
-            status: self.status,
+            status: self.status as u8,
             proc_upgrade: self.proc_upgrade,
             l1_cache_handle: self.l1_cache_handle.into(),
             l2_cache_handle: self.l2_cache_handle.into(),
@@ -293,11 +293,113 @@ impl Table for Type4 {
             core_count: self.core_count,
             core_enabled: self.core_enabled,
             thread_count: self.thread_count,
-            proc_characteristics: self.proc_characteristics,
+            proc_characteristics: self.proc_characteristics.bits(),
             proc_family2: self.proc_family2,
             ..bits::Type4::new(handle.into())
         };
         render_table(data, None, Some(stab))
+    }
+}
+
+pub mod type4 {
+    /// Processor type.
+    ///
+    /// See Table 21 in section 7.5 of [the SMBIOS Reference
+    /// Specification][DSP0136] for details.
+    ///
+    /// [DSP0136]:
+    ///     https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+    #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+    #[repr(u8)]
+    pub enum ProcType {
+        /// Other
+        Other = 0x01,
+        /// Unknown
+        #[default]
+        Unknown = 0x02,
+        /// Central Processor
+        Cpu = 0x03,
+        /// Math Processor
+        Math = 0x04,
+        /// DSP Processor
+        Dsp = 0x05,
+        /// Video processor
+        Video = 0x06,
+    }
+
+    /// Processor status.
+    ///
+    /// See Table 21 in section 7.5 of [the SMBIOS Reference
+    /// Specification][DSP0136] for details.
+    ///
+    /// [DSP0136]:
+    ///     https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+    #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+    #[repr(u8)]
+    pub enum ProcStatus {
+        /// Status unknown, socket unpopulated.
+        UnknownUnpopulated = 0x00,
+        /// Status unknown, socket populated.
+        #[default]
+        UnknownPopulated = Self::POPULATED,
+
+        /// CPU Enabled
+        ///
+        /// It...probably doesn't make sense to have a CPU enabled that's
+        /// unpopulated?
+        Enabled = 0x01 | Self::POPULATED,
+        /// CPU Disabled by User through BIOS Setup.
+        UserDisabled = 0x02 | Self::POPULATED,
+        /// CPU Disabled by BIOS (POST Error).
+        BiosDisabled = 0x03 | Self::POPULATED,
+        /// CPU is Idle, waiting to be enabled.
+        Idle = 0x04 | Self::POPULATED,
+
+        /// Other
+        OtherPopulated = 0x07 | Self::POPULATED,
+        OtherUnpopulated = 0x07,
+    }
+
+    impl ProcStatus {
+        const POPULATED: u8 = 1 << 6;
+
+        pub fn is_populated(&self) -> bool {
+            (*self as u8) & Self::POPULATED != 0
+        }
+    }
+
+    bitflags! {
+        /// Processor characteristics.
+        ///
+        /// See Table 27 in section 7.5.9 of [the SMBIOS Reference
+        /// Specification][DSP0136] for details.
+        ///
+        /// [DSP0136]:
+        ///     https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf
+        #[repr(transparent)]
+        #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub struct Characteristics: u16 {
+            // Bit 0 is reserved
+
+            /// Unknown
+            const UNKNOWN = 1 << 1;
+            /// 64-bit Capable
+            const IS_64_BIT = 1 << 2;
+            /// Multi-core
+            const MULTI_CORE = 1 << 3;
+            /// Hardware Thread
+            const HARDWARE_THREAD = 1 << 4;
+            /// Execute Protection
+            const EXECUTE_PROTECTION = 1 << 5;
+            /// Enhanced Virtualization
+            const VIRTUALIZATION = 1 << 6;
+            /// Power/Performance Control
+            const POWER_PERF_CONTROL = 1 << 7;
+            /// 128-bit Capable
+            const IS_128_BIT = 1 << 8;
+            /// Arm64 SoC ID
+            const ARM64_SOC_ID = 1 << 9;
+        }
     }
 }
 


### PR DESCRIPTION
Currently, most of the SMBIOS fields that we populate are magic numbers, with comments describing what that magic number indicates. For SMBIOS enum fields, this isn't too bad, but for bitfields like the various "characteristics" fields, it's a bit of a shame, since the hex constant doesn't always make it obvious which bit corresponds to which characteristic.

To make this a bit nicer, this commit adds enums for most of the SMBIOS enum fields we currently populate, and bitflags for most of the bitflags fields. This way, we can refer to them by name rather than as magic numbers. Also, I've made the `Default` implementation for the various enum fields return the "unknown" (0x2) variant. Eventually, we may want to default-initialize more SMBIOS tables --- but, we should probably hold off on that until *all* the enum fields in the tables we populate are Rust types with `Default` impls, so that we don't have to manually initialize some of them to 0x2.