### PR TITLE
PciVirtio should properly import lintr state

### DIFF
--- a/lib/propolis/src/hw/virtio/viona.rs
+++ b/lib/propolis/src/hw/virtio/viona.rs
@@ -481,7 +481,16 @@ impl MigrateMulti for PciVirtioViona {
         offer: &mut PayloadOffers,
         ctx: &MigrateCtx,
     ) -> Result<(), MigrateStateError> {
-        <dyn PciVirtio>::import(self, offer, ctx)
+        <dyn PciVirtio>::import(self, offer, ctx)?;
+
+        let feat = self.virtio_state.negotiated_features();
+        self.hdl.set_features(feat).map_err(|e| {
+            MigrateStateError::ImportFailed(format!(
+                "error while setting viona features ({feat:x}): {e:?}"
+            ))
+        })?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Guests should rarely (read: never) be using legacy pin interrupts on virtio (or really any PCI) devices, but if they do, we should properly import that state during a migration.