### PR TITLE
Standardize on `mod test`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,8 @@ jobs:
       run: cargo fmt -- --version
     - name: Check style
       run: cargo fmt -- --check
+    - name: Check misc. style
+      run: cargo xtask style
   check-clippy:
     runs-on: ubuntu-latest
     steps:

--- a/bin/propolis-server/src/lib/migrate/protocol.rs
+++ b/bin/propolis-server/src/lib/migrate/protocol.rs
@@ -256,7 +256,7 @@ pub(super) fn select_protocol_from_offer(
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
 
     // N.B. The test protocol lists are sorted by version to meet the

--- a/bin/propolis-server/src/lib/serial/history_buffer.rs
+++ b/bin/propolis-server/src/lib/serial/history_buffer.rs
@@ -218,7 +218,7 @@ impl HistoryBuffer {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
     use SerialHistoryOffset::*;
 

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -1147,7 +1147,7 @@ fn not_created_error() -> HttpError {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     #[test]
     fn test_propolis_server_openapi() {
         let mut buf: Vec<u8> = vec![];

--- a/bin/propolis-server/src/lib/stats/virtual_machine.rs
+++ b/bin/propolis-server/src/lib/stats/virtual_machine.rs
@@ -395,7 +395,7 @@ fn produce_vcpu_usage<'a>(
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::kstat_instance_from_instance_id;
     use super::kstat_microstate_to_state_name;
     use super::produce_vcpu_usage;

--- a/bin/propolis-server/src/lib/vm/request_queue.rs
+++ b/bin/propolis-server/src/lib/vm/request_queue.rs
@@ -444,7 +444,7 @@ impl ExternalRequestQueue {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
 
     use uuid::Uuid;

--- a/bin/propolis-server/src/lib/vm/state_driver.rs
+++ b/bin/propolis-server/src/lib/vm/state_driver.rs
@@ -567,7 +567,7 @@ where
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use anyhow::bail;
     use mockall::Sequence;
 

--- a/crates/propolis-server-config/src/lib.rs
+++ b/crates/propolis-server-config/src/lib.rs
@@ -143,7 +143,7 @@ pub fn parse<P: AsRef<Path>>(path: P) -> Result<Config, ParseError> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
 
     #[test]

--- a/lib/propolis-client/src/support.rs
+++ b/lib/propolis-client/src/support.rs
@@ -449,7 +449,7 @@ fn _assert_impls() {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::InstanceSerialConsoleControlMessage;
     use super::InstanceSerialConsoleHelper;
     use super::Role;

--- a/lib/propolis/src/chardev/pollers.rs
+++ b/lib/propolis/src/chardev/pollers.rs
@@ -555,7 +555,7 @@ impl Params {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
     use crate::chardev::*;
 

--- a/lib/propolis/src/common.rs
+++ b/lib/propolis/src/common.rs
@@ -388,7 +388,7 @@ pub const GB: usize = 1024 * 1024 * 1024;
 pub const TB: usize = 1024 * 1024 * 1024 * 1024;
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
 
     #[test]

--- a/lib/propolis/src/firmware/smbios/table.rs
+++ b/lib/propolis/src/firmware/smbios/table.rs
@@ -416,7 +416,7 @@ pub mod type1 {
     }
 
     #[cfg(test)]
-    mod tests {
+    mod test {
         use super::*;
 
         enum_serde_roundtrip_tests! {
@@ -607,7 +607,7 @@ pub mod type4 {
     }
 
     #[cfg(test)]
-    mod tests {
+    mod test {
         use super::*;
 
         enum_serde_roundtrip_tests! {
@@ -759,7 +759,7 @@ pub mod type16 {
     }
 
     #[cfg(test)]
-    mod tests {
+    mod test {
         use super::*;
 
         enum_serde_roundtrip_tests! {

--- a/lib/propolis/src/hw/nvme/queue.rs
+++ b/lib/propolis/src/hw/nvme/queue.rs
@@ -877,7 +877,7 @@ pub(super) mod migrate {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use rand::Rng;
 
     use super::*;

--- a/lib/propolis/src/hw/pci/bar.rs
+++ b/lib/propolis/src/hw/pci/bar.rs
@@ -314,7 +314,7 @@ pub mod migrate {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
 
     fn setup() -> Bars {

--- a/lib/propolis/src/hw/uart/uart16550.rs
+++ b/lib/propolis/src/hw/uart/uart16550.rs
@@ -635,7 +635,7 @@ impl UartReg {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
 
     mod bits {
         #![allow(unused)]

--- a/lib/propolis/src/util/aspace.rs
+++ b/lib/propolis/src/util/aspace.rs
@@ -280,7 +280,7 @@ impl<'a, T> Iterator for Range<'a, T> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
 
     #[test]

--- a/lib/propolis/src/vmm/mem.rs
+++ b/lib/propolis/src/vmm/mem.rs
@@ -1039,7 +1039,7 @@ impl<'a, T: Copy> Iterator for MemMany<'a, T> {
 }
 
 #[cfg(test)]
-pub mod tests {
+pub mod test {
     use super::*;
 
     const TEST_LEN: usize = 16 * 1024;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -10,6 +10,7 @@ mod task_fmt;
 mod task_license;
 mod task_phd;
 mod task_prepush;
+mod task_style;
 mod util;
 
 #[derive(Parser)]
@@ -43,6 +44,8 @@ enum Cmds {
         #[clap(subcommand)]
         cmd: task_phd::Cmd,
     },
+    /// Perform misc style checks
+    Style,
 }
 
 fn main() -> Result<()> {
@@ -62,6 +65,12 @@ fn main() -> Result<()> {
             task_prepush::cmd_prepush()?;
 
             println!("Pre-push checks pass");
+            Ok(())
+        }
+        Cmds::Style => {
+            task_style::cmd_style()?;
+
+            println!("Style checks pass");
             Ok(())
         }
     }

--- a/xtask/src/task_prepush.rs
+++ b/xtask/src/task_prepush.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{bail, Result};
 
-use crate::{task_clippy, task_fmt, task_license};
+use crate::{task_clippy, task_fmt, task_license, task_style};
 
 pub(crate) fn cmd_prepush() -> Result<()> {
     let mut errs = Vec::new();
@@ -16,6 +16,9 @@ pub(crate) fn cmd_prepush() -> Result<()> {
     }
     if task_license::cmd_license().is_err() {
         errs.push("license");
+    }
+    if task_style::cmd_style().is_err() {
+        errs.push("style");
     }
 
     if !errs.is_empty() {

--- a/xtask/src/task_style.rs
+++ b/xtask/src/task_style.rs
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::BTreeSet;
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+
+use anyhow::Result;
+
+use crate::util::*;
+
+fn check_test_names() -> Result<()> {
+    let wroot = workspace_root()?;
+
+    let mut cmd = Command::new("cargo");
+    let child = cmd
+        .args(["test", "--workspace", "--", "--list", "--format=terse"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .current_dir(&wroot)
+        .spawn()?;
+
+    let problem_mods = BufReader::new(child.stdout.expect("stdout is present"))
+        .lines()
+        .map_while(std::result::Result::ok)
+        .filter_map(|line| {
+            // Look for "<test name>: test"
+            let test_name = match line.rsplit_once(": ") {
+                Some((p, "test")) => p,
+                _ => return None,
+            };
+
+            // skip doctests which follow "<path> - <testname> (line <num>)"
+            if test_name.contains(" - ") {
+                return None;
+            }
+
+            // Check for `mod tests` instead of `mod test` as the last component of
+            // the test name;
+            match test_name.split("::").collect::<Vec<_>>().iter().nth_back(1) {
+                Some(&"tests") => {
+                    Some(test_name.rsplit_once("::").unwrap().0.to_owned())
+                }
+                _ => None,
+            }
+        })
+        .collect::<BTreeSet<_>>();
+
+    if !problem_mods.is_empty() {
+        eprintln!("The following test module paths should use `mod test` instead of `mod tests`:");
+        for path in problem_mods {
+            eprintln!("\t{path}");
+        }
+        Err(anyhow::anyhow!("Unconforming test module names"))
+    } else {
+        Ok(())
+    }
+}
+
+pub(crate) fn cmd_style() -> Result<()> {
+    check_test_names()
+}


### PR DESCRIPTION
Keep a consistent style of `mod test`, rather than a mix of that and `mod tests`.  Enforce this new rule with a rudimentary check, added as `xtask style`.