### PR TITLE
remove bare Serialize and Deserialize progenitor patch imperatives

### DIFF
--- a/bin/mock-server/src/lib/api_types.rs
+++ b/bin/mock-server/src/lib/api_types.rs
@@ -9,27 +9,9 @@ progenitor::generate_api!(
     spec = "../../openapi/propolis-server.json",
     derives = [schemars::JsonSchema],
     patch = {
-        InstanceMetadata = {
-            derives = [
-                Clone,
-                schemars::JsonSchema,
-                Serialize,
-                Deserialize,
-                Eq,
-                PartialEq,
-            ]
-        },
-        InstanceProperties = {
-            derives = [
-                Clone,
-                schemars::JsonSchema,
-                Serialize,
-                Deserialize,
-                Eq,
-                PartialEq,
-            ]
-        },
-        Slot = { derives = [Copy, Clone, schemars::JsonSchema, Serialize, Deserialize] },
+        InstanceMetadata = { derives = [Clone, Eq, PartialEq] },
+        InstanceProperties = { derives = [ Clone, Eq, PartialEq ] },
+        Slot = { derives = [Copy] },
     },
 );
 

--- a/lib/propolis-client/Cargo.toml
+++ b/lib/propolis-client/Cargo.toml
@@ -13,8 +13,8 @@ futures.workspace = true
 progenitor.workspace = true
 rand.workspace = true
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
-schemars = { workspace = true, features = [ "uuid1" ] }
-serde.workspace = true
+schemars = { workspace = true, features = ["uuid1"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 slog.workspace = true
 thiserror.workspace = true

--- a/lib/propolis-client/src/lib.rs
+++ b/lib/propolis-client/src/lib.rs
@@ -24,7 +24,7 @@ progenitor::generate_api!(
         Slot = { derives = [schemars::JsonSchema] },
 
         PciPath = { derives = [
-            Copy, Clone, Debug, Ord, Eq, PartialEq, PartialOrd
+            Copy, Ord, Eq, PartialEq, PartialOrd
         ] },
 
         InstanceMetadata = { derives = [ PartialEq ] },

--- a/lib/propolis-client/src/lib.rs
+++ b/lib/propolis-client/src/lib.rs
@@ -11,20 +11,20 @@ progenitor::generate_api!(
     tags = Separate,
     patch = {
         // Add `Default` to types related to instance specs
-        InstanceSpecV0 = { derives = [Clone, Debug, Default, Serialize, Deserialize] },
-        BackendSpecV0 = { derives = [Clone, Debug, Default, Serialize, Deserialize] },
-        DeviceSpecV0 = { derives = [Clone, Debug, Default, Serialize, Deserialize] },
-        Board = { derives = [Clone, Debug, Default, Serialize, Deserialize] },
+        InstanceSpecV0 = { derives = [Default] },
+        BackendSpecV0 = { derives = [Default] },
+        DeviceSpecV0 = { derives = [Default] },
+        Board = { derives = [Default] },
 
         // Some Crucible-related bits are re-exported through simulated
         // sled-agent and thus require JsonSchema
-        DiskRequest = { derives = [Clone, Debug, schemars::JsonSchema, Serialize, Deserialize] },
-        VolumeConstructionRequest = { derives = [Clone, Debug, schemars::JsonSchema, Serialize, Deserialize] },
-        CrucibleOpts = { derives = [Clone, Debug, schemars::JsonSchema, Serialize, Deserialize] },
-        Slot = { derives = [Copy, Clone, Debug, schemars::JsonSchema, Serialize, Deserialize] },
+        DiskRequest = { derives = [schemars::JsonSchema] },
+        VolumeConstructionRequest = { derives = [schemars::JsonSchema] },
+        CrucibleOpts = { derives = [schemars::JsonSchema] },
+        Slot = { derives = [schemars::JsonSchema] },
 
         PciPath = { derives = [
-            Copy, Clone, Debug, Ord, Eq, PartialEq, PartialOrd, Serialize, Deserialize
+            Copy, Clone, Debug, Ord, Eq, PartialEq, PartialOrd
         ] },
 
         InstanceMetadata = { derives = [ PartialEq ] },
@@ -38,20 +38,20 @@ progenitor::generate_api!(
     tags = Separate,
     patch = {
         // Add `Default` to types related to instance specs
-        InstanceSpecV0 = { derives = [Clone, Debug, Default, Serialize, Deserialize] },
-        BackendSpecV0 = { derives = [Clone, Debug, Default, Serialize, Deserialize] },
-        DeviceSpecV0 = { derives = [Clone, Debug, Default, Serialize, Deserialize] },
-        Board = { derives = [Clone, Debug, Default, Serialize, Deserialize] },
+        InstanceSpecV0 = { derives = [Default] },
+        BackendSpecV0 = { derives = [Default] },
+        DeviceSpecV0 = { derives = [Default] },
+        Board = { derives = [Default] },
 
         // Some Crucible-related bits are re-exported through simulated
         // sled-agent and thus require JsonSchema
-        DiskRequest = { derives = [Clone, Debug, schemars::JsonSchema, Serialize, Deserialize] },
-        VolumeConstructionRequest = { derives = [Clone, Debug, schemars::JsonSchema, Serialize, Deserialize] },
-        CrucibleOpts = { derives = [Clone, Debug, schemars::JsonSchema, Serialize, Deserialize] },
-        Slot = { derives = [Copy, Clone, Debug, schemars::JsonSchema, Serialize, Deserialize] },
+        DiskRequest = { derives = [schemars::JsonSchema] },
+        VolumeConstructionRequest = { derives = [schemars::JsonSchema] },
+        CrucibleOpts = { derives = [schemars::JsonSchema] },
+        Slot = { derives = [schemars::JsonSchema] },
 
         PciPath = { derives = [
-            Copy, Clone, Debug, Ord, Eq, PartialEq, PartialOrd, Serialize, Deserialize
+            Copy, Ord, Eq, PartialEq, PartialOrd
         ] },
 
         InstanceMetadata = { derives = [ PartialEq ] },


### PR DESCRIPTION
This doesn't update progenitor as it would require https://github.com/oxidecomputer/omicron/pull/6258 as well, but I've tested both together locally with an updated progenitor.