### PR TITLE
Allow direct use of OPTE/XDE ports under Viona

### DIFF
--- a/crates/dladm/src/lib.rs
+++ b/crates/dladm/src/lib.rs
@@ -39,13 +39,17 @@ impl Handle {
         })?;
 
         match datalink_class::from_repr(class) {
-            Some(datalink_class::DATALINK_CLASS_VNIC) => {
-                // acceptable value
+            Some(
+                datalink_class::DATALINK_CLASS_VNIC
+                | datalink_class::DATALINK_CLASS_MISC,
+            ) => {
+                // acceptable values: this supports both VNICs
+                // and direct use of XDE/OPTE ports.
             }
             Some(c) => {
                 return Err(Error::new(
                     ErrorKind::InvalidInput,
-                    format!("{} is not vnic class, but {:?}", name, c),
+                    format!("{} is not vnic/misc class, but {:?}", name, c),
                 ));
             }
             None => {

--- a/crates/dladm/src/lib.rs
+++ b/crates/dladm/src/lib.rs
@@ -24,7 +24,7 @@ impl Handle {
         Ok(Self { inner: hdl })
     }
 
-    pub fn query_vnic(&self, name: &str) -> Result<LinkInfo> {
+    pub fn query_link(&self, name: &str) -> Result<LinkInfo> {
         let name_cstr = CString::new(name).unwrap();
         let mut link_id: sys::datalink_id_t = 0;
         let mut class: i32 = 0;

--- a/crates/dladm/src/lib.rs
+++ b/crates/dladm/src/lib.rs
@@ -142,13 +142,14 @@ impl Handle {
             let state = &mut *(arg as *mut Arg);
             state.n_seen += 1;
 
-            if !state.written && (*macaddr).ma_addrlen == (ETHERADDRL as u32) {
+            if (*macaddr).ma_addrlen == (ETHERADDRL as u32) {
                 state.mac.copy_from_slice(&(*macaddr).ma_addr[..ETHERADDRL]);
                 state.written = true;
+                sys::boolean_t::B_FALSE
+            } else {
+                // Keep going.
+                sys::boolean_t::B_TRUE
             }
-
-            // Keep going.
-            sys::boolean_t::B_TRUE
         }
 
         struct Arg<'a> {
@@ -165,7 +166,7 @@ impl Handle {
             sys::dladm_walk_macaddr(
                 self.inner,
                 linkid,
-                addr_of_mut!(state) as *mut c_void,
+                &mut state as *mut _ as *mut c_void,
                 per_macaddr,
             )
         })?;

--- a/crates/dladm/src/lib.rs
+++ b/crates/dladm/src/lib.rs
@@ -5,7 +5,6 @@
 use std::ffi::CString;
 use std::io::{BufRead, BufReader, Error, ErrorKind, Result};
 use std::process::{Command, Stdio};
-use std::ptr::addr_of_mut;
 
 #[allow(non_camel_case_types)]
 mod sys;

--- a/crates/dladm/src/sys.rs
+++ b/crates/dladm/src/sys.rs
@@ -80,6 +80,7 @@ pub struct dladm_macaddr_attr_t {
     pub ma_client_name: [c_char; MAXNAMELEN],
     pub ma_client_linkid: datalink_id_t,
 }
+#[allow(unused)]
 #[repr(C)]
 pub enum boolean_t {
     B_FALSE,

--- a/crates/dladm/src/sys.rs
+++ b/crates/dladm/src/sys.rs
@@ -66,6 +66,7 @@ pub enum datalink_class {
     DATALINK_CLASS_BRIDGE = 0x40,
     DATALINK_CLASS_IPTUN = 0x80,
     DATALINK_CLASS_PART = 0x100,
+    DATALINK_CLASS_MISC = 0x400,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, FromRepr)]

--- a/crates/dladm/src/sys.rs
+++ b/crates/dladm/src/sys.rs
@@ -80,7 +80,6 @@ pub struct dladm_macaddr_attr_t {
     pub ma_client_name: [c_char; MAXNAMELEN],
     pub ma_client_linkid: datalink_id_t,
 }
-#[allow(unused)]
 #[repr(C)]
 pub enum boolean_t {
     B_FALSE,

--- a/crates/dladm/src/sys.rs
+++ b/crates/dladm/src/sys.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use libc::c_int;
+use libc::{c_char, c_int, c_uchar, c_uint, c_void};
 use strum::FromRepr;
 
 #[cfg(target_os = "illumos")]
@@ -19,12 +19,20 @@ extern "C" {
         classp: *mut c_int,
         mediap: *mut u32,
     ) -> c_int;
+    pub fn dladm_walk_macaddr(
+        handle: dladm_handle_t,
+        linkid: datalink_id_t,
+        arg: *mut c_void,
+        callback: unsafe extern "C" fn(
+            *mut c_void,
+            *mut dladm_macaddr_attr_t,
+        ) -> boolean_t,
+    ) -> c_int;
 }
 
 #[cfg(not(target_os = "illumos"))]
 mod compat {
     #![allow(unused)]
-
     use super::*;
 
     pub unsafe extern "C" fn dladm_open(handle: *mut dladm_handle_t) -> c_int {
@@ -33,7 +41,6 @@ mod compat {
     pub unsafe extern "C" fn dladm_close(handle: dladm_handle_t) {
         panic!("illumos only");
     }
-    #[cfg(not(target_os = "illumos"))]
     pub unsafe extern "C" fn dladm_name2info(
         handle: dladm_handle_t,
         link: *const u8,
@@ -45,6 +52,17 @@ mod compat {
     ) -> c_int {
         panic!("illumos only");
     }
+    pub unsafe extern "C" fn dladm_walk_macaddr(
+        handle: dladm_handle_t,
+        linkid: datalink_id_t,
+        arg: *mut c_void,
+        callback: unsafe extern "C" fn(
+            *mut c_void,
+            *mut dladm_macaddr_attr_t,
+        ) -> boolean_t,
+    ) -> c_int {
+        panic!("illumos only");
+    }
 }
 #[cfg(not(target_os = "illumos"))]
 pub use compat::*;
@@ -53,6 +71,23 @@ pub use compat::*;
 pub enum dladm_handle {}
 pub type dladm_handle_t = *mut dladm_handle;
 pub type datalink_id_t = u32;
+#[repr(C)]
+pub struct dladm_macaddr_attr_t {
+    pub ma_slot: c_uint,
+    pub ma_flags: c_uint,
+    pub ma_addr: [c_uchar; MAXMACADDRLEN],
+    pub ma_addrlen: c_uint,
+    pub ma_client_name: [c_char; MAXNAMELEN],
+    pub ma_client_linkid: datalink_id_t,
+}
+#[repr(C)]
+pub enum boolean_t {
+    B_FALSE,
+    B_TRUE,
+}
+
+const MAXMACADDRLEN: usize = 20;
+const MAXNAMELEN: usize = 256;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, FromRepr)]
 #[repr(i32)]

--- a/lib/propolis/src/hw/virtio/viona.rs
+++ b/lib/propolis/src/hw/virtio/viona.rs
@@ -105,7 +105,7 @@ impl PciVirtioViona {
         vm: &VmmHdl,
     ) -> io::Result<Arc<PciVirtioViona>> {
         let dlhdl = dladm::Handle::new()?;
-        let info = dlhdl.query_vnic(vnic_name)?;
+        let info = dlhdl.query_link(vnic_name)?;
         let hdl = VionaHdl::new(info.link_id, vm.fd())?;
 
         // TX and RX


### PR DESCRIPTION
This PR allows propolis to construct viona instances on top of `misc`-type links (i.e., OPTE pseudo-devices), in addition to the existing VNIC support.

Unfortunately, `misc` devices are not well-serviced by `dladm`. Pulling the MAC address of a misc-type device requires that we directly interface with libdllink/libdladm -- what I have here works for creating and using the network from VMs, but if there's a simpler way I'd prefer we use that.