### PR TITLE
instance specs: remove extra layer of builder

### DIFF
--- a/bin/propolis-server/src/lib/spec/builder.rs
+++ b/bin/propolis-server/src/lib/spec/builder.rs
@@ -6,13 +6,18 @@
 
 use std::collections::BTreeSet;
 
-use propolis_api_types::instance_spec::{
-    components::{
-        board::Board,
-        devices::{PciPciBridge, QemuPvpanic, SerialPort, SerialPortNumber},
+use propolis_api_types::{
+    instance_spec::{
+        components::{
+            board::{Board, Chipset, I440Fx},
+            devices::{
+                PciPciBridge, QemuPvpanic, SerialPort, SerialPortNumber,
+            },
+        },
+        v0::{DeviceSpecV0, InstanceSpecV0, NetworkDeviceV0, StorageDeviceV0},
+        PciPath,
     },
-    v0::{DeviceSpecV0, InstanceSpecV0, NetworkDeviceV0, StorageDeviceV0},
-    PciPath,
+    DiskRequest, InstanceProperties, NetworkInterfaceRequest,
 };
 use thiserror::Error;
 
@@ -25,12 +30,27 @@ use propolis_api_types::instance_spec::{
     v0::NetworkBackendV0,
 };
 
-use super::{ParsedNetworkDevice, ParsedStorageDevice};
+use crate::config;
+
+use super::{
+    api_request::{self, DeviceRequestError},
+    config_toml::{ConfigTomlError, ParsedConfig},
+    ParsedNetworkDevice, ParsedStorageDevice,
+};
+
+#[cfg(feature = "falcon")]
+use super::ParsedSoftNpu;
 
 /// Errors that can arise while building an instance spec from component parts.
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Error)]
 pub(crate) enum SpecBuilderError {
+    #[error("error parsing config TOML")]
+    ConfigToml(#[from] ConfigTomlError),
+
+    #[error("error parsing device in ensure request")]
+    DeviceRequest(#[from] DeviceRequestError),
+
     #[error("A device with name {0} already exists")]
     DeviceNameInUse(String),
 
@@ -75,7 +95,13 @@ impl PciComponent for NetworkDeviceV0 {
 }
 
 impl SpecBuilder {
-    pub(super) fn new(board: Board) -> Self {
+    pub fn new(properties: &InstanceProperties) -> Self {
+        let board = Board {
+            cpus: properties.vcpus,
+            memory_mb: properties.memory,
+            chipset: Chipset::I440Fx(I440Fx { enable_pcie: false }),
+        };
+
         Self {
             spec: InstanceSpecV0 {
                 devices: DeviceSpecV0 { board, ..Default::default() },
@@ -83,6 +109,92 @@ impl SpecBuilder {
             },
             pci_paths: Default::default(),
         }
+    }
+
+    /// Converts an HTTP API request to add a NIC to an instance into
+    /// device/backend entries in the spec under construction.
+    pub fn add_nic_from_request(
+        &mut self,
+        nic: &NetworkInterfaceRequest,
+    ) -> Result<(), SpecBuilderError> {
+        self.add_network_device(api_request::parse_nic_from_request(nic)?)?;
+        Ok(())
+    }
+
+    /// Converts an HTTP API request to add a disk to an instance into
+    /// device/backend entries in the spec under construction.
+    pub fn add_disk_from_request(
+        &mut self,
+        disk: &DiskRequest,
+    ) -> Result<(), SpecBuilderError> {
+        self.add_storage_device(api_request::parse_disk_from_request(disk)?)?;
+        Ok(())
+    }
+
+    /// Converts an HTTP API request to add a cloud-init disk to an instance
+    /// into device/backend entries in the spec under construction.
+    pub fn add_cloud_init_from_request(
+        &mut self,
+        base64: String,
+    ) -> Result<(), SpecBuilderError> {
+        self.add_storage_device(api_request::parse_cloud_init_from_request(
+            base64,
+        )?)?;
+
+        Ok(())
+    }
+
+    /// Adds all the devices and backends specified in the supplied
+    /// configuration TOML to the spec under construction.
+    pub fn add_devices_from_config(
+        &mut self,
+        config: &config::Config,
+    ) -> Result<(), SpecBuilderError> {
+        let parsed = ParsedConfig::try_from(config)?;
+
+        let Chipset::I440Fx(ref mut i440fx) = self.spec.devices.board.chipset;
+        i440fx.enable_pcie = parsed.enable_pcie;
+
+        for disk in parsed.disks {
+            self.add_storage_device(disk)?;
+        }
+
+        for nic in parsed.nics {
+            self.add_network_device(nic)?;
+        }
+
+        for bridge in parsed.pci_bridges {
+            self.add_pci_bridge(bridge.name, bridge.bridge)?;
+        }
+
+        #[cfg(feature = "falcon")]
+        self.add_parsed_softnpu_devices(parsed.softnpu)?;
+
+        Ok(())
+    }
+
+    #[cfg(feature = "falcon")]
+    fn add_parsed_softnpu_devices(
+        &mut self,
+        devices: ParsedSoftNpu,
+    ) -> Result<(), SpecBuilderError> {
+        for pci_port in devices.pci_ports {
+            self.set_softnpu_pci_port(pci_port)?;
+        }
+
+        for port in devices.ports {
+            self.add_softnpu_port(port.name.clone(), port)?;
+        }
+
+        for p9 in devices.p9_devices {
+            self.set_softnpu_p9(p9)?;
+        }
+
+        for p9fs in devices.p9fs {
+            self.set_p9fs(p9fs)?;
+        }
+
+        Ok(())
     }
 
     /// Adds a PCI path to this builder's record of PCI locations with an
@@ -274,5 +386,100 @@ impl SpecBuilder {
     /// Yields the completed spec, consuming the builder.
     pub fn finish(self) -> InstanceSpecV0 {
         self.spec
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use propolis_api_types::{
+        InstanceMetadata, Slot, VolumeConstructionRequest,
+    };
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn test_metadata() -> InstanceMetadata {
+        InstanceMetadata {
+            silo_id: uuid::uuid!("556a67f8-8b14-4659-bd9f-d8f85ecd36bf"),
+            project_id: uuid::uuid!("75f60038-daeb-4a1d-916a-5fa5b7237299"),
+            sled_id: uuid::uuid!("43a789ac-a0dd-4e1e-ac33-acdada142faa"),
+            sled_serial: "some-gimlet".into(),
+            sled_revision: 1,
+            sled_model: "abcd".into(),
+        }
+    }
+
+    fn test_builder() -> SpecBuilder {
+        SpecBuilder::new(&InstanceProperties {
+            id: Default::default(),
+            name: Default::default(),
+            description: Default::default(),
+            metadata: test_metadata(),
+            image_id: Default::default(),
+            bootrom_id: Default::default(),
+            memory: 512,
+            vcpus: 4,
+        })
+    }
+
+    #[test]
+    fn duplicate_pci_slot() {
+        let mut builder = test_builder();
+        // Adding the same disk device twice should fail.
+        assert!(builder
+            .add_disk_from_request(&DiskRequest {
+                name: "disk1".to_string(),
+                slot: Slot(0),
+                read_only: true,
+                device: "nvme".to_string(),
+                volume_construction_request: VolumeConstructionRequest::File {
+                    id: Uuid::new_v4(),
+                    block_size: 512,
+                    path: "disk1.img".to_string()
+                },
+            })
+            .is_ok());
+
+        assert!(builder
+            .add_disk_from_request(&DiskRequest {
+                name: "disk2".to_string(),
+                slot: Slot(0),
+                read_only: true,
+                device: "virtio".to_string(),
+                volume_construction_request: VolumeConstructionRequest::File {
+                    id: Uuid::new_v4(),
+                    block_size: 512,
+                    path: "disk2.img".to_string()
+                },
+            })
+            .is_err());
+    }
+
+    #[test]
+    fn duplicate_serial_port() {
+        let mut builder = test_builder();
+        assert!(builder.add_serial_port(SerialPortNumber::Com1).is_ok());
+        assert!(builder.add_serial_port(SerialPortNumber::Com2).is_ok());
+        assert!(builder.add_serial_port(SerialPortNumber::Com3).is_ok());
+        assert!(builder.add_serial_port(SerialPortNumber::Com4).is_ok());
+        assert!(builder.add_serial_port(SerialPortNumber::Com1).is_err());
+    }
+
+    #[test]
+    fn unknown_storage_device_type() {
+        let mut builder = test_builder();
+        assert!(builder
+            .add_disk_from_request(&DiskRequest {
+                name: "disk3".to_string(),
+                slot: Slot(0),
+                read_only: true,
+                device: "virtio-scsi".to_string(),
+                volume_construction_request: VolumeConstructionRequest::File {
+                    id: Uuid::new_v4(),
+                    block_size: 512,
+                    path: "disk3.img".to_string()
+                },
+            })
+            .is_err());
     }
 }

--- a/bin/propolis-server/src/lib/spec/config_toml.rs
+++ b/bin/propolis-server/src/lib/spec/config_toml.rs
@@ -27,6 +27,9 @@ use crate::config;
 
 use super::{ParsedNetworkDevice, ParsedStorageDevice};
 
+#[cfg(feature = "falcon")]
+use super::ParsedSoftNpu;
+
 #[derive(Debug, Error)]
 pub(crate) enum ConfigTomlError {
     #[error("unrecognized device type {0:?}")]
@@ -71,17 +74,9 @@ pub(crate) enum ConfigTomlError {
     NoP9Target(String),
 }
 
-#[cfg(feature = "falcon")]
-#[derive(Default)]
-pub(super) struct ParsedSoftNpu {
-    pub(super) pci_ports: Vec<SoftNpuPciPort>,
-    pub(super) ports: Vec<SoftNpuPort>,
-    pub(super) p9_devices: Vec<SoftNpuP9>,
-    pub(super) p9fs: Vec<P9fs>,
-}
-
 #[derive(Default)]
 pub(super) struct ParsedConfig {
+    pub(super) enable_pcie: bool,
     pub(super) disks: Vec<ParsedStorageDevice>,
     pub(super) nics: Vec<ParsedNetworkDevice>,
     pub(super) pci_bridges: Vec<ParsedPciPciBridge>,
@@ -94,7 +89,24 @@ impl TryFrom<&config::Config> for ParsedConfig {
     type Error = ConfigTomlError;
 
     fn try_from(config: &config::Config) -> Result<Self, Self::Error> {
-        let mut parsed = Self::default();
+        let mut parsed = ParsedConfig {
+            enable_pcie: config
+                .chipset
+                .options
+                .get("enable-pcie")
+                .map_or_else(
+                    || Ok(false),
+                    |v| {
+                        v.as_bool().ok_or_else(|| {
+                            ConfigTomlError::EnablePcieParseFailed(
+                                v.to_string(),
+                            )
+                        })
+                    },
+                )?,
+            ..Default::default()
+        };
+
         for (device_name, device) in config.devices.iter() {
             let driver = device.driver.as_str();
             match driver {

--- a/bin/propolis-server/src/lib/spec/config_toml.rs
+++ b/bin/propolis-server/src/lib/spec/config_toml.rs
@@ -94,16 +94,13 @@ impl TryFrom<&config::Config> for ParsedConfig {
                 .chipset
                 .options
                 .get("enable-pcie")
-                .map_or_else(
-                    || Ok(false),
-                    |v| {
-                        v.as_bool().ok_or_else(|| {
-                            ConfigTomlError::EnablePcieParseFailed(
-                                v.to_string(),
-                            )
-                        })
-                    },
-                )?,
+                .map(|v| {
+                    v.as_bool().ok_or_else(|| {
+                        ConfigTomlError::EnablePcieParseFailed(v.to_string())
+                    })
+                })
+                .transpose()?
+                .unwrap_or(false),
             ..Default::default()
         };
 

--- a/bin/propolis-server/src/lib/spec/mod.rs
+++ b/bin/propolis-server/src/lib/spec/mod.rs
@@ -4,21 +4,12 @@
 
 //! Helper functions for building instance specs from server parameters.
 
-use crate::config;
-use api_request::DeviceRequestError;
-use builder::SpecBuilder;
-use config_toml::ConfigTomlError;
-use propolis_api_types::instance_spec::components::board::{Chipset, I440Fx};
+use propolis_api_types::instance_spec::{v0::*, PciPath};
+
+#[cfg(feature = "falcon")]
 use propolis_api_types::instance_spec::components::devices::{
-    QemuPvpanic, SerialPortNumber,
+    P9fs, SoftNpuP9, SoftNpuPciPort, SoftNpuPort,
 };
-use propolis_api_types::instance_spec::{
-    components::board::Board, v0::*, PciPath,
-};
-use propolis_api_types::{
-    DiskRequest, InstanceProperties, NetworkInterfaceRequest,
-};
-use thiserror::Error;
 
 mod api_request;
 pub(crate) mod builder;
@@ -42,17 +33,13 @@ struct ParsedNetworkDevice {
     backend_spec: NetworkBackendV0,
 }
 
-/// Errors that can occur while building an instance spec from component parts.
-#[derive(Debug, Error)]
-pub(crate) enum ServerSpecBuilderError {
-    #[error(transparent)]
-    InnerBuilderError(#[from] builder::SpecBuilderError),
-
-    #[error("error parsing config TOML")]
-    ConfigToml(#[from] ConfigTomlError),
-
-    #[error("error parsing device in ensure request")]
-    DeviceRequest(#[from] DeviceRequestError),
+#[cfg(feature = "falcon")]
+#[derive(Default)]
+struct ParsedSoftNpu {
+    pci_ports: Vec<SoftNpuPciPort>,
+    ports: Vec<SoftNpuPort>,
+    p9_devices: Vec<SoftNpuP9>,
+    p9fs: Vec<P9fs>,
 }
 
 /// Generates NIC device and backend names from the NIC's PCI path. This is
@@ -67,261 +54,4 @@ pub(crate) enum ServerSpecBuilderError {
 ///      with the old behavior from migrating processes with the new behavior.
 fn pci_path_to_nic_names(path: PciPath) -> (String, String) {
     (format!("vnic-{}", path), format!("vnic-{}-backend", path))
-}
-
-/// A helper for building instance specs out of component parts.
-pub struct ServerSpecBuilder {
-    builder: SpecBuilder,
-}
-
-impl ServerSpecBuilder {
-    /// Creates a new spec builder from an instance's properties (supplied via
-    /// the instance APIs) and the config TOML supplied at server startup.
-    pub fn new(
-        properties: &InstanceProperties,
-        config: &config::Config,
-    ) -> Result<Self, ServerSpecBuilderError> {
-        let enable_pcie =
-            config.chipset.options.get("enable-pcie").map_or_else(
-                || Ok(false),
-                |v| {
-                    v.as_bool().ok_or_else(|| {
-                        ServerSpecBuilderError::ConfigToml(
-                            ConfigTomlError::EnablePcieParseFailed(
-                                v.to_string(),
-                            ),
-                        )
-                    })
-                },
-            )?;
-
-        let mut builder = SpecBuilder::new(Board {
-            cpus: properties.vcpus,
-            memory_mb: properties.memory,
-            chipset: Chipset::I440Fx(I440Fx { enable_pcie }),
-        });
-
-        builder.add_pvpanic_device(QemuPvpanic { enable_isa: true })?;
-
-        Ok(Self { builder })
-    }
-
-    /// Converts an HTTP API request to add a NIC to an instance into
-    /// device/backend entries in the spec under construction.
-    pub fn add_nic_from_request(
-        &mut self,
-        nic: &NetworkInterfaceRequest,
-    ) -> Result<(), ServerSpecBuilderError> {
-        self.builder
-            .add_network_device(api_request::parse_nic_from_request(nic)?)?;
-
-        Ok(())
-    }
-
-    /// Converts an HTTP API request to add a disk to an instance into
-    /// device/backend entries in the spec under construction.
-    pub fn add_disk_from_request(
-        &mut self,
-        disk: &DiskRequest,
-    ) -> Result<(), ServerSpecBuilderError> {
-        self.builder
-            .add_storage_device(api_request::parse_disk_from_request(disk)?)?;
-
-        Ok(())
-    }
-
-    /// Converts an HTTP API request to add a cloud-init disk to an instance
-    /// into device/backend entries in the spec under construction.
-    pub fn add_cloud_init_from_request(
-        &mut self,
-        base64: String,
-    ) -> Result<(), ServerSpecBuilderError> {
-        self.builder.add_storage_device(
-            api_request::parse_cloud_init_from_request(base64)?,
-        )?;
-
-        Ok(())
-    }
-
-    /// Adds all the devices and backends specified in the supplied
-    /// configuration TOML to the spec under construction.
-    pub fn add_devices_from_config(
-        &mut self,
-        config: &config::Config,
-    ) -> Result<(), ServerSpecBuilderError> {
-        let parsed = config_toml::ParsedConfig::try_from(config)?;
-        for disk in parsed.disks {
-            self.builder.add_storage_device(disk)?;
-        }
-
-        for nic in parsed.nics {
-            self.builder.add_network_device(nic)?;
-        }
-
-        for bridge in parsed.pci_bridges {
-            self.builder.add_pci_bridge(bridge.name, bridge.bridge)?;
-        }
-
-        #[cfg(feature = "falcon")]
-        self.add_parsed_softnpu_devices(parsed.softnpu)?;
-
-        Ok(())
-    }
-
-    #[cfg(feature = "falcon")]
-    fn add_parsed_softnpu_devices(
-        &mut self,
-        devices: config_toml::ParsedSoftNpu,
-    ) -> Result<(), ServerSpecBuilderError> {
-        for pci_port in devices.pci_ports {
-            self.builder.set_softnpu_pci_port(pci_port)?;
-        }
-
-        for port in devices.ports {
-            self.builder.add_softnpu_port(port.name.clone(), port)?;
-        }
-
-        for p9 in devices.p9_devices {
-            self.builder.set_softnpu_p9(p9)?;
-        }
-
-        for p9fs in devices.p9fs {
-            self.builder.set_p9fs(p9fs)?;
-        }
-
-        Ok(())
-    }
-
-    /// Adds a serial port specification to the spec under construction.
-    pub fn add_serial_port(
-        &mut self,
-        port: SerialPortNumber,
-    ) -> Result<(), ServerSpecBuilderError> {
-        self.builder.add_serial_port(port)?;
-        Ok(())
-    }
-
-    pub fn finish(self) -> InstanceSpecV0 {
-        self.builder.finish()
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crucible_client_types::VolumeConstructionRequest;
-    use propolis_api_types::{InstanceMetadata, Slot};
-    use uuid::Uuid;
-
-    use crate::config::Config;
-
-    use super::*;
-
-    fn test_metadata() -> InstanceMetadata {
-        InstanceMetadata {
-            silo_id: uuid::uuid!("556a67f8-8b14-4659-bd9f-d8f85ecd36bf"),
-            project_id: uuid::uuid!("75f60038-daeb-4a1d-916a-5fa5b7237299"),
-            sled_id: uuid::uuid!("43a789ac-a0dd-4e1e-ac33-acdada142faa"),
-            sled_serial: "some-gimlet".into(),
-            sled_revision: 1,
-            sled_model: "abcd".into(),
-        }
-    }
-
-    fn default_spec_builder(
-    ) -> Result<ServerSpecBuilder, ServerSpecBuilderError> {
-        ServerSpecBuilder::new(
-            &InstanceProperties {
-                id: Default::default(),
-                name: Default::default(),
-                description: Default::default(),
-                metadata: test_metadata(),
-                image_id: Default::default(),
-                bootrom_id: Default::default(),
-                memory: 512,
-                vcpus: 4,
-            },
-            &Config::default(),
-        )
-    }
-
-    #[test]
-    fn make_default_builder() {
-        assert!(default_spec_builder().is_ok());
-    }
-
-    #[test]
-    fn duplicate_pci_slot() {
-        let mut builder = default_spec_builder().unwrap();
-
-        // Adding the same disk device twice should fail.
-        assert!(builder
-            .add_disk_from_request(&DiskRequest {
-                name: "disk1".to_string(),
-                slot: Slot(0),
-                read_only: true,
-                device: "nvme".to_string(),
-                volume_construction_request: VolumeConstructionRequest::File {
-                    id: Uuid::new_v4(),
-                    block_size: 512,
-                    path: "disk1.img".to_string()
-                },
-            })
-            .is_ok());
-        assert!(matches!(
-            builder
-                .add_disk_from_request(&DiskRequest {
-                    name: "disk2".to_string(),
-                    slot: Slot(0),
-                    read_only: true,
-                    device: "virtio".to_string(),
-                    volume_construction_request:
-                        VolumeConstructionRequest::File {
-                            id: Uuid::new_v4(),
-                            block_size: 512,
-                            path: "disk2.img".to_string()
-                        },
-                })
-                .err(),
-            Some(ServerSpecBuilderError::InnerBuilderError(
-                builder::SpecBuilderError::PciPathInUse(_)
-            ))
-        ));
-    }
-
-    #[test]
-    fn duplicate_serial_port() {
-        let mut builder = default_spec_builder().unwrap();
-        assert!(builder.add_serial_port(SerialPortNumber::Com1).is_ok());
-        assert!(builder.add_serial_port(SerialPortNumber::Com2).is_ok());
-        assert!(builder.add_serial_port(SerialPortNumber::Com3).is_ok());
-        assert!(builder.add_serial_port(SerialPortNumber::Com4).is_ok());
-        assert!(matches!(
-            builder.add_serial_port(SerialPortNumber::Com1).err(),
-            Some(ServerSpecBuilderError::InnerBuilderError(
-                builder::SpecBuilderError::SerialPortInUse(_)
-            ))
-        ));
-    }
-
-    #[test]
-    fn unknown_storage_device_type() {
-        let mut builder = default_spec_builder().unwrap();
-        assert!(matches!(
-            builder
-                .add_disk_from_request(&DiskRequest {
-                    name: "disk3".to_string(),
-                    slot: Slot(0),
-                    read_only: true,
-                    device: "virtio-scsi".to_string(),
-                    volume_construction_request:
-                        VolumeConstructionRequest::File {
-                            id: Uuid::new_v4(),
-                            block_size: 512,
-                            path: "disk3.img".to_string()
-                        },
-                })
-                .err(),
-            Some(ServerSpecBuilderError::DeviceRequest(_))
-        ));
-    }
 }


### PR DESCRIPTION
(5/X in the instance spec rework; see #735.)

Now that the instance spec builder from `propolis_api_types` has moved into `propolis-server`, the server crate actually has two layers of builder: the "inner" `SpecBuilder` originally lived in the API types crate, and the "outer" `ServerSpecBuilder` was meant to transform server-only sources of spec elements (config TOML elements and API requests) into components to pass to the inner builder. Now that everything is in one crate, this layering is redundant, so collapse everything into a single `SpecBuilder` type and make the server use that.

Once again, this is mostly a matter of shuffling existing code around. The only substantial not-just-a-copy-and-paste change is that the server now has to enable a pvpanic device explicitly instead of it being included for free with a new spec builder. (The next PR in this series will do more than simply rearrange deck chairs!)

Tests: cargo test, PHD, booted a propolis-server ad hoc and made sure all the expected devices were there.