### PR TITLE
[network metrics] instance network interface metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "api_identity"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
@@ -754,7 +754,7 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=d037eeb9a56a8a62ff17266f340c011224d15146#d037eeb9a56a8a62ff17266f340c011224d15146"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2aee0bc0fea61f26474b04c88d2c150fa0d35f56#2aee0bc0fea61f26474b04c88d2c150fa0d35f56"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -807,7 +807,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=d037eeb9a56a8a62ff17266f340c011224d15146#d037eeb9a56a8a62ff17266f340c011224d15146"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2aee0bc0fea61f26474b04c88d2c150fa0d35f56#2aee0bc0fea61f26474b04c88d2c150fa0d35f56"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -820,7 +820,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=d037eeb9a56a8a62ff17266f340c011224d15146#d037eeb9a56a8a62ff17266f340c011224d15146"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2aee0bc0fea61f26474b04c88d2c150fa0d35f56#2aee0bc0fea61f26474b04c88d2c150fa0d35f56"
 dependencies = [
  "anyhow",
  "atty",
@@ -850,7 +850,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=d037eeb9a56a8a62ff17266f340c011224d15146#d037eeb9a56a8a62ff17266f340c011224d15146"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2aee0bc0fea61f26474b04c88d2c150fa0d35f56#2aee0bc0fea61f26474b04c88d2c150fa0d35f56"
 dependencies = [
  "anyhow",
  "bincode",
@@ -869,7 +869,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=e58ca3693cb9ce0438947beba10e97ee38a0966b#e58ca3693cb9ce0438947beba10e97ee38a0966b"
+source = "git+https://github.com/oxidecomputer/crucible?rev=88c45eebf34027c3bc80e60a5f527738bcfaf16a#88c45eebf34027c3bc80e60a5f527738bcfaf16a"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -1151,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "dns-service-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2111,7 +2111,7 @@ source = "git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c
 [[package]]
 name = "illumos-utils"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2211,7 +2211,7 @@ dependencies = [
 [[package]]
 name = "internal-dns"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2700,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "nexus-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "chrono",
  "futures",
@@ -2724,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "nexus-sled-agent-shared"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "omicron-common",
  "omicron-passwords",
@@ -2742,7 +2742,7 @@ dependencies = [
 [[package]]
 name = "nexus-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -3028,7 +3028,7 @@ dependencies = [
 [[package]]
 name = "omicron-common"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -3070,7 +3070,7 @@ dependencies = [
 [[package]]
 name = "omicron-passwords"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "argon2",
  "omicron-workspace-hack",
@@ -3084,7 +3084,7 @@ dependencies = [
 [[package]]
 name = "omicron-uuid-kinds"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "newtype-uuid",
  "paste",
@@ -3284,7 +3284,7 @@ dependencies = [
 [[package]]
 name = "oximeter"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "oximeter-instruments"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -3321,7 +3321,7 @@ dependencies = [
 [[package]]
 name = "oximeter-macro-impl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
@@ -3332,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "oximeter-producer"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "chrono",
  "dropshot",
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "oximeter-schema"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3374,7 +3374,7 @@ dependencies = [
 [[package]]
 name = "oximeter-timeseries-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "omicron-workspace-hack",
  "oximeter-schema",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "oximeter-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "bytes",
  "chrono",
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "oxlog"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "anyhow",
  "camino",
@@ -3431,7 +3431,7 @@ dependencies = [
 [[package]]
 name = "oxql-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5122,7 +5122,7 @@ dependencies = [
 [[package]]
 name = "sled-hardware-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#758818aea3f0d375b6bbf9bd87f713a5da09ffbd"
+source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
 dependencies = [
  "illumos-utils",
  "omicron-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "api_identity"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
@@ -754,7 +754,7 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=eab46702b6a43ff558672462dea3eb5ff7b8a0e6#eab46702b6a43ff558672462dea3eb5ff7b8a0e6"
+source = "git+https://github.com/oxidecomputer/crucible?rev=9d82a99058e7f4d76ccc2141dcd78e7d4730cc78#9d82a99058e7f4d76ccc2141dcd78e7d4730cc78"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -807,7 +807,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=eab46702b6a43ff558672462dea3eb5ff7b8a0e6#eab46702b6a43ff558672462dea3eb5ff7b8a0e6"
+source = "git+https://github.com/oxidecomputer/crucible?rev=9d82a99058e7f4d76ccc2141dcd78e7d4730cc78#9d82a99058e7f4d76ccc2141dcd78e7d4730cc78"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -820,7 +820,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=eab46702b6a43ff558672462dea3eb5ff7b8a0e6#eab46702b6a43ff558672462dea3eb5ff7b8a0e6"
+source = "git+https://github.com/oxidecomputer/crucible?rev=9d82a99058e7f4d76ccc2141dcd78e7d4730cc78#9d82a99058e7f4d76ccc2141dcd78e7d4730cc78"
 dependencies = [
  "anyhow",
  "atty",
@@ -850,7 +850,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=eab46702b6a43ff558672462dea3eb5ff7b8a0e6#eab46702b6a43ff558672462dea3eb5ff7b8a0e6"
+source = "git+https://github.com/oxidecomputer/crucible?rev=9d82a99058e7f4d76ccc2141dcd78e7d4730cc78#9d82a99058e7f4d76ccc2141dcd78e7d4730cc78"
 dependencies = [
  "anyhow",
  "bincode",
@@ -869,7 +869,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=88c45eebf34027c3bc80e60a5f527738bcfaf16a#88c45eebf34027c3bc80e60a5f527738bcfaf16a"
+source = "git+https://github.com/oxidecomputer/crucible?rev=eab46702b6a43ff558672462dea3eb5ff7b8a0e6#eab46702b6a43ff558672462dea3eb5ff7b8a0e6"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -1151,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "dns-service-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2111,7 +2111,7 @@ source = "git+https://github.com/oxidecomputer/opte?rev=76878de67229ea113d70503c
 [[package]]
 name = "illumos-utils"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2211,7 +2211,7 @@ dependencies = [
 [[package]]
 name = "internal-dns"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2700,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "nexus-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "chrono",
  "futures",
@@ -2724,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "nexus-sled-agent-shared"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "omicron-common",
  "omicron-passwords",
@@ -2742,7 +2742,7 @@ dependencies = [
 [[package]]
 name = "nexus-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -3028,7 +3028,7 @@ dependencies = [
 [[package]]
 name = "omicron-common"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -3070,7 +3070,7 @@ dependencies = [
 [[package]]
 name = "omicron-passwords"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "argon2",
  "omicron-workspace-hack",
@@ -3084,7 +3084,7 @@ dependencies = [
 [[package]]
 name = "omicron-uuid-kinds"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "newtype-uuid",
  "paste",
@@ -3284,7 +3284,7 @@ dependencies = [
 [[package]]
 name = "oximeter"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "oximeter-instruments"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -3321,7 +3321,7 @@ dependencies = [
 [[package]]
 name = "oximeter-macro-impl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
@@ -3332,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "oximeter-producer"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "chrono",
  "dropshot",
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "oximeter-schema"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3374,7 +3374,7 @@ dependencies = [
 [[package]]
 name = "oximeter-timeseries-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "omicron-workspace-hack",
  "oximeter-schema",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "oximeter-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "bytes",
  "chrono",
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "oxlog"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "anyhow",
  "camino",
@@ -3431,7 +3431,7 @@ dependencies = [
 [[package]]
 name = "oxql-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5122,7 +5122,7 @@ dependencies = [
 [[package]]
 name = "sled-hardware-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=zl/instance-network-interface#5bb97ae7a432a34ec426add21fb6d9eb54e3a44e"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#5bf5f09545b7b74f809c099db5c0b315ea06f9be"
 dependencies = [
  "illumos-utils",
  "omicron-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,7 +754,7 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2aee0bc0fea61f26474b04c88d2c150fa0d35f56#2aee0bc0fea61f26474b04c88d2c150fa0d35f56"
+source = "git+https://github.com/oxidecomputer/crucible?rev=eab46702b6a43ff558672462dea3eb5ff7b8a0e6#eab46702b6a43ff558672462dea3eb5ff7b8a0e6"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -807,7 +807,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2aee0bc0fea61f26474b04c88d2c150fa0d35f56#2aee0bc0fea61f26474b04c88d2c150fa0d35f56"
+source = "git+https://github.com/oxidecomputer/crucible?rev=eab46702b6a43ff558672462dea3eb5ff7b8a0e6#eab46702b6a43ff558672462dea3eb5ff7b8a0e6"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -820,7 +820,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2aee0bc0fea61f26474b04c88d2c150fa0d35f56#2aee0bc0fea61f26474b04c88d2c150fa0d35f56"
+source = "git+https://github.com/oxidecomputer/crucible?rev=eab46702b6a43ff558672462dea3eb5ff7b8a0e6#eab46702b6a43ff558672462dea3eb5ff7b8a0e6"
 dependencies = [
  "anyhow",
  "atty",
@@ -850,7 +850,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2aee0bc0fea61f26474b04c88d2c150fa0d35f56#2aee0bc0fea61f26474b04c88d2c150fa0d35f56"
+source = "git+https://github.com/oxidecomputer/crucible?rev=eab46702b6a43ff558672462dea3eb5ff7b8a0e6#eab46702b6a43ff558672462dea3eb5ff7b8a0e6"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,8 +81,8 @@ oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/inst
 sled-agent-client = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface" }
 
 # Crucible
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "2aee0bc0fea61f26474b04c88d2c150fa0d35f56" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "2aee0bc0fea61f26474b04c88d2c150fa0d35f56" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "eab46702b6a43ff558672462dea3eb5ff7b8a0e6" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "eab46702b6a43ff558672462dea3eb5ff7b8a0e6" }
 
 # External dependencies
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,18 +71,18 @@ p9ds = { git = "https://github.com/oxidecomputer/p9fs" }
 softnpu = { git = "https://github.com/oxidecomputer/softnpu" }
 
 # Omicron-related
-internal-dns = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface" }
-nexus-client = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface" }
-omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface" }
+internal-dns = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
+nexus-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
+omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 omicron-zone-package = "0.9.0"
-oximeter-instruments = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface", default-features = false, features = ["kstat"] }
-oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface" }
-oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface" }
-sled-agent-client = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface" }
+oximeter-instruments = { git = "https://github.com/oxidecomputer/omicron", branch = "main", default-features = false, features = ["kstat"] }
+oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
+oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
+sled-agent-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 
 # Crucible
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "eab46702b6a43ff558672462dea3eb5ff7b8a0e6" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "eab46702b6a43ff558672462dea3eb5ff7b8a0e6" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "9d82a99058e7f4d76ccc2141dcd78e7d4730cc78" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "9d82a99058e7f4d76ccc2141dcd78e7d4730cc78" }
 
 # External dependencies
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,8 +81,8 @@ oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 sled-agent-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 
 # Crucible
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "d037eeb9a56a8a62ff17266f340c011224d15146" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "d037eeb9a56a8a62ff17266f340c011224d15146" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "e58ca3693cb9ce0438947beba10e97ee38a0966b" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "e58ca3693cb9ce0438947beba10e97ee38a0966b" }
 
 # External dependencies
 anyhow = "1.0"
@@ -96,7 +96,7 @@ bitflags = "2.4"
 bitstruct = "0.1"
 bitvec = "1.0"
 byteorder = "1"
-bytes = "1.1"
+bytes = "1.7.1"
 camino = "1.1.6"
 cargo_metadata = "0.18.1"
 cc = "1.0.73"
@@ -164,3 +164,20 @@ tracing-subscriber = "0.3.14"
 usdt = { version = "0.5", default-features = false }
 uuid = "1.3.2"
 zerocopy = "0.7.34"
+
+
+#
+# It's common during development to use a local copy of various complex
+# dependencies.  If you want to use those, uncomment one of these blocks.
+#
+# [patch."https://github.com/oxidecomputer/omicron"]
+# internal-dns = { path = "../omicron/internal-dns" }
+# nexus-client = { path = "../omicron/clients/nexus-client" }
+# omicron-common = { path = "../omicron/common" }
+# omicron-zone-package = "0.9.0"
+# oximeter-instruments = { path = "../omicron/oximeter/instruments" }
+# oximeter-producer = { path = "../omicron/oximeter/producer" }
+# oximeter = { path = "../omicron/oximeter/oximeter" }
+# [patch."https://github.com/oxidecomputer/crucible"]
+# crucible = { path = "../crucible/upstairs" }
+# crucible-client-types = { path = "../crucible/crucible-client-types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,18 +71,18 @@ p9ds = { git = "https://github.com/oxidecomputer/p9fs" }
 softnpu = { git = "https://github.com/oxidecomputer/softnpu" }
 
 # Omicron-related
-internal-dns = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-nexus-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
+internal-dns = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface" }
+nexus-client = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface" }
+omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface" }
 omicron-zone-package = "0.9.0"
-oximeter-instruments = { git = "https://github.com/oxidecomputer/omicron", branch = "main", default-features = false, features = ["kstat"] }
-oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-sled-agent-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
+oximeter-instruments = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface", default-features = false, features = ["kstat"] }
+oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface" }
+oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface" }
+sled-agent-client = { git = "https://github.com/oxidecomputer/omicron", branch = "zl/instance-network-interface" }
 
 # Crucible
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "e58ca3693cb9ce0438947beba10e97ee38a0966b" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "e58ca3693cb9ce0438947beba10e97ee38a0966b" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "2aee0bc0fea61f26474b04c88d2c150fa0d35f56" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "2aee0bc0fea61f26474b04c88d2c150fa0d35f56" }
 
 # External dependencies
 anyhow = "1.0"
@@ -174,7 +174,6 @@ zerocopy = "0.7.34"
 # internal-dns = { path = "../omicron/internal-dns" }
 # nexus-client = { path = "../omicron/clients/nexus-client" }
 # omicron-common = { path = "../omicron/common" }
-# omicron-zone-package = "0.9.0"
 # oximeter-instruments = { path = "../omicron/oximeter/instruments" }
 # oximeter-producer = { path = "../omicron/oximeter/producer" }
 # oximeter = { path = "../omicron/oximeter/oximeter" }

--- a/bin/propolis-server/src/lib/spec/api_request.rs
+++ b/bin/propolis-server/src/lib/spec/api_request.rs
@@ -138,6 +138,7 @@ pub(super) fn parse_nic_from_request(
     let (device_name, backend_name) = super::pci_path_to_nic_names(pci_path);
     let device_spec = NetworkDeviceV0::VirtioNic(VirtioNic {
         backend_name: backend_name.clone(),
+        interface_id: nic.interface_id,
         pci_path,
     });
 
@@ -193,8 +194,11 @@ mod test {
 
     #[test]
     fn parsed_network_devices_point_to_backends() {
-        let req =
-            NetworkInterfaceRequest { name: "vnic".to_string(), slot: Slot(0) };
+        let req = NetworkInterfaceRequest {
+            name: "vnic".to_string(),
+            interface_id: uuid::Uuid::new_v4(),
+            slot: Slot(0),
+        };
 
         let parsed = parse_nic_from_request(&req).unwrap();
         let NetworkDeviceV0::VirtioNic(nic) = &parsed.device_spec;

--- a/bin/propolis-server/src/lib/spec/config_toml.rs
+++ b/bin/propolis-server/src/lib/spec/config_toml.rs
@@ -293,7 +293,7 @@ pub(super) fn parse_network_device_from_config(
         backend_name: backend_name.clone(),
         // We don't allow for configuration to specify the interface_id, so we
         // generate a new one.
-        interface_id: uuid::Uuid::new_v4(),
+        interface_id: uuid::Uuid::nil(),
         pci_path,
     });
 

--- a/bin/propolis-server/src/lib/spec/config_toml.rs
+++ b/bin/propolis-server/src/lib/spec/config_toml.rs
@@ -291,6 +291,9 @@ pub(super) fn parse_network_device_from_config(
 
     let device_spec = NetworkDeviceV0::VirtioNic(VirtioNic {
         backend_name: backend_name.clone(),
+        // We don't allow for configuration to specify the interface_id, so we
+        // generate a new one.
+        interface_id: uuid::Uuid::new_v4(),
         pci_path,
     });
 

--- a/bin/propolis-server/src/lib/stats/network_interface.rs
+++ b/bin/propolis-server/src/lib/stats/network_interface.rs
@@ -152,7 +152,7 @@ impl InstanceNetworkInterfaces {
     #[cfg(all(not(test), target_os = "illumos"))]
     pub(crate) fn new(
         properties: &propolis_api_types::InstanceProperties,
-        interface_ids: NetworkInterfaceIds,
+        interface_ids: &NetworkInterfaceIds,
     ) -> Self {
         Self {
             target: InstanceNetworkInterface {

--- a/bin/propolis-server/src/lib/stats/network_interface.rs
+++ b/bin/propolis-server/src/lib/stats/network_interface.rs
@@ -1,0 +1,384 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2024 Oxide Computer Company
+
+//! Types and functions for tracking statistics about an instance's network
+//! interfaces.
+
+// Propolis is built in a variety of configurations, including checks and tests
+// run on non-illumos machines where kstats are meaningless. This is a big
+// hammer, but a large number of the values in this module are not referenced in
+// those configurations, and so this is more straightfoward than littering the
+// code with cfg directives.
+#![cfg_attr(any(test, not(target_os = "illumos")), allow(dead_code))]
+
+use chrono::{DateTime, Utc};
+use oximeter::{types::Cumulative, FieldType, FieldValue, Sample, Target};
+
+use super::kstat_types::{
+    hrtime_to_utc, ConvertNamedData, Data, Error, Kstat, KstatList,
+    KstatTarget, Named,
+};
+use crate::vm::NetworkInterfaceIds;
+
+// NOTE: TOML definitions of timeseries are centralized in Omicron, so this file
+// lives in that repo, at
+// `./omicron/oximeter/oximeter/schema/instance-network-interface.toml`.
+oximeter::use_timeseries!("instance-network-interface.toml");
+use self::instance_network_interface::{
+    BytesReceived, BytesSent, ErrorsReceived, ErrorsSent,
+    InstanceNetworkInterface, PacketsDropped, PacketsReceived, PacketsSent,
+};
+
+const KSTAT_RX_BYTES: &str = "rx_bytes";
+const KSTAT_TX_BYTES: &str = "tx_bytes";
+const KSTAT_RX_PACKETS: &str = "rx_packets";
+const KSTAT_TX_PACKETS: &str = "tx_packets";
+const KSTAT_RX_DROPS: &str = "rx_drops";
+const KSTAT_RX_ERRORS: &str = "rx_errors";
+const KSTAT_TX_ERRORS: &str = "tx_errors";
+
+/// The names of the kstat fields that represent the instance network interface metrics
+/// we are interested in tracking.
+const KSTAT_FIELDS: &[&str] = &[
+    KSTAT_RX_BYTES,
+    KSTAT_TX_BYTES,
+    KSTAT_RX_PACKETS,
+    KSTAT_TX_PACKETS,
+    KSTAT_RX_DROPS,
+    KSTAT_RX_ERRORS,
+    KSTAT_TX_ERRORS,
+];
+
+/// The name of the kstat module that contains the instance network interface
+/// metrics.
+const KSTAT_MODULE_NAME: &str = "viona";
+
+/// The name of the kstat that contains the instance network interface metrics.
+const KSTAT_NAME: &str = "viona_stat";
+
+/// Helper function to extract the same kstat metrics from all link targets.
+fn extract_nic_kstats(
+    target: &InstanceNetworkInterface,
+    named_data: &Named,
+    creation_time: DateTime<Utc>,
+    snapshot_time: DateTime<Utc>,
+) -> Option<Result<Sample, Error>> {
+    let Named { name, value } = named_data;
+    if *name == KSTAT_RX_BYTES {
+        Some(value.as_u64().and_then(|x| {
+            let metric = BytesReceived {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == KSTAT_TX_BYTES {
+        Some(value.as_u64().and_then(|x| {
+            let metric = BytesSent {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == KSTAT_RX_PACKETS {
+        Some(value.as_u64().and_then(|x| {
+            let metric = PacketsReceived {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == KSTAT_TX_PACKETS {
+        Some(value.as_u64().and_then(|x| {
+            let metric = PacketsSent {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == KSTAT_RX_DROPS {
+        Some(value.as_u64().and_then(|x| {
+            let metric = PacketsDropped {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == KSTAT_RX_ERRORS {
+        Some(value.as_u64().and_then(|x| {
+            let metric = ErrorsReceived {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else if *name == KSTAT_TX_ERRORS {
+        Some(value.as_u64().and_then(|x| {
+            let metric = ErrorsSent {
+                datum: Cumulative::with_start_time(creation_time, x),
+            };
+            Sample::new_with_timestamp(snapshot_time, target, &metric)
+                .map_err(Error::Sample)
+        }))
+    } else {
+        None
+    }
+}
+
+/// A wrapper around the `oximeter::Target` representing all instance network interfaces.
+#[derive(Clone, Debug)]
+pub(crate) struct InstanceNetworkInterfaces {
+    /// The `oximeter::Target` itself, storing the target fields for the
+    /// timeseries.
+    ///
+    /// **NOTE**: While this struct represents multiple instance network interfaces,
+    /// they all share the same target fields.
+    ///
+    /// We default `interface_id` by generating a `uuid::Uuid::nil()` on first
+    /// creation, before creating multiple targets in the `to_samples` method.
+    pub(crate) target: InstanceNetworkInterface,
+
+    /// A tuple-mapping of the interface UUIDs to the kstat instance IDs.
+    pub(crate) interface_ids: NetworkInterfaceIds,
+}
+
+impl InstanceNetworkInterfaces {
+    /// Create a new instance network interface metrics target from the given
+    /// instance properties and add the interface_ids to match and gather
+    /// metrics from.
+    #[cfg(all(not(test), target_os = "illumos"))]
+    pub(crate) fn new(
+        properties: &propolis_api_types::InstanceProperties,
+        interface_ids: NetworkInterfaceIds,
+    ) -> Self {
+        Self {
+            target: InstanceNetworkInterface {
+                // Default `interface_id` to a new UUID, as we will create
+                // multiple targets in the `to_samples` method and override
+                // this.
+                interface_id: uuid::Uuid::nil(),
+                instance_id: properties.id,
+                project_id: properties.metadata.project_id,
+                silo_id: properties.metadata.silo_id,
+            },
+            interface_ids: interface_ids.to_vec(),
+        }
+    }
+}
+
+impl KstatTarget for InstanceNetworkInterfaces {
+    fn interested(&self, kstat: &Kstat<'_>) -> bool {
+        kstat.ks_module == KSTAT_MODULE_NAME
+            && kstat.ks_name == KSTAT_NAME
+            && self.interface_ids.iter().any(|(_id, device_instance_id)| {
+                kstat.ks_instance as u32 == *device_instance_id
+            })
+    }
+
+    fn to_samples(
+        &self,
+        kstats: KstatList<'_, '_>,
+    ) -> Result<Vec<Sample>, Error> {
+        let kstats_for_nics =
+            kstats.iter().filter_map(|(creation_time, kstat, data)| {
+                self.interface_ids.iter().find_map(
+                    |(id, device_instance_id)| {
+                        if kstat.ks_instance as u32 == *device_instance_id {
+                            let target = InstanceNetworkInterface {
+                                interface_id: *id,
+                                instance_id: self.target.instance_id,
+                                project_id: self.target.project_id,
+                                silo_id: self.target.silo_id,
+                            };
+                            Some((*creation_time, kstat, data, target))
+                        } else {
+                            None
+                        }
+                    },
+                )
+            });
+
+        // Capacity is determined by the number of interfaces times the number
+        // of kstat fields we track.
+        let mut out =
+            Vec::with_capacity(self.interface_ids.len() * KSTAT_FIELDS.len());
+        for (creation_time, kstat, data, target) in kstats_for_nics {
+            let snapshot_time = hrtime_to_utc(kstat.ks_snaptime)?;
+            if let Data::Named(named) = data {
+                named
+                    .iter()
+                    .filter_map(|nd| {
+                        extract_nic_kstats(
+                            &target,
+                            nd,
+                            creation_time,
+                            snapshot_time,
+                        )
+                        .and_then(|opt_result| opt_result.ok())
+                    })
+                    .for_each(|sample| out.push(sample));
+            }
+        }
+
+        Ok(out)
+    }
+}
+
+// Implement the `oximeter::Target` trait for `InstanceNetworkInterfaces` using
+// the single `InstanceNetworkInterface` target as it represents all the same fields.
+impl Target for InstanceNetworkInterfaces {
+    fn name(&self) -> &'static str {
+        self.target.name()
+    }
+    fn field_names(&self) -> &'static [&'static str] {
+        self.target.field_names()
+    }
+
+    fn field_types(&self) -> Vec<FieldType> {
+        self.target.field_types()
+    }
+
+    fn field_values(&self) -> Vec<FieldValue> {
+        self.target.field_values()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashSet;
+
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::stats::kstat_types::NamedData;
+
+    fn test_network_interface() -> InstanceNetworkInterface {
+        const INTERFACE_ID: Uuid =
+            uuid::uuid!("f4b3b3b3-3b3b-3b3b-3b3b-3b3b3b3b3b3b");
+        const INSTANCE_ID: Uuid =
+            uuid::uuid!("96d6ec78-543a-4188-830e-37e2a0eeff16");
+        const PROJECT_ID: Uuid =
+            uuid::uuid!("7b61df02-0794-4b37-93bc-89f03c7289ca");
+        const SILO_ID: Uuid =
+            uuid::uuid!("6a4bd4b6-e9aa-44d1-b616-399d48baa173");
+
+        InstanceNetworkInterface {
+            interface_id: INTERFACE_ID,
+            instance_id: INSTANCE_ID,
+            project_id: PROJECT_ID,
+            silo_id: SILO_ID,
+        }
+    }
+
+    #[test]
+    fn test_kstat_interested() {
+        let target = InstanceNetworkInterfaces {
+            target: test_network_interface(),
+            interface_ids: vec![(Uuid::new_v4(), 2), (Uuid::new_v4(), 3)],
+        };
+
+        let ks_interested2 = Kstat {
+            ks_module: KSTAT_MODULE_NAME,
+            ks_instance: 2,
+            ks_snaptime: 0,
+            ks_name: KSTAT_NAME,
+        };
+
+        assert!(target.interested(&ks_interested2));
+
+        let ks_interested3 = Kstat {
+            ks_module: KSTAT_MODULE_NAME,
+            ks_instance: 3,
+            ks_snaptime: 0,
+            ks_name: KSTAT_NAME,
+        };
+
+        assert!(target.interested(&ks_interested3));
+
+        let ks_not_interested_module = Kstat {
+            ks_module: "not-viona",
+            ks_instance: 2,
+            ks_snaptime: 0,
+            ks_name: KSTAT_NAME,
+        };
+        assert!(!target.interested(&ks_not_interested_module));
+
+        let ks_not_interested_instance = Kstat {
+            ks_module: KSTAT_MODULE_NAME,
+            ks_instance: 4,
+            ks_snaptime: 0,
+            ks_name: KSTAT_NAME,
+        };
+        assert!(!target.interested(&ks_not_interested_instance));
+    }
+
+    #[test]
+    fn test_kstat_to_samples() {
+        let target = InstanceNetworkInterfaces {
+            target: test_network_interface(),
+            interface_ids: vec![(Uuid::new_v4(), 2), (Uuid::new_v4(), 3)],
+        };
+
+        let kstat2 = Kstat {
+            ks_module: KSTAT_MODULE_NAME,
+            ks_instance: 2,
+            ks_snaptime: 0,
+            ks_name: KSTAT_NAME,
+        };
+
+        let kstat3 = Kstat {
+            ks_module: KSTAT_MODULE_NAME,
+            ks_instance: 3,
+            ks_snaptime: 0,
+            ks_name: KSTAT_NAME,
+        };
+
+        let bytes_received =
+            Named { name: KSTAT_RX_BYTES, value: NamedData::UInt64(100) };
+        let bytes_sent =
+            Named { name: KSTAT_TX_BYTES, value: NamedData::UInt64(200) };
+        let packets_received =
+            Named { name: KSTAT_RX_PACKETS, value: NamedData::UInt64(4) };
+        let packets_sent =
+            Named { name: KSTAT_TX_PACKETS, value: NamedData::UInt64(4) };
+        let packets_dropped =
+            Named { name: KSTAT_RX_DROPS, value: NamedData::UInt64(0) };
+        let errors_received =
+            Named { name: KSTAT_RX_ERRORS, value: NamedData::UInt64(0) };
+        let errors_sent =
+            Named { name: KSTAT_TX_ERRORS, value: NamedData::UInt64(0) };
+
+        let data = Data::Named(vec![
+            bytes_received,
+            bytes_sent,
+            packets_received,
+            packets_sent,
+            packets_dropped,
+            errors_received,
+            errors_sent,
+        ]);
+
+        let kstat_list = vec![
+            (Utc::now(), kstat2, data.clone()),
+            (Utc::now(), kstat3, data),
+        ];
+        let samples = target.to_samples(kstat_list.as_slice()).unwrap();
+        assert_eq!(samples.len(), 2 * KSTAT_FIELDS.len());
+
+        let mut interface_uuids = HashSet::new();
+        for sample in samples {
+            assert_eq!(sample.target_name(), "instance_network_interface");
+            for field in sample.fields() {
+                assert!(target.field_names().contains(&field.name.as_str()));
+                if field.name == "interface_id" {
+                    interface_uuids.insert(field.value);
+                }
+            }
+        }
+        // We should have two unique interface UUIDs.
+        assert_eq!(interface_uuids.len(), 2);
+    }
+}

--- a/bin/propolis-server/src/lib/vm/ensure.rs
+++ b/bin/propolis-server/src/lib/vm/ensure.rs
@@ -199,7 +199,7 @@ impl<'a> VmEnsureNotStarted<'a> {
         let ps2ctrl = init.initialize_ps2(&chipset)?;
         init.initialize_qemu_debug_port()?;
         init.initialize_qemu_pvpanic(properties.into())?;
-        init.initialize_network_devices(&chipset)?;
+        init.initialize_network_devices(&chipset, &maybe_kstat_sampler).await?;
 
         #[cfg(not(feature = "omicron-build"))]
         init.initialize_test_devices(&options.toml_config.devices)?;
@@ -219,7 +219,9 @@ impl<'a> VmEnsureNotStarted<'a> {
             .await?;
 
         let ramfb = init.initialize_fwcfg(v0_spec.devices.board.cpus)?;
+
         init.initialize_cpus(&maybe_kstat_sampler).await?;
+
         let vcpu_tasks = Box::new(crate::vcpu_tasks::VcpuTasks::new(
             &machine,
             event_queue.clone()

--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -111,6 +111,9 @@ pub(crate) mod state_publisher;
 pub(crate) type DeviceMap =
     BTreeMap<String, Arc<dyn propolis::common::Lifecycle>>;
 
+/// Mapping of NIC identifiers to viona device instance IDs.
+pub(crate) type NetworkInterfaceIds = Vec<(uuid::Uuid, KstatInstanceId)>;
+
 /// Maps component names to block backend trait objects.
 pub(crate) type BlockBackendMap =
     BTreeMap<String, Arc<dyn propolis::block::Backend>>;
@@ -136,6 +139,10 @@ pub(crate) type CrucibleReplaceResult =
 /// reconfiguration results.
 pub(crate) type CrucibleReplaceResultTx =
     oneshot::Sender<CrucibleReplaceResult>;
+
+/// PCI device instance ID type to which a per-component Kstat (kernal stat)
+/// instance ID maps to.
+type KstatInstanceId = u32;
 
 /// Type alias for the sender side of a channel that receives the results of
 /// instance-ensure API calls.

--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -112,6 +112,7 @@ pub(crate) type DeviceMap =
     BTreeMap<String, Arc<dyn propolis::common::Lifecycle>>;
 
 /// Mapping of NIC identifiers to viona device instance IDs.
+/// We use a Vec here due to the limited size of the NIC array.
 pub(crate) type NetworkInterfaceIds = Vec<(uuid::Uuid, KstatInstanceId)>;
 
 /// Maps component names to block backend trait objects.

--- a/bin/propolis-server/src/lib/vm/services.rs
+++ b/bin/propolis-server/src/lib/vm/services.rs
@@ -14,7 +14,7 @@ use slog::{error, info, Logger};
 use crate::{
     serial::SerialTaskControlMessage,
     server::MetricsEndpointConfig,
-    stats::{virtual_machine::VirtualMachine, ServerStats},
+    stats::{ServerStats, VirtualMachine},
     vnc::VncServer,
 };
 

--- a/crates/propolis-api-types/src/instance_spec/components/devices.rs
+++ b/crates/propolis-api-types/src/instance_spec/components/devices.rs
@@ -96,8 +96,10 @@ pub struct VirtioNic {
     /// The name of the device's backend.
     pub backend_name: String,
 
-    /// The interface ID of the device from the requested NIC to which we are
-    /// binding.
+    /// A caller-defined correlation identifier for this interface. If Propolis
+    /// is configured to collect network interface kstats in its Oximeter
+    /// metrics, the metric series for this interface will be associated with
+    /// this identifier.
     pub interface_id: uuid::Uuid,
 
     /// The PCI path at which to attach this device.

--- a/crates/propolis-api-types/src/instance_spec/components/devices.rs
+++ b/crates/propolis-api-types/src/instance_spec/components/devices.rs
@@ -96,6 +96,10 @@ pub struct VirtioNic {
     /// The name of the device's backend.
     pub backend_name: String,
 
+    /// The interface ID of the device from the requested NIC to which we are
+    /// binding.
+    pub interface_id: uuid::Uuid,
+
     /// The PCI path at which to attach this device.
     pub pci_path: PciPath,
 }
@@ -361,6 +365,7 @@ mod test {
     fn compatible_virtio_nic() {
         let d1 = VirtioNic {
             backend_name: "storage_backend".to_string(),
+            interface_id: uuid::Uuid::new_v4(),
             pci_path: PciPath::new(0, 5, 0).unwrap(),
         };
         assert!(d1.can_migrate_from_element(&d1).is_ok());
@@ -370,6 +375,7 @@ mod test {
     fn incompatible_virtio_nic() {
         let d1 = VirtioNic {
             backend_name: "storage_backend".to_string(),
+            interface_id: uuid::Uuid::new_v4(),
             pci_path: PciPath::new(0, 5, 0).unwrap(),
         };
 

--- a/crates/propolis-api-types/src/lib.rs
+++ b/crates/propolis-api-types/src/lib.rs
@@ -209,7 +209,6 @@ pub struct InstanceProperties {
     pub description: String,
     /// Metadata used to track statistics for this Instance.
     pub metadata: InstanceMetadata,
-
     /// ID of the image used to initialize this Instance.
     pub image_id: Uuid,
     /// ID of the bootrom used to initialize this Instance.
@@ -231,7 +230,6 @@ impl InstanceProperties {
 pub struct Instance {
     pub properties: InstanceProperties,
     pub state: InstanceState,
-
     pub disks: Vec<DiskAttachment>,
     pub nics: Vec<NetworkInterface>,
 }
@@ -394,6 +392,7 @@ pub struct Slot(pub u8);
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct NetworkInterfaceRequest {
+    pub interface_id: Uuid,
     pub name: String,
     pub slot: Slot,
 }

--- a/crates/viona-api/src/lib.rs
+++ b/crates/viona-api/src/lib.rs
@@ -5,6 +5,7 @@
 use std::fs::{File, OpenOptions};
 use std::io::{Error, ErrorKind, Result};
 use std::os::fd::*;
+use std::os::unix::fs::MetadataExt;
 
 pub use viona_api_sys::*;
 
@@ -63,6 +64,15 @@ impl VionaFd {
         // VNA_IOC_VERSION interface.
         assert!(vers > 0);
         Ok(vers as u32)
+    }
+
+    /// Retrieve the minor number of the viona device instance.
+    /// This is used for matching kernal statistic entries to the viona device.
+    pub fn instance_id(&self) -> Result<u32> {
+        let meta = self.0.metadata()?;
+        let rdev = meta.rdev();
+        let minor = unsafe { libc::minor(rdev) };
+        Ok(minor)
     }
 
     /// Check VMM ioctl command against those known to not require any

--- a/lib/propolis/src/hw/virtio/viona.rs
+++ b/lib/propolis/src/hw/virtio/viona.rs
@@ -91,7 +91,6 @@ impl Inner {
 pub struct PciVirtioViona {
     virtio_state: PciVirtioState,
     pci_state: pci::DeviceState,
-
     dev_features: u32,
     mac_addr: [u8; ETHERADDRL],
     mtu: Option<u16>,
@@ -155,6 +154,11 @@ impl PciVirtioViona {
         drop(inner);
 
         Ok(this)
+    }
+
+    /// Get the minor instance number of the viona device.
+    pub fn instance_id(&self) -> io::Result<u32> {
+        self.hdl.instance_id()
     }
 
     fn process_interrupts(&self) {
@@ -646,6 +650,12 @@ impl VionaHdl {
     fn ring_intr_clear(&self, idx: u16) -> io::Result<()> {
         self.0.ioctl_usize(viona_api::VNA_IOC_RING_INTR_CLR, idx as usize)?;
         Ok(())
+    }
+
+    /// Get the minor instance number of the viona device.
+    /// This is used for matching kernal statistic entries to the viona device.
+    fn instance_id(&self) -> io::Result<u32> {
+        self.0.instance_id()
     }
 
     /// Set the desired promiscuity level on this interface.

--- a/openapi/propolis-server-falcon.json
+++ b/openapi/propolis-server-falcon.json
@@ -1792,7 +1792,7 @@
             "type": "string"
           },
           "interface_id": {
-            "description": "The interface ID of the device from the requested NIC to which we are binding.",
+            "description": "A caller-defined correlation identifier for this interface. If Propolis is configured to collect network interface kstats in its Oximeter metrics, the metric series for this interface will be associated with this identifier.",
             "type": "string",
             "format": "uuid"
           },

--- a/openapi/propolis-server-falcon.json
+++ b/openapi/propolis-server-falcon.json
@@ -1385,6 +1385,10 @@
       "NetworkInterfaceRequest": {
         "type": "object",
         "properties": {
+          "interface_id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "name": {
             "type": "string"
           },
@@ -1393,6 +1397,7 @@
           }
         },
         "required": [
+          "interface_id",
           "name",
           "slot"
         ]
@@ -1786,6 +1791,11 @@
             "description": "The name of the device's backend.",
             "type": "string"
           },
+          "interface_id": {
+            "description": "The interface ID of the device from the requested NIC to which we are binding.",
+            "type": "string",
+            "format": "uuid"
+          },
           "pci_path": {
             "description": "The PCI path at which to attach this device.",
             "allOf": [
@@ -1797,6 +1807,7 @@
         },
         "required": [
           "backend_name",
+          "interface_id",
           "pci_path"
         ],
         "additionalProperties": false

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -1675,7 +1675,7 @@
             "type": "string"
           },
           "interface_id": {
-            "description": "The interface ID of the device from the requested NIC to which we are binding.",
+            "description": "A caller-defined correlation identifier for this interface. If Propolis is configured to collect network interface kstats in its Oximeter metrics, the metric series for this interface will be associated with this identifier.",
             "type": "string",
             "format": "uuid"
           },

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -1354,6 +1354,10 @@
       "NetworkInterfaceRequest": {
         "type": "object",
         "properties": {
+          "interface_id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "name": {
             "type": "string"
           },
@@ -1362,6 +1366,7 @@
           }
         },
         "required": [
+          "interface_id",
           "name",
           "slot"
         ]
@@ -1669,6 +1674,11 @@
             "description": "The name of the device's backend.",
             "type": "string"
           },
+          "interface_id": {
+            "description": "The interface ID of the device from the requested NIC to which we are binding.",
+            "type": "string",
+            "format": "uuid"
+          },
           "pci_path": {
             "description": "The PCI path at which to attach this device.",
             "allOf": [
@@ -1680,6 +1690,7 @@
         },
         "required": [
           "backend_name",
+          "interface_id",
           "pci_path"
         ],
         "additionalProperties": false


### PR DESCRIPTION
Overview
========

This closes the ongoing work related to [plumbing instance/guest metrics](https://github.com/oxidecomputer/propolis/issues/742) through to an oximeter producer in propolis.

Includes:

* An update to `NetworkInterfaceRequest` to include an interface_id, which is part of the request on the [sled instance in Omicron](https://github.com/oxidecomputer/omicron/pull/6414).
* Within initialization, with concrete types, we create interface_ids mapping nic UUIDs => `minor` number of the device instance of viona.
  - The device instance number matches the Kstat we'll look for.
  - We track this mapping via a type alias `InterfaceIdentifiers`, which is passed through from Machine initialization to VM objects (and VM objects shared), the latter of which we can use as part of registering the oximeter producer.
* A new stats module for collecting network_interface metrics.
  - In `to_samples` we generate multiple network interface targets based on vnics per instance, appropriately updating the `interface_id`, which is tracked in `interface_ids`.
* Move kstat_types out of virtual machine-specific stats and use its mocking for other stats tests

Dependencies
------------

- [x] https://github.com/oxidecomputer/omicron/pull/6414
- [x] https://code.illumos.org/c/illumos-gate/+/3630
- [ ] **Note**: Will need to update the commit hash in https://github.com/oxidecomputer/falcon once all this is finished. 