### PR TITLE
Modernize fw_cfg emulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3457,6 +3457,7 @@ dependencies = [
  "usdt 0.5.0",
  "uuid",
  "viona_api",
+ "zerocopy 0.7.34",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,3 +159,4 @@ tracing-bunyan-formatter = "0.3.3"
 tracing-subscriber = "0.3.14"
 usdt = { version = "0.5", default-features = false }
 uuid = "1.3.2"
+zerocopy = "0.7.34"

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -29,6 +29,7 @@ erased-serde.workspace = true
 serde_json.workspace = true
 strum = { workspace = true, features = ["derive"] }
 uuid.workspace = true
+zerocopy = { workspace = true, features = ["derive", "byteorder" ] }
 crucible-client-types = { workspace = true, optional = true }
 crucible = { workspace = true, optional = true }
 oximeter = { workspace = true, optional = true }

--- a/lib/propolis/src/common.rs
+++ b/lib/propolis/src/common.rs
@@ -136,6 +136,9 @@ impl<'a> ReadOp<'a> {
     pub fn offset(&self) -> usize {
         self.offset
     }
+    pub fn bytes_written(&self) -> usize {
+        self.write_offset
+    }
 
     pub fn write_u8(&mut self, val: u8) {
         self.write_bytes(&val.to_le_bytes()[..]);
@@ -269,6 +272,9 @@ impl<'a> WriteOp<'a> {
     }
     pub fn offset(&self) -> usize {
         self.offset
+    }
+    pub fn bytes_read(&self) -> usize {
+        self.read_offset
     }
 
     fn read_val<const COUNT: usize>(&mut self) -> [u8; COUNT] {


### PR DESCRIPTION
Being one of the early parts of the prototypical Propolis, the fw_cfg emulation was rather unpolished, and lacked the ability for entries to be added or removed after instance initialization.

This change should improve it on several fronts:
- Entries can be added and/or removed during runtime
- Association of any RamFB device is more flexible and can also be modified during runtime
- fw_cfg entries are properly migrated, instead of requiring identical population on the destination instance.
- A modicum of test coverage is present