### PR TITLE
PHD: add support for in-memory disk backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,6 +3136,7 @@ dependencies = [
  "hex",
  "http 0.2.12",
  "libc",
+ "newtype_derive",
  "propolis-client",
  "propolis-server-config",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3130,6 +3130,7 @@ dependencies = [
  "camino",
  "cfg-if",
  "errno 0.2.8",
+ "fatfs",
  "flate2",
  "futures",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ kstat-rs = "0.2.3"
 lazy_static = "1.4"
 libc = "0.2"
 mockall = "0.12"
+newtype_derive = "0.1.6"
 newtype-uuid = { version = "1.0.1", features = [ "v4" ] }
 owo-colors = "4"
 pin-project-lite = "0.2.13"

--- a/phd-tests/framework/Cargo.toml
+++ b/phd-tests/framework/Cargo.toml
@@ -16,6 +16,7 @@ bhyve_api.workspace = true
 camino = { workspace = true, features = ["serde1"] }
 cfg-if.workspace = true
 errno.workspace = true
+fatfs.workspace = true
 futures.workspace = true
 flate2.workspace = true
 hex.workspace = true

--- a/phd-tests/framework/Cargo.toml
+++ b/phd-tests/framework/Cargo.toml
@@ -22,6 +22,7 @@ flate2.workspace = true
 hex.workspace = true
 http.workspace = true
 libc.workspace = true
+newtype_derive.workspace = true
 propolis-client.workspace = true
 propolis-server-config.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/phd-tests/framework/src/disk/fat.rs
+++ b/phd-tests/framework/src/disk/fat.rs
@@ -118,9 +118,10 @@ struct File {
 #[derive(Debug, Error)]
 pub enum Error {
     #[error(
-        "insufficient space for new file: {0} sectors required, {1} available"
+        "insufficient space for new file: {required} sectors required, \
+        {available} available"
     )]
-    NoSpace(usize, usize),
+    NoSpace { required: usize, available: usize },
 }
 
 /// Builds a collection of files that can be extruded as an array of bytes
@@ -150,7 +151,10 @@ impl FatFilesystem {
         let bytes = contents.as_bytes();
         let sectors_needed = Sectors::needed_for_bytes(bytes.len());
         if sectors_needed > self.sectors_remaining {
-            Err(Error::NoSpace(sectors_needed.0, self.sectors_remaining.0))
+            Err(Error::NoSpace {
+                required: sectors_needed.0,
+                available: self.sectors_remaining.0,
+            })
         } else {
             self.files
                 .push(File { path: path.to_owned(), contents: bytes.to_vec() });

--- a/phd-tests/framework/src/disk/fat.rs
+++ b/phd-tests/framework/src/disk/fat.rs
@@ -215,3 +215,35 @@ impl FatFilesystem {
         Ok(disk.into_inner())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn cannot_add_file_too_large_for_disk() {
+        let mut fs = FatFilesystem::new();
+        assert!(fs
+            .add_file_from_str("too_big", &"a".repeat(MAX_DISK_SIZE_BYTES))
+            .is_err());
+    }
+
+    #[test]
+    fn cannot_exceed_disk_size_limit_with_multiple_files() {
+        let mut fs = FatFilesystem::new();
+        for idx in 0..total_usable_sectors().0 {
+            assert!(
+                fs.add_file_from_str(
+                    &format!("file{idx}"),
+                    &"a".repeat(BYTES_PER_SECTOR)
+                )
+                .is_ok(),
+                "adding file {idx}"
+            );
+        }
+
+        assert!(fs
+            .add_file_from_str("file", &"a".repeat(BYTES_PER_SECTOR))
+            .is_err());
+    }
+}

--- a/phd-tests/framework/src/disk/fat.rs
+++ b/phd-tests/framework/src/disk/fat.rs
@@ -1,0 +1,209 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tools for creating a FAT volume that can be used as the contents of a VM
+//! disk.
+
+use std::io::{Cursor, Write};
+
+use anyhow::Context;
+use fatfs::{FileSystem, FormatVolumeOptions, FsOptions};
+use thiserror::Error;
+
+/// The maximum size of disk this module can create. This is fixed to put an
+/// upper bound on the overhead the FAT filesystem requires.
+///
+/// This value must be less than or equal to 2,091,008 (4084 * 512). See the
+/// docs for [`overhead_sectors`].
+const MAX_DISK_SIZE_BYTES: usize = 1 << 20;
+
+/// The size of a sector in this module's produced volumes.
+///
+/// This module assumes that each FAT cluster is one sector in size.
+const BYTES_PER_SECTOR: usize = 512;
+
+/// The size of a directory entry, given by the FAT specification.
+const BYTES_PER_DIRECTORY_ENTRY: usize = 32;
+
+/// The number of directory entries in the filesystem's root directory region.
+const ROOT_DIRECTORY_ENTRIES: usize = 512;
+
+/// The number of allocation tables that can be found in each FAT volume. This
+/// is the default value used by the `fatfs` crate.
+const TABLES_PER_VOLUME: usize = 2;
+
+/// A number of disk sectors.
+#[derive(Clone, Copy, Debug, Default)]
+struct Sectors(usize);
+
+impl Sectors {
+    /// Yields the number of sectors needed to hold the supplied quantity of
+    /// bytes.
+    const fn needed_for_bytes(bytes: usize) -> Self {
+        Self(bytes.div_ceil(BYTES_PER_SECTOR))
+    }
+}
+
+/// Computes the number of sectors to reserve for overhead in this module's FAT
+/// volumes.
+///
+/// FAT volumes consist of four regions:
+///
+/// 1. A reserved region for the BIOS parameter block (BPB)
+/// 2. The file allocation tables themselves
+/// 3. A set of root directory entries (FAT12/FAT16 only)
+/// 4. File and directory data
+///
+/// The file and directory data is divided into clusters of one or more sectors.
+/// The cluster size is given in the FAT metadata in the BPB; in this module
+/// each cluster contains just one sector.
+///
+/// The specific format of a FAT volume (FAT12 vs. FAT16 vs. FAT32) depends on
+/// the number of clusters in the file and directory data region:
+///
+/// - 0 <= clusters <= 4084: FAT12
+/// - 4085 <= clusters <= 65524: FAT16
+/// - clusters >= 65525: FAT32
+///
+/// There is a small catch-22 here: a volume's format depends on the number of
+/// clusters it has, but the number of clusters in the volume depends on the
+/// size of the filesystem metadata, which depends on the volume's format.
+/// This module avoids the problem by requiring that the total volume size is
+/// less than or equal to 4,084 sectors. The number of clusters will never be
+/// greater than this, so the filesystem will always be FAT12, which makes it
+/// possible to compute its overhead size.
+const fn overhead_sectors() -> Sectors {
+    let dir_entry_bytes = ROOT_DIRECTORY_ENTRIES * BYTES_PER_DIRECTORY_ENTRY;
+    let dir_entry_sectors = Sectors::needed_for_bytes(dir_entry_bytes);
+
+    // To compute the size of the FAT, conservatively assume that all the
+    // sectors on the disk are in addressable clusters, figure out how many
+    // bytes that would take, and convert to sectors. (In practice, some of the
+    // sectors are used for overhead and won't have entries in the FAT, but this
+    // gives an upper bound.)
+    let max_sectors = Sectors::needed_for_bytes(MAX_DISK_SIZE_BYTES);
+
+    // FAT12 tables use 12 bits per cluster entry.
+    let cluster_bits = max_sectors.0 * 12;
+    let cluster_bytes = cluster_bits.div_ceil(8);
+    let sectors_per_table = Sectors::needed_for_bytes(cluster_bytes);
+
+    // The total overhead size is one sector (for the BPB) plus the sectors
+    // needed for regions 2 and 3 (the tables themselves and the root directory
+    // entries). Note that there are multiple tables per volume!
+    Sectors(1 + (TABLES_PER_VOLUME * sectors_per_table.0) + dir_entry_sectors.0)
+}
+
+const fn usable_sectors() -> Sectors {
+    let total = Sectors::needed_for_bytes(MAX_DISK_SIZE_BYTES);
+    Sectors(total.0 - overhead_sectors().0)
+}
+
+#[derive(Clone, Debug)]
+struct File {
+    path: String,
+    contents: Vec<u8>,
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(
+        "insufficient space for new file: {0} sectors required, {1} available"
+    )]
+    NoSpace(usize, usize),
+}
+
+/// Builds a collection of files that can be extruded as an array of bytes
+/// containing a FAT filesystem with the collected files.
+#[derive(Clone, Default, Debug)]
+pub struct FatFilesystem {
+    files: Vec<File>,
+    sectors_used: Sectors,
+}
+
+impl FatFilesystem {
+    /// Creates a new file collection.
+    pub fn new() -> Self {
+        Self { files: vec![], sectors_used: Sectors(0) }
+    }
+
+    /// Adds a file with the supplied `contents` that will appear in the
+    /// resulting file system in the supplied `path`.
+    ///
+    /// N.B. `path` is interpreted relative to the root of the file system and
+    ///      should not have a leading '/'.
+    pub fn add_file_from_str(
+        &mut self,
+        path: &str,
+        contents: &str,
+    ) -> Result<(), Error> {
+        let bytes = contents.as_bytes();
+        let sectors_needed = Sectors::needed_for_bytes(bytes.len());
+        let sectors_available = usable_sectors().0 - self.sectors_used.0;
+        if sectors_available < sectors_needed.0 {
+            Err(Error::NoSpace(sectors_needed.0, sectors_available))
+        } else {
+            self.files
+                .push(File { path: path.to_owned(), contents: bytes.to_vec() });
+            self.sectors_used.0 += sectors_needed.0;
+            Ok(())
+        }
+    }
+
+    pub fn as_bytes(&self) -> anyhow::Result<Vec<u8>> {
+        let file_sectors: usize = self
+            .files
+            .iter()
+            .map(|f| Sectors::needed_for_bytes(f.contents.len()).0)
+            .sum();
+
+        assert!(file_sectors <= usable_sectors().0);
+
+        // `fatfs` requires that the output volume has at least 42 sectors, no
+        // matter what.
+        let sectors = 42.max(file_sectors + overhead_sectors().0);
+
+        assert!(sectors <= Sectors::needed_for_bytes(MAX_DISK_SIZE_BYTES).0);
+
+        // Some guest software requires that a FAT disk's sector count be a
+        // multiple of the sectors-per-track value in its BPB. Trivially enforce
+        // this by ensuring there's one track containing all the sectors.
+        let sectors_per_track: u16 = sectors.try_into().map_err(|_| {
+            anyhow::anyhow!(
+                "disk has {} sectors, which is too many for one FAT track",
+                sectors
+            )
+        })?;
+
+        let mut disk = Cursor::new(vec![0; sectors * BYTES_PER_SECTOR]);
+        fatfs::format_volume(
+            &mut disk,
+            FormatVolumeOptions::new()
+                .bytes_per_sector(BYTES_PER_SECTOR.try_into().unwrap())
+                .bytes_per_cluster(BYTES_PER_SECTOR.try_into().unwrap())
+                .sectors_per_track(sectors_per_track)
+                .fat_type(fatfs::FatType::Fat12)
+                .volume_label(*b"phd        "),
+        )
+        .context("formatting FAT volume")?;
+
+        {
+            let fs = FileSystem::new(&mut disk, FsOptions::new())
+                .context("creating FAT filesystem")?;
+
+            let root_dir = fs.root_dir();
+            for file in &self.files {
+                root_dir
+                    .create_file(&file.path)
+                    .with_context(|| format!("creating file {}", file.path))?
+                    .write_all(file.contents.as_slice())
+                    .with_context(|| {
+                        format!("writing contents of file {}", file.path)
+                    })?;
+            }
+        }
+
+        Ok(disk.into_inner())
+    }
+}

--- a/phd-tests/framework/src/disk/in_memory.rs
+++ b/phd-tests/framework/src/disk/in_memory.rs
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Abstractions for disks with an in-memory backend.
+
+use propolis_client::types::{BlobStorageBackend, StorageBackendV0};
+
+use super::DiskConfig;
+
+/// A disk with an in-memory backend.
+#[derive(Debug)]
+pub struct InMemoryDisk {
+    backend_name: String,
+    contents: Vec<u8>,
+    readonly: bool,
+}
+
+impl InMemoryDisk {
+    /// Creates an in-memory backend that will present the supplied `contents`
+    /// to the guest.
+    pub fn new(
+        backend_name: String,
+        contents: Vec<u8>,
+        readonly: bool,
+    ) -> Self {
+        Self { backend_name, contents, readonly }
+    }
+}
+
+impl DiskConfig for InMemoryDisk {
+    fn backend_spec(&self) -> (String, StorageBackendV0) {
+        let base64 = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            self.contents.as_slice(),
+        );
+
+        (
+            self.backend_name.clone(),
+            StorageBackendV0::Blob(BlobStorageBackend {
+                base64,
+                readonly: self.readonly,
+            }),
+        )
+    }
+
+    fn guest_os(&self) -> Option<crate::guest_os::GuestOsKind> {
+        None
+    }
+}

--- a/phd-tests/framework/src/disk/mod.rs
+++ b/phd-tests/framework/src/disk/mod.rs
@@ -36,8 +36,8 @@ pub enum DiskError {
     #[error("Disk factory has no Crucible downstairs artifact")]
     NoCrucibleDownstairs,
 
-    #[error("can't create a {0} disk from source of type {1}")]
-    SourceNotSupported(String, String),
+    #[error("can't create a {disk_type} disk from source of type {src}")]
+    SourceNotSupported { disk_type: &'static str, src: &'static str },
 
     #[error(transparent)]
     PortAllocatorError(#[from] PortAllocatorError),
@@ -192,10 +192,10 @@ impl DiskFactory {
             // the supplied disk contents to it, but for now this isn't
             // supported.
             DiskSource::Blank(_) | DiskSource::FatFilesystem(_) => {
-                return Err(DiskError::SourceNotSupported(
-                    "file-backed".to_owned(),
-                    source.kind().to_owned(),
-                ));
+                return Err(DiskError::SourceNotSupported {
+                    disk_type: "file-backed",
+                    src: source.kind(),
+                });
             }
         };
 
@@ -249,10 +249,10 @@ impl DiskFactory {
             // importing them directly into the Crucible regions), but for now
             // this isn't supported.
             DiskSource::FatFilesystem(_) => {
-                return Err(DiskError::SourceNotSupported(
-                    "Crucible-backed".to_owned(),
-                    source.kind().to_owned(),
-                ));
+                return Err(DiskError::SourceNotSupported {
+                    disk_type: "Crucible-backed",
+                    src: source.kind(),
+                });
             }
         };
 

--- a/phd-tests/framework/src/lib.rs
+++ b/phd-tests/framework/src/lib.rs
@@ -246,9 +246,9 @@ impl Framework {
     /// Spawns a new test VM using the supplied `config`. If `environment` is
     /// `Some`, the VM is spawned using the supplied environment; otherwise it
     /// is spawned using the default `environment_builder`.
-    pub async fn spawn_vm(
+    pub async fn spawn_vm<'dr>(
         &self,
-        config: &VmConfig,
+        config: &VmConfig<'dr>,
         environment: Option<&EnvironmentSpec>,
     ) -> anyhow::Result<TestVm> {
         TestVm::new(

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -184,7 +184,15 @@ impl TestVm {
         let guest_os_kind = spec.guest_os_kind;
 
         let vm_name = &spec.vm_name;
-        info!(%vm_name, ?spec.instance_spec, ?guest_os_kind, ?environment);
+
+        // TODO(#735): It would be nice to log the instance spec here too, but
+        // this is extremely noisy for disks with an in-memory disk backend. The
+        // problem is that this spec is a propolis-client generated type with a
+        // derived Debug impl. This can be fixed by making propolis-client
+        // re-export the instance spec types from propolis_api_types (instead of
+        // generating them) so that it can pick up the latter crate's explicit
+        // Debug impls for verbose component types.
+        info!(%vm_name, ?guest_os_kind, ?environment);
 
         match environment
             .build(framework)
@@ -378,7 +386,6 @@ impl TestVm {
 
         info!(
             ?instance_description.instance,
-            ?self.spec.instance_spec,
             "Started instance"
         );
 

--- a/phd-tests/tests/src/crucible/mod.rs
+++ b/phd-tests/tests/src/crucible/mod.rs
@@ -13,10 +13,10 @@ use phd_testcase::{
 mod migrate;
 mod smoke;
 
-fn add_crucible_boot_disk_or_skip(
+fn add_crucible_boot_disk_or_skip<'a>(
     ctx: &Framework,
-    config: &mut VmConfig,
-    artifact: &str,
+    config: &mut VmConfig<'a>,
+    artifact: &'a str,
     interface: DiskInterface,
     pci_slot: u8,
     min_disk_size_gib: u64,
@@ -36,9 +36,9 @@ fn add_crucible_boot_disk_or_skip(
     Ok(())
 }
 
-fn add_default_boot_disk(
-    ctx: &Framework,
-    config: &mut VmConfig,
+fn add_default_boot_disk<'a>(
+    ctx: &'a Framework,
+    config: &mut VmConfig<'a>,
 ) -> phd_testcase::Result<()> {
     add_crucible_boot_disk_or_skip(
         ctx,

--- a/phd-tests/tests/src/disk.rs
+++ b/phd-tests/tests/src/disk.rs
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use phd_framework::{
+    disk::{fat::FatFilesystem, DiskSource},
+    test_vm::{DiskBackend, DiskInterface},
+};
+use phd_testcase::*;
+use tracing::info;
+
+#[phd_testcase]
+async fn in_memory_backend_smoke_test(ctx: &Framework) {
+    const HELLO_MSG: &str = "hello oxide!";
+
+    let mut cfg = ctx.vm_config_builder("in_memory_backend_test");
+    let mut data = FatFilesystem::new();
+    data.add_file_from_str("hello_oxide.txt", HELLO_MSG)?;
+    cfg.data_disk(
+        DiskSource::FatFilesystem(data),
+        DiskInterface::Virtio,
+        DiskBackend::InMemory { readonly: true },
+        24,
+    );
+
+    let mut vm = ctx.spawn_vm(&cfg, None).await?;
+    vm.launch().await?;
+    vm.wait_to_boot().await?;
+
+    // /dev/disk/by-path contains a set of symlinks that redirect device PCI
+    // paths to their device nodes under /dev. Here, the in-memory disk is
+    // supposed to be a virtio disk at 0/24/0 (note that the output PCI path is
+    // in hex). If this doesn't map to /dev/vda, then the subsequent mount
+    // command isn't going to work, so fail the test.
+    //
+    // The device naming scheme is up to the guest, so if this assumption fails
+    // for some guest, it's always possible to have the test parse the output of
+    // `ls` to figure out the actual path to mount.
+    let ls = vm.run_shell_command("ls -la /dev/disk/by-path").await?;
+    info!(%ls, "guest disk device paths");
+    assert!(ls.contains("virtio-pci-0000:00:18.0 -> ../../vda"));
+
+    vm.run_shell_command("mkdir /phd").await?;
+
+    // The disk is read-only, so pass the `ro` option to `mount` so that it
+    // doesn't complain about not being able to mount for writing.
+    let mount = vm.run_shell_command("mount -o ro /dev/vda /phd").await?;
+    assert_eq!(mount, "");
+
+    // The file should be there and have the expected contents.
+    let ls = vm.run_shell_command("ls /phd").await?;
+    assert_eq!(ls, "hello_oxide.txt");
+
+    let cat = vm.run_shell_command("cat /phd/hello_oxide.txt").await?;
+    assert_eq!(cat, HELLO_MSG);
+}

--- a/phd-tests/tests/src/lib.rs
+++ b/phd-tests/tests/src/lib.rs
@@ -5,6 +5,7 @@
 pub use phd_testcase;
 
 mod crucible;
+mod disk;
 mod framework;
 mod hw;
 mod migrate;


### PR DESCRIPTION
Add an affordance for creating in-memory disk backends in PHD and populating them with data in a FAT filesystem (similar to what propolis-standalone and omicron do to create cloud-init data volumes). Add a small test that such volumes can be mounted and read as expected.

A future PR will use this for integration testing of #301, but this stands alone so thought I would put it up as its own PR.