### PR TITLE
Allow boot order config in propolis-standalone

### DIFF
--- a/bin/propolis-standalone/README.md
+++ b/bin/propolis-standalone/README.md
@@ -23,6 +23,9 @@ memory = 1024
 # Exit propolis-standalone process with <code> if instance reboots (default: unset)
 # exit_on_reboot = <code>
 
+# Override boot order (via communication to OVMF bootrom)
+# boot_order = ["net0", "block0"]
+
 [block_dev.alpine_iso]
 type = "file"
 path = "/path/to/alpine-extended-3.12.0-x86_64.iso"

--- a/bin/propolis-standalone/src/config.rs
+++ b/bin/propolis-standalone/src/config.rs
@@ -61,6 +61,9 @@ pub struct Main {
     /// Default: None, does not exit on reboot
     #[serde(default)]
     pub exit_on_reboot: Option<u8>,
+
+    /// Request bootrom override boot order using the devices specified
+    pub boot_order: Option<Vec<String>>,
 }
 
 /// A hard-coded device, either enabled by default or accessible locally

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -981,7 +981,9 @@ fn generate_bootorder(config: &config::Config) -> anyhow::Result<fwcfg::Entry> {
                 order.add_pci(get_pci_path().location, "device");
             }
             dev => {
-                anyhow::bail!("Unsupported boot device type: {dev}");
+                anyhow::bail!(
+                    "Boot device '{name}' is unsupported device type: {dev}"
+                );
             }
         }
     }
@@ -1298,7 +1300,13 @@ fn setup_instance(
     // It is "safe" to generate bootorder (if requested) now, given that PCI
     // device configuration has been validated by preceding logic
     if config.main.boot_order.is_some() {
-        fwcfg.insert_named("bootorder", generate_bootorder(&config)?).unwrap();
+        fwcfg
+            .insert_named(
+                "bootorder",
+                generate_bootorder(&config)
+                    .context("Failed to generate boot order")?,
+            )
+            .unwrap();
     }
 
     fwcfg.attach(pio, &machine.acc_mem);

--- a/lib/propolis/src/hw/pci/mod.rs
+++ b/lib/propolis/src/hw/pci/mod.rs
@@ -38,6 +38,12 @@ impl BusNum {
         self.0
     }
 }
+
+impl From<BusNum> for u8 {
+    fn from(value: BusNum) -> Self {
+        value.get()
+    }
+}
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Ord, PartialOrd)]
 pub struct DevNum(u8);
 impl DevNum {
@@ -68,6 +74,13 @@ impl DevNum {
         self.0
     }
 }
+
+impl From<DevNum> for u8 {
+    fn from(value: DevNum) -> Self {
+        value.get()
+    }
+}
+
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Ord, PartialOrd)]
 pub struct FuncNum(u8);
 impl FuncNum {
@@ -96,6 +109,12 @@ impl FuncNum {
     }
     pub const fn get(&self) -> u8 {
         self.0
+    }
+}
+
+impl From<FuncNum> for u8 {
+    fn from(value: FuncNum) -> Self {
+        value.get()
     }
 }
 

--- a/lib/propolis/src/hw/qemu/fwcfg.rs
+++ b/lib/propolis/src/hw/qemu/fwcfg.rs
@@ -1086,6 +1086,9 @@ pub mod formats {
             // nvme devices as vendor=0x8086 and device=5845.  While that
             // hardcoded logic exists, we must encode our entry to match, even
             // when the device in question may bear different identity info.
+            //
+            // For more details, see the TranslatePciOfwNodes() function in
+            // OvmfPkg/Library/QemuBootOrderLib/QemuBootOrderLib.c.
             let pci_path = Self::format_pci(loc, "pci8086,5845");
             let ns = 1;
             self.0.push(format!("{pci_path}/namespace@{ns:x},{eui:x}"));


### PR DESCRIPTION
While the propolis-server bits of this aren't entirely hammered out, I figured I'd get the initial pieces in.