### PR TITLE
Don't return None from BlockData::block_for_req when attachment is paused

### DIFF
--- a/lib/propolis/src/block/attachment.rs
+++ b/lib/propolis/src/block/attachment.rs
@@ -70,16 +70,12 @@ impl BlockData {
                         // conditions under protection of the lock before
                         // finally blocking.
                         let guard = self.lock.lock().unwrap();
-                        match check_state(att_state) {
-                            Err(ReqError::Stopped | ReqError::Detached) => {
-                                return None;
-                            }
-                            Ok(())
-                            | Err(ReqError::Paused | ReqError::NonePending) => {
-                                let _guard = self.cv.wait(guard).unwrap();
-                                continue;
-                            }
+                        if !att_state.is_attached() || att_state.is_stopped() {
+                            return None;
                         }
+
+                        let _guard = self.cv.wait(guard).unwrap();
+                        continue;
                     }
                     _ => {
                         return None;

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -849,7 +849,7 @@ impl TestVm {
 
     /// Sends `string` to the guest's serial console worker, then waits for the
     /// entire string to be sent to the guest before returning.
-    pub(crate) async fn send_serial_str(&self, string: &str) -> Result<()> {
+    pub async fn send_serial_str(&self, string: &str) -> Result<()> {
         if !string.is_empty() {
             self.send_serial_bytes(Vec::from(string.as_bytes()))?.await?;
         }

--- a/phd-tests/tests/src/crucible/smoke.rs
+++ b/phd-tests/tests/src/crucible/smoke.rs
@@ -17,6 +17,33 @@ async fn boot_test(ctx: &Framework) {
 }
 
 #[phd_testcase]
+async fn api_reboot_test(ctx: &Framework) {
+    let mut config = ctx.vm_config_builder("crucible_guest_reboot_test");
+    super::add_default_boot_disk(ctx, &mut config)?;
+
+    let mut vm = ctx.spawn_vm(&config, None).await?;
+    vm.launch().await?;
+    vm.wait_to_boot().await?;
+    vm.reset().await?;
+    vm.wait_to_boot().await?;
+}
+
+#[phd_testcase]
+async fn guest_reboot_test(ctx: &Framework) {
+    let mut config = ctx.vm_config_builder("crucible_guest_reboot_test");
+    super::add_default_boot_disk(ctx, &mut config)?;
+
+    let mut vm = ctx.spawn_vm(&config, None).await?;
+    vm.launch().await?;
+    vm.wait_to_boot().await?;
+
+    // Don't use `run_shell_command` because the guest won't echo another prompt
+    // after this.
+    vm.send_serial_str("reboot\n").await?;
+    vm.wait_to_boot().await?;
+}
+
+#[phd_testcase]
 async fn shutdown_persistence_test(ctx: &Framework) {
     let mut config =
         ctx.vm_config_builder("crucible_shutdown_persistence_test");

--- a/phd-tests/tests/src/smoke.rs
+++ b/phd-tests/tests/src/smoke.rs
@@ -16,6 +16,27 @@ async fn nproc_test(ctx: &Framework) {
 }
 
 #[phd_testcase]
+async fn api_reboot_test(ctx: &Framework) {
+    let mut vm = ctx.spawn_default_vm("api_reboot_test").await?;
+    vm.launch().await?;
+    vm.wait_to_boot().await?;
+    vm.reset().await?;
+    vm.wait_to_boot().await?;
+}
+
+#[phd_testcase]
+async fn guest_reboot_test(ctx: &Framework) {
+    let mut vm = ctx.spawn_default_vm("guest_reboot_test").await?;
+    vm.launch().await?;
+    vm.wait_to_boot().await?;
+
+    // Don't use `run_shell_command` because the guest won't echo another prompt
+    // after this.
+    vm.send_serial_str("reboot\n").await?;
+    vm.wait_to_boot().await?;
+}
+
+#[phd_testcase]
 async fn instance_spec_get_test(ctx: &Framework) {
     let mut vm = ctx
         .spawn_vm(


### PR DESCRIPTION
Change `BlockData::block_for_req` so that it doesn't return early when the device/backend pair is paused. (The async block backend's request future doesn't have this issue.)

Add PHD tests for guest reboot (both in-guest and API-driven) to verify the fix; the non-Crucible variants of these tests fail without this fix and pass with them. The Crucible variants (which use the async driver) pass without issue, but it's useful to get coverage there, too.

Fix PHD's raw-buffering serial adapter so that, if a caller asks to wait for a string to appear in the buffer, the buffer properly trims its contents when the wait is satisfied. This is needed to keep the new tests from passing trivially; without the fix, the first login sequence to appear on the serial console satisfies all of the "wait for guest to boot" calls in the rest of the test.

Tests: PHD runs of Alpine and Debian 11 w/new test cases.

Fixes #709. Fixes #710.