### PR TITLE
split migrate-from-base tests into a separate PHD run

### DIFF
--- a/.github/buildomat/jobs/phd-build.sh
+++ b/.github/buildomat/jobs/phd-build.sh
@@ -48,6 +48,7 @@ tar -czvf target/debug/phd-runner.tar.gz \
 banner copy
 pfexec mkdir -p $outdir
 pfexec chown "$UID" $outdir
+cp .github/buildomat/phd-run-with-args.sh $outdir/phd-run-with-args.sh
 mv target/debug/propolis-server-debug.tar.gz \
 	$outdir/propolis-server-debug.tar.gz
 mv target/debug/phd-runner.tar.gz $outdir/phd-runner.tar.gz

--- a/.github/buildomat/jobs/phd-run-migrate-from-base.sh
+++ b/.github/buildomat/jobs/phd-run-migrate-from-base.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #:
-#: name = "phd-run"
+#: name = "phd-run-migrate-from-base"
 #: variety = "basic"
 #: target = "lab-2.0-opte"
 #: output_rules = [
@@ -15,4 +15,4 @@
 
 cp /input/phd-build/out/phd-run-with-args.sh /tmp/phd-run-with-args.sh
 chmod a+x /tmp/phd-run-with-args.sh
-exec /tmp/phd-run-with-args.sh --exclude-filter "phd_tests::migrate::from_base"
+exec /tmp/phd-run-with-args.sh --include-filter "phd_tests::migrate::from_base"

--- a/.github/buildomat/jobs/phd-run-migrate-from-base.sh
+++ b/.github/buildomat/jobs/phd-run-migrate-from-base.sh
@@ -15,4 +15,6 @@
 
 cp /input/phd-build/out/phd-run-with-args.sh /tmp/phd-run-with-args.sh
 chmod a+x /tmp/phd-run-with-args.sh
-exec /tmp/phd-run-with-args.sh --include-filter "phd_tests::migrate::from_base"
+exec /tmp/phd-run-with-args.sh \
+    --include-filter "phd_tests::migrate::from_base" \
+    --base-propolis-branch master

--- a/.github/buildomat/jobs/phd-run-migrate-from-base.sh
+++ b/.github/buildomat/jobs/phd-run-migrate-from-base.sh
@@ -13,6 +13,17 @@
 #: job = "phd-build"
 #:
 
+# This job runs the PHD migrate-from-base tests, which test upgrading from the
+# current mainline propolis-server to the propolis-server version under test.
+#
+# PHD always uses the propolis-client from the commit under test, so these tests
+# will fail if there is a breaking change to the Propolis API. They'll also fail
+# if there's a breaking change to the migration protocol. These changes may be
+# expected, in which case this run will fail. However, the "regular" phd-run
+# job should always be green before merging new PRs.
+#
+# This job will be removed once API breaking changes are no longer allowed.
+
 cp /input/phd-build/out/phd-run-with-args.sh /tmp/phd-run-with-args.sh
 chmod a+x /tmp/phd-run-with-args.sh
 exec /tmp/phd-run-with-args.sh \

--- a/.github/buildomat/jobs/phd-run.sh
+++ b/.github/buildomat/jobs/phd-run.sh
@@ -13,6 +13,12 @@
 #: job = "phd-build"
 #:
 
+# This job runs all the PHD test cases that don't involve upgrading from an
+# earlier version of Propolis.
+#
+# These tests should always pass even in the presence of breaking changes to the
+# Propolis API or live migration protocol.
+
 cp /input/phd-build/out/phd-run-with-args.sh /tmp/phd-run-with-args.sh
 chmod a+x /tmp/phd-run-with-args.sh
 exec /tmp/phd-run-with-args.sh --exclude-filter "phd_tests::migrate::from_base"

--- a/.github/buildomat/phd-run-with-args.sh
+++ b/.github/buildomat/phd-run-with-args.sh
@@ -47,15 +47,15 @@ ls $runner
 ls $artifacts
 ls $propolis
 
