### PR TITLE
add InstanceMetadata derive to falcon client

### DIFF
--- a/lib/propolis-client/src/lib.rs
+++ b/lib/propolis-client/src/lib.rs
@@ -53,6 +53,8 @@ progenitor::generate_api!(
         PciPath = { derives = [
             Copy, Clone, Debug, Ord, Eq, PartialEq, PartialOrd, Serialize, Deserialize
         ] },
+
+        InstanceMetadata = { derives = [ PartialEq ] },
     }
 );
 


### PR DESCRIPTION
This fixes the build when building PHD against the Falcon version of propolis-client. (PHD doesn't actually use Falcon devices or require a Falcon-compatible propolis-server, but your humble author tells rust-analyzer to enable the feature on all `cargo check` runs in this repo and is mildly aggravated by seeing errors in the trouble pane.)