### PR TITLE
PHD: add test coverage for `instance_ensure` API endpoint

### DIFF
--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -5,7 +5,7 @@
 //! Routines for starting VMs, changing their states, and interacting with their
 //! guest OSes.
 
-use std::{fmt::Debug, io::Write, sync::Arc, time::Duration};
+use std::{fmt::Debug, io::Write, pin::Pin, sync::Arc, time::Duration};
 
 use crate::{
     guest_os::{self, CommandSequenceEntry, GuestOs, GuestOsKind},
@@ -19,14 +19,15 @@ use crate::{
 use anyhow::{anyhow, Context, Result};
 use camino::Utf8PathBuf;
 use core::result::Result as StdResult;
+use futures::Future;
 use propolis_client::{
     support::{InstanceSerialConsoleHelper, WSClientOffset},
     types::{
-        InstanceGetResponse, InstanceMigrateInitiateRequest,
-        InstanceMigrateStatusResponse, InstanceProperties,
-        InstanceSerialConsoleHistoryResponse, InstanceSpecEnsureRequest,
-        InstanceSpecGetResponse, InstanceState, InstanceStateRequested,
-        MigrationState, VersionedInstanceSpec,
+        InstanceEnsureRequest, InstanceEnsureResponse, InstanceGetResponse,
+        InstanceMigrateInitiateRequest, InstanceMigrateStatusResponse,
+        InstanceProperties, InstanceSerialConsoleHistoryResponse,
+        InstanceSpecEnsureRequest, InstanceSpecGetResponse, InstanceState,
+        InstanceStateRequested, MigrationState, VersionedInstanceSpec,
     },
 };
 use propolis_client::{Client, ResponseValue};
@@ -124,6 +125,15 @@ enum InstanceConsoleSource<'a> {
 
     // Clone an existing console connection from the supplied VM.
     InheritFrom(&'a TestVm),
+}
+
+/// Specifies the propolis-server interface to use when starting a VM.
+enum InstanceEnsureApi {
+    /// Use the `instance_spec_ensure` interface.
+    SpecEnsure,
+
+    /// Use the `instance_ensure` interface.
+    Ensure,
 }
 
 enum VmState {
@@ -281,6 +291,7 @@ impl TestVm {
     #[instrument(skip_all, fields(vm = self.spec.vm_name, vm_id = %self.id))]
     async fn instance_ensure_internal<'a>(
         &self,
+        api: InstanceEnsureApi,
         migrate: Option<InstanceMigrateInitiateRequest>,
         console_source: InstanceConsoleSource<'a>,
     ) -> Result<SerialConsole> {
@@ -305,27 +316,67 @@ impl TestVm {
             vcpus,
         };
 
-        let versioned_spec =
-            VersionedInstanceSpec::V0(self.spec.instance_spec.clone());
-        let ensure_req = InstanceSpecEnsureRequest {
-            properties,
-            instance_spec: versioned_spec,
-            migrate,
+        // The non-spec ensure interface requires a set of `DiskRequest`
+        // structures to specify disks. Create those once and clone them if the
+        // ensure call needs to be retried.
+        let disk_reqs = if let InstanceEnsureApi::Ensure = api {
+            Some(self.spec.make_disk_requests()?)
+        } else {
+            None
         };
 
         // There is a brief period where the Propolis server process has begun
         // to run but hasn't started its Dropshot server yet. Ensure requests
-        // that land in that window will fail, so retry them. This shouldn't
-        // ever take more than a couple of seconds (if it does, that should be
-        // considered a bug impacting VM startup times).
+        // that land in that window will fail, so retry them.
+        //
+        // The `instance_ensure` and `instance_spec_ensure` endpoints return the
+        // same response type, so (with some gnarly writing out of the types)
+        // it's possible to create a boxed future that abstracts over the
+        // caller's chosen endpoint.
         let ensure_fn = || async {
-            if let Err(e) = self
-                .client
-                .instance_spec_ensure()
-                .body(&ensure_req)
-                .send()
-                .await
-            {
+            let send_fut: Pin<
+                Box<
+                    dyn Future<
+                            Output = Result<
+                                ResponseValue<InstanceEnsureResponse>,
+                                _,
+                            >,
+                        > + Send,
+                >,
+            > = match api {
+                InstanceEnsureApi::SpecEnsure => {
+                    let versioned_spec = VersionedInstanceSpec::V0(
+                        self.spec.instance_spec.clone(),
+                    );
+
+                    let ensure_req = InstanceSpecEnsureRequest {
+                        properties: properties.clone(),
+                        instance_spec: versioned_spec,
+                        migrate: migrate.clone(),
+                    };
+
+                    Box::pin(
+                        self.client
+                            .instance_spec_ensure()
+                            .body(&ensure_req)
+                            .send(),
+                    )
+                }
+                InstanceEnsureApi::Ensure => {
+                    let ensure_req = InstanceEnsureRequest {
+                        cloud_init_bytes: None,
+                        disks: disk_reqs.clone().unwrap(),
+                        migrate: migrate.clone(),
+                        nics: vec![],
+                        properties: properties.clone(),
+                    };
+
+                    Box::pin(
+                        self.client.instance_ensure().body(&ensure_req).send(),
+                    )
+                }
+            };
+            if let Err(e) = send_fut.await {
                 match e {
                     propolis_client::Error::CommunicationError(_) => {
                         info!(%e, "retriable error from instance_spec_ensure");
@@ -341,6 +392,9 @@ impl TestVm {
             }
         };
 
+        // It shouldn't ever take more than a couple of seconds for the Propolis
+        // server to come to life. (If it does, that should be considered a bug
+        // impacting VM startup times.)
         backoff::future::retry(
             backoff::ExponentialBackoff {
                 max_elapsed_time: Some(std::time::Duration::from_secs(2)),
@@ -412,7 +466,29 @@ impl TestVm {
         match self.state {
             VmState::New => {
                 let console = self
-                    .instance_ensure_internal(None, InstanceConsoleSource::New)
+                    .instance_ensure_internal(
+                        InstanceEnsureApi::SpecEnsure,
+                        None,
+                        InstanceConsoleSource::New,
+                    )
+                    .await?;
+                self.state = VmState::Ensured { serial: console };
+            }
+            VmState::Ensured { .. } => {}
+        }
+
+        Ok(())
+    }
+
+    pub async fn instance_ensure_using_api_request(&mut self) -> Result<()> {
+        match self.state {
+            VmState::New => {
+                let console = self
+                    .instance_ensure_internal(
+                        InstanceEnsureApi::Ensure,
+                        None,
+                        InstanceConsoleSource::New,
+                    )
                     .await?;
                 self.state = VmState::Ensured { serial: console };
             }
@@ -515,6 +591,7 @@ impl TestVm {
 
                 let serial = self
                     .instance_ensure_internal(
+                        InstanceEnsureApi::SpecEnsure,
                         Some(InstanceMigrateInitiateRequest {
                             migration_id,
                             src_addr: server_addr.to_string(),

--- a/phd-tests/framework/src/test_vm/spec.rs
+++ b/phd-tests/framework/src/test_vm/spec.rs
@@ -86,7 +86,7 @@ impl VmSpec {
     ///
     /// All of the disks in the spec must be Crucible disks. If one is not, this
     /// routine returns an error.
-    pub(crate) fn make_legacy_disk_requests(
+    pub(crate) fn make_disk_requests(
         &self,
     ) -> anyhow::Result<Vec<DiskRequest>> {
         struct DeviceInfo<'a> {

--- a/phd-tests/framework/src/test_vm/spec.rs
+++ b/phd-tests/framework/src/test_vm/spec.rs
@@ -9,7 +9,8 @@ use crate::{
     guest_os::GuestOsKind,
 };
 use propolis_client::types::{
-    InstanceMetadata, InstanceSpecV0, StorageBackendV0,
+    DiskRequest, InstanceMetadata, InstanceSpecV0, PciPath, Slot,
+    StorageBackendV0, StorageDeviceV0,
 };
 use uuid::Uuid;
 
@@ -78,5 +79,75 @@ impl VmSpec {
         let id = Uuid::new_v4();
         self.metadata.sled_id = id;
         self.metadata.sled_serial = id.to_string();
+    }
+
+    /// Generates a set of [`propolis_client::types::DiskRequest`] structures
+    /// corresponding to the disks in this VM spec.
+    ///
+    /// All of the disks in the spec must be Crucible disks. If one is not, this
+    /// routine returns an error.
+    pub(crate) fn make_legacy_disk_requests(
+        &self,
+    ) -> anyhow::Result<Vec<DiskRequest>> {
+        struct DeviceInfo<'a> {
+            backend_name: &'a str,
+            interface: &'static str,
+            slot: Slot,
+        }
+
+        fn convert_to_slot(pci_path: PciPath) -> anyhow::Result<Slot> {
+            match pci_path.device {
+                dev @ 0x10..=0x17 => Ok(Slot(dev - 0x10)),
+                _ => Err(anyhow::anyhow!(
+                    "PCI device number {} out of range",
+                    pci_path.device
+                )),
+            }
+        }
+
+        fn get_device_info(
+            device: &StorageDeviceV0,
+        ) -> anyhow::Result<DeviceInfo> {
+            match device {
+                StorageDeviceV0::VirtioDisk(d) => Ok(DeviceInfo {
+                    backend_name: &d.backend_name,
+                    interface: "virtio",
+                    slot: convert_to_slot(d.pci_path)?,
+                }),
+                StorageDeviceV0::NvmeDisk(d) => Ok(DeviceInfo {
+                    backend_name: &d.backend_name,
+                    interface: "nvme",
+                    slot: convert_to_slot(d.pci_path)?,
+                }),
+            }
+        }
+
+        let mut reqs = vec![];
+        for (name, device) in self.instance_spec.devices.storage_devices.iter()
+        {
+            let info = get_device_info(device)?;
+            let backend = self
+                .instance_spec
+                .backends
+                .storage_backends
+                .get(info.backend_name)
+                .expect("storage device should have a matching backend");
+
+            let StorageBackendV0::Crucible(backend) = backend else {
+                anyhow::bail!("disk {name} does not have a Crucible backend");
+            };
+
+            reqs.push(DiskRequest {
+                device: info.interface.to_owned(),
+                name: name.clone(),
+                read_only: backend.readonly,
+                slot: info.slot,
+                volume_construction_request: serde_json::from_str(
+                    &backend.request_json,
+                )?,
+            })
+        }
+
+        Ok(reqs)
     }
 }

--- a/phd-tests/tests/src/ensure_api.rs
+++ b/phd-tests/tests/src/ensure_api.rs
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tests that explicitly exercise the `instance_ensure` form of the VM start
+//! API.
+
+use phd_framework::{
+    disk::BlockSize,
+    test_vm::{DiskBackend, DiskInterface},
+};
+use phd_testcase::*;
+
+#[phd_testcase]
+async fn instance_ensure_api_test(ctx: &Framework) {
+    if !ctx.crucible_enabled() {
+        phd_skip!("test requires Crucible to be enabled");
+    }
+
+    let mut config = ctx.vm_config_builder("instance_ensure_api_test");
+    config.boot_disk(
+        ctx.default_guest_os_artifact(),
+        DiskInterface::Nvme,
+        DiskBackend::Crucible {
+            min_disk_size_gib: 10,
+            block_size: BlockSize::Bytes512,
+        },
+        0x10,
+    );
+
+    let mut vm = ctx.spawn_vm(&config, None).await?;
+    vm.instance_ensure_using_api_request().await?;
+}

--- a/phd-tests/tests/src/lib.rs
+++ b/phd-tests/tests/src/lib.rs
@@ -6,6 +6,7 @@ pub use phd_testcase;
 
 mod crucible;
 mod disk;
+mod ensure_api;
 mod framework;
 mod hw;
 mod migrate;


### PR DESCRIPTION
PHD uses the propolis-server `instance_spec_ensure` endpoint when creating VMs. This maximizes the framework's control over what virtual devices and backends get created and its knowledge of how devices should manifest to guests.

When sled agent creates a VM, it uses the `instance_ensure` endpoint, which takes an `InstanceEnsureRequest` that specifies components at a slightly higher level of abstraction than `instance_spec_ensure`. The server handles calls to the former endpoint by shimming the `InstanceEnsureRequest` into an instance spec and then pretending the caller called `instance_spec_ensure`. The shim is relatively straightforward, but because PHD doesn't use it (and as #750 shows) it can be a great place for bugs to hide...

Although the medium-term plan is to try to switch sled agent over to using the spec endpoint (see RFD 505), for now add an affordance to PHD to allow it to use the `instance_ensure` endpoint if a test requests it.

Tested by running the new test against master before and after #751 merged and verifying that the test fails without that change and passes with it.