-args=()
-args+=($runner '--emit-bunyan' 'run')
-args+=('--propolis-server-cmd' $propolis)
-args+=('--base-propolis-branch' 'master')
-args+=('--crucible-downstairs-commit' 'auto')
-args+=('--artifact-toml-path' $artifacts)
-args+=('--tmp-directory' $tmpdir)
-args+=('--artifact-directory' $artifactdir)
-args+=($@)
+args=(
+    $runner '--emit-bunyan' 'run'
+    '--propolis-server-cmd' $propolis
+    '--crucible-downstairs-commit' 'auto'
+    '--artifact-toml-path' $artifacts
+    '--tmp-directory' $tmpdir
+    '--artifact-directory' $artifactdir
+    $@
+)
 
 # Disable errexit so that we still upload logs on failure
 set +e

--- a/.github/buildomat/phd-run-with-args.sh
+++ b/.github/buildomat/phd-run-with-args.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Unpacks and executes the PHD runner in the Buildomat environment, passing
+# through to the runner any arguments that were passed to this script.
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+indir="/input"
+indir_suffix="phd-build/out/*.tar.gz"
+phddir="$PWD/phd-test"
+
+# Put artifacts on the runner's SSDs (the /work ramdisk is small by design, too
+# small for images of any appreciable size).
+pfexec zpool create -f phd-artifacts c1t1d0 c2t1d0
+artifactdir="/phd-artifacts"
+
+banner 'Inputs'
+find $indir -ls
+
+rm -rf "$phddir"
+mkdir "$phddir"
+
+for p in $indir/$indir_suffix; do
+	tar xzvf $p -C $phddir
+	for f in $(tar tf "$p"); do
+		chmod +x "$phddir/$f"
+	done
+done
+
+ls $phddir
+
+banner 'Setup'
+tmpdir="/tmp/propolis-phd"
+if [ ! -d "$tmpdir" ]; then
+	mkdir $tmpdir
+fi
+
+banner 'Tests'
+
+runner="$phddir/phd-runner"
+artifacts="$phddir/artifacts.toml"
+propolis="$phddir/propolis-server"
+
+ls $runner
+ls $artifacts
+ls $propolis
+
+args=()
+args+=($runner '--emit-bunyan' 'run')
+args+=('--propolis-server-cmd' $propolis)
+args+=('--base-propolis-branch' 'master')
+args+=('--crucible-downstairs-commit' 'auto')
+args+=('--artifact-toml-path' $artifacts)
+args+=('--tmp-directory' $tmpdir)
+args+=('--artifact-directory' $artifactdir)
+args+=($@)
+
+# Disable errexit so that we still upload logs on failure
+set +e
+(RUST_BACKTRACE=1 RUST_LOG="info,phd=debug" ptime -m pfexec "${args[@]}" | \
+    tee /tmp/phd-runner.log)
+failcount=$?
+set -e
+
+tar -czvf /tmp/phd-tmp-files.tar.gz \
+	-C /tmp/propolis-phd /tmp/propolis-phd/*.log \
+	-C /tmp/propolis-phd /tmp/propolis-phd/*.toml
+
+exitcode=0
+if [ $failcount -eq 0 ]; then
+	echo
+	echo "ALL TESTS PASSED"
+	echo
+else
+	echo
+	echo "SOME TESTS FAILED"
+	echo
+	exitcode=1
+fi
+
+if find /dev/vmm -mindepth 1 -maxdepth 1 | read ; then
+	echo "VMM handles leaked:"
+	find /dev/vmm -type c -exec basename {} \;
+	exitcode=2
+fi
+
+exit $exitcode


### PR DESCRIPTION
Move the existing phd-run script into a callable phd-run-with-args.sh that passes its arguments through to its phd-runner invocation. Then create separate "run PHD" jobs that call this script, respectively including and excluding the migrate-from-base tests from their runs.

Fixes #732.