### PR TITLE
Build and clippy fixes for Rust 1.79

### DIFF
--- a/lib/propolis/src/hw/nvme/cmds.rs
+++ b/lib/propolis/src/hw/nvme/cmds.rs
@@ -54,7 +54,7 @@ pub enum AdminCmd {
     /// Asynchronous Event Request Command
     AsyncEventReq,
     /// An unknown admin command
-    Unknown(SubmissionQueueEntry),
+    Unknown(#[allow(dead_code)] SubmissionQueueEntry),
 }
 
 impl AdminCmd {
@@ -141,6 +141,7 @@ impl AdminCmd {
 }
 
 /// Create I/O Completion Queue Command Parameters
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct CreateIOCQCmd {
     /// PRP Entry 1 (PRP1)
@@ -181,6 +182,7 @@ pub struct CreateIOCQCmd {
 }
 
 /// Create I/O Submission Queue Command Parameters
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct CreateIOSQCmd {
     /// PRP Entry 1 (PRP1)
@@ -236,6 +238,7 @@ pub enum QueuePriority {
 }
 
 /// Get Log Page Command Parameters
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct GetLogPageCmd {
     /// Namespace Identifier (NSID)
@@ -278,6 +281,7 @@ impl GetLogPageCmd {
 /// The type of Log pages that may be retrieved with the Get Log Page command.
 ///
 /// See NVMe 1.0e Section 5.10.1, Figure 58 Get Log Page - Log Page Identifiers
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum LogPageIdent {
     /// Reserved Log Page
@@ -432,7 +436,7 @@ pub enum FeatureIdent {
     /// See NVMe 1.0e Section 7.6.1.1 Software Progress Marker
     SoftwareProgressMarker,
     /// Vendor specific feature.
-    Vendor(u8),
+    Vendor(#[allow(dead_code)] u8),
 }
 
 impl From<u8> for FeatureIdent {
@@ -631,6 +635,7 @@ impl From<FeatInterruptVectorConfig> for u32 {
 }
 
 /// A parsed NVM Command
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum NvmCmd {
     /// Commit data and metadata

--- a/lib/propolis/src/hw/ps2/keyboard/mod.rs
+++ b/lib/propolis/src/hw/ps2/keyboard/mod.rs
@@ -9,7 +9,7 @@ use std::convert::TryFrom;
 
 use anyhow::{anyhow, Result};
 use rfb::keysym::AsciiChar;
-use rfb::keysym::KeySym::{self, *};
+use rfb::keysym::KeySym::*;
 use rfb::rfb::KeyEvent;
 
 use scan_code_1::*;
@@ -64,7 +64,6 @@ pub struct ScanCodeBase {
 #[derive(Debug)]
 pub struct KeyEventRep {
     pub keysym_raw: u32,
-    pub keysym: KeySym,
     pub is_pressed: bool,
     pub scan_code_1: ScanCodeBase,
     pub scan_code_2: ScanCodeBase,
@@ -317,7 +316,6 @@ impl TryFrom<KeyEvent> for KeyEventRep {
         let sc2 = ScanCodeBase { base_val: base_val_2, prefix: prefix_2 };
 
         Ok(Self {
-            keysym: keyevent.keysym(),
             keysym_raw: keyevent.keysym_raw(),
             is_pressed: keyevent.is_pressed(),
             scan_code_1: sc1,

--- a/phd-tests/testcase_macro/Cargo.toml
+++ b/phd-tests/testcase_macro/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-proc_macro = true
+proc-macro = true
 test = false
 doctest = false
 

--- a/xtask/src/task_clippy.rs
+++ b/xtask/src/task_clippy.rs
@@ -22,8 +22,9 @@ pub(crate) fn cmd_clippy(strict: bool, quiet: bool) -> Result<()> {
         // no-deps and subsequent options must follow `--`
         cmd.args(["--", "--no-deps"]);
 
-        // be more strict about lossless casts
-        cmd.args(["--warn", "clippy::cast_lossless"]);
+        // Disable lossless cast warnings until
+        // https://github.com/oxidecomputer/usdt/issues/240 is fixed.
+        // cmd.args(["--warn", "clippy::cast_lossless"]);
 
         if strict {
             cmd.arg("-Dwarnings");


### PR DESCRIPTION
- Remove an unread struct field from the PS/2 keyboard implementation.
- Suppress unread field warnings for NVMe structs/enums that are meant explicitly to match data types in the NVMe spec.
- Disable the `cast_lossless` warning for now, since in Rust 1.79 it now applies within macro expansions, which causes new warnings to fire from USDT probe invocations.
- Use a hyphen instead of an underscore in PHD's testcase macro crate to fix a forward-compatibility warning.

Tests: `cargo build --all-targets` with both 1.78 and current stable.