### PR TITLE
instance spec rework: remove most dependencies on `InstanceSpecV0` from propolis-server

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::serial::Serial;
-use crate::spec::{self, StorageBackend};
+use crate::spec::{self, Spec, StorageBackend};
 use crate::stats::{
     track_network_interface_kstats, track_vcpu_kstats, VirtualDiskProducer,
     VirtualMachine,
@@ -47,7 +47,7 @@ use slog::info;
 /// Arbitrary ROM limit for now
 const MAX_ROM_SIZE: usize = 0x20_0000;
 
-fn get_spec_guest_ram_limits(spec: &spec::Spec) -> (usize, usize) {
+fn get_spec_guest_ram_limits(spec: &Spec) -> (usize, usize) {
     let memsize = spec.board.memory_mb as usize * MB;
     let lowmem = memsize.min(3 * GB);
     let highmem = memsize.saturating_sub(3 * GB);
@@ -56,7 +56,7 @@ fn get_spec_guest_ram_limits(spec: &spec::Spec) -> (usize, usize) {
 
 pub fn build_instance(
     name: &str,
-    spec: &spec::Spec,
+    spec: &Spec,
     use_reservoir: bool,
     _log: slog::Logger,
 ) -> Result<Machine> {
@@ -120,7 +120,7 @@ pub struct MachineInitializer<'a> {
     pub(crate) devices: DeviceMap,
     pub(crate) block_backends: BlockBackendMap,
     pub(crate) crucible_backends: CrucibleBackendMap,
-    pub(crate) spec: &'a spec::Spec,
+    pub(crate) spec: &'a Spec,
     pub(crate) properties: &'a InstanceProperties,
     pub(crate) toml_config: &'a crate::server::VmTomlConfig,
     pub(crate) producer_registry: Option<ProducerRegistry>,

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::serial::Serial;
-use crate::spec;
+use crate::spec::{self, StorageBackend};
 use crate::stats::{
     track_network_interface_kstats, track_vcpu_kstats, VirtualDiskProducer,
     VirtualMachine,
@@ -391,12 +391,12 @@ impl<'a> MachineInitializer<'a> {
 
     async fn create_storage_backend_from_spec(
         &self,
-        backend_spec: &instance_spec::v0::StorageBackendV0,
+        backend_spec: &StorageBackend,
         backend_name: &str,
         nexus_client: &Option<NexusClient>,
     ) -> Result<StorageBackendInstance, Error> {
         match backend_spec {
-            instance_spec::v0::StorageBackendV0::Crucible(spec) => {
+            StorageBackend::Crucible(spec) => {
                 info!(self.log, "Creating Crucible disk";
                       "backend_name" => backend_name);
 
@@ -433,7 +433,7 @@ impl<'a> MachineInitializer<'a> {
                 let crucible = Some((be.get_uuid().await?, be.clone()));
                 Ok(StorageBackendInstance { be, crucible })
             }
-            instance_spec::v0::StorageBackendV0::File(spec) => {
+            StorageBackend::File(spec) => {
                 info!(self.log, "Creating file disk backend";
                       "path" => &spec.path);
 
@@ -459,7 +459,7 @@ impl<'a> MachineInitializer<'a> {
 
                 Ok(StorageBackendInstance { be, crucible: None })
             }
-            instance_spec::v0::StorageBackendV0::Blob(spec) => {
+            StorageBackend::Blob(spec) => {
                 let bytes = base64::Engine::decode(
                     &base64::engine::general_purpose::STANDARD,
                     &spec.base64,
@@ -520,10 +520,10 @@ impl<'a> MachineInitializer<'a> {
             let (device_interface, backend_name, pci_path) = match &disk
                 .device_spec
             {
-                instance_spec::v0::StorageDeviceV0::VirtioDisk(disk) => {
+                spec::StorageDevice::Virtio(disk) => {
                     (DeviceInterface::Virtio, &disk.backend_name, disk.pci_path)
                 }
-                instance_spec::v0::StorageDeviceV0::NvmeDisk(disk) => {
+                spec::StorageDevice::Nvme(disk) => {
                     (DeviceInterface::Nvme, &disk.backend_name, disk.pci_path)
                 }
             };
@@ -642,18 +642,16 @@ impl<'a> MachineInitializer<'a> {
 
         for (device_name, nic) in &self.spec.nics {
             info!(self.log, "Creating vNIC {}", device_name);
-            let instance_spec::v0::NetworkDeviceV0::VirtioNic(vnic_spec) =
-                &nic.device_spec;
-
-            let bdf: pci::Bdf = vnic_spec.pci_path.try_into().map_err(|e| {
-                Error::new(
-                    ErrorKind::InvalidInput,
-                    format!(
-                        "Couldn't get PCI BDF for vNIC {}: {}",
-                        device_name, e
-                    ),
-                )
-            })?;
+            let bdf: pci::Bdf =
+                nic.device_spec.pci_path.try_into().map_err(|e| {
+                    Error::new(
+                        ErrorKind::InvalidInput,
+                        format!(
+                            "Couldn't get PCI BDF for vNIC {}: {}",
+                            device_name, e
+                        ),
+                    )
+                })?;
 
             let viona = virtio::PciVirtioViona::new(
                 &nic.backend_spec.vnic_name,
@@ -665,7 +663,7 @@ impl<'a> MachineInitializer<'a> {
 
             // Only push to interface_ids if kstat_sampler exists
             if let Some(ref mut ids) = interface_ids {
-                ids.push((vnic_spec.interface_id, viona.instance_id()?));
+                ids.push((nic.device_spec.interface_id, viona.instance_id()?));
             }
 
             chipset.pci_attach(bdf, viona);

--- a/bin/propolis-server/src/lib/migrate/destination.rs
+++ b/bin/propolis-server/src/lib/migrate/destination.rs
@@ -346,8 +346,8 @@ impl<T: MigrateConn> RonV0<T> {
         }?;
         info!(self.log(), "Destination read Preamble: {:?}", preamble);
 
-        if let Err(e) =
-            preamble.is_migration_compatible(ensure_ctx.instance_spec())
+        if let Err(e) = preamble
+            .is_migration_compatible(&ensure_ctx.instance_spec().clone().into())
         {
             error!(
                 self.log(),

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -468,7 +468,7 @@ impl<'vm, T: MigrateConn> RonV0Runner<'vm, T> {
     async fn sync(&mut self) -> Result<(), MigrateError> {
         self.update_state(MigrationState::Sync);
         let preamble = Preamble::new(VersionedInstanceSpec::V0(
-            self.vm.lock_shared().await.instance_spec().clone(),
+            self.vm.lock_shared().await.instance_spec().clone().into(),
         ));
         let s = ron::ser::to_string(&preamble)
             .map_err(codec::ProtocolError::from)?;

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -143,9 +143,10 @@ fn instance_spec_from_request(
     #[cfg(feature = "falcon")]
     spec_builder.set_softnpu_com4()?;
 
-    spec_builder.add_pvpanic_device(spec::QemuPvpanic(QemuPvpanic {
-        enable_isa: true,
-    }))?;
+    spec_builder.add_pvpanic_device(spec::QemuPvpanic {
+        name: "pvpanic".to_string(),
+        spec: QemuPvpanic { enable_isa: true },
+    })?;
 
     Ok(spec_builder.finish())
 }

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -20,7 +20,7 @@ use crate::{
     serial::history_buffer::SerialHistoryOffset,
     spec::{
         self,
-        api_spec_v0::ApiSpecParseError,
+        api_spec_v0::ApiSpecError,
         builder::{SpecBuilder, SpecBuilderError},
         Spec,
     },
@@ -325,7 +325,7 @@ async fn instance_spec_ensure(
 ) -> Result<HttpResponseCreated<api::InstanceEnsureResponse>, HttpError> {
     let request = request.into_inner();
     let VersionedInstanceSpec::V0(v0_spec) = request.instance_spec;
-    let spec = Spec::try_from(v0_spec).map_err(|e: ApiSpecParseError| {
+    let spec = Spec::try_from(v0_spec).map_err(|e: ApiSpecError| {
         HttpError::for_bad_request(None, e.to_string())
     })?;
 

--- a/bin/propolis-server/src/lib/spec/api_request.rs
+++ b/bin/propolis-server/src/lib/spec/api_request.rs
@@ -15,10 +15,7 @@ use propolis_api_types::{
             },
             devices::{NvmeDisk, VirtioDisk, VirtioNic},
         },
-        v0::{
-            NetworkBackendV0, NetworkDeviceV0, StorageBackendV0,
-            StorageDeviceV0,
-        },
+        v0::{NetworkDeviceV0, StorageBackendV0, StorageDeviceV0},
         PciPath,
     },
     DiskRequest, NetworkInterfaceRequest, Slot,
@@ -132,10 +129,7 @@ pub(super) fn parse_nic_from_request(
         pci_path,
     });
 
-    let backend_spec = NetworkBackendV0::Virtio(VirtioNetworkBackend {
-        vnic_name: nic.name.to_string(),
-    });
-
+    let backend_spec = VirtioNetworkBackend { vnic_name: nic.name.to_string() };
     Ok(Nic { device_name, device_spec, backend_name, backend_spec })
 }
 

--- a/bin/propolis-server/src/lib/spec/api_spec_v0.rs
+++ b/bin/propolis-server/src/lib/spec/api_spec_v0.rs
@@ -1,0 +1,256 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Conversions from version-0 instance specs in the [`propolis_api_types`]
+//! crate to the internal [`super::Spec`] representation.
+
+use propolis_api_types::instance_spec::{
+    components::devices::{SerialPort as SerialPortSpec, SerialPortNumber},
+    v0::{InstanceSpecV0, NetworkDeviceV0, StorageDeviceV0},
+};
+use thiserror::Error;
+
+#[cfg(feature = "falcon")]
+use propolis_api_types::instance_spec::{
+    components::devices::SoftNpuPort as SoftNpuPortSpec, v0::NetworkBackendV0,
+};
+
+#[cfg(feature = "falcon")]
+use crate::spec::SoftNpuPort;
+
+use super::{
+    builder::{SpecBuilder, SpecBuilderError},
+    Disk, Nic, PciPciBridge, QemuPvpanic, SerialPort, Spec,
+};
+
+#[derive(Debug, Error)]
+pub(crate) enum ApiSpecParseError {
+    #[error(transparent)]
+    BuilderError(#[from] SpecBuilderError),
+
+    #[error("backend {0} not found for device {1}")]
+    BackendNotFound(String, String),
+
+    #[error("backend {0} not used by any device")]
+    BackendNotUsed(String),
+
+    #[cfg(feature = "falcon")]
+    #[error("network backend for device {0} is not a DLPI backend")]
+    NotDlpiBackend(String),
+}
+
+impl From<Spec> for InstanceSpecV0 {
+    fn from(val: Spec) -> Self {
+        let mut spec = InstanceSpecV0::default();
+
+        spec.devices.board = val.board;
+        for disk in val.disks {
+            let _old = spec
+                .devices
+                .storage_devices
+                .insert(disk.device_name, disk.device_spec);
+
+            assert!(_old.is_none());
+
+            let _old = spec
+                .backends
+                .storage_backends
+                .insert(disk.backend_name, disk.backend_spec);
+
+            assert!(_old.is_none());
+        }
+
+        for nic in val.nics {
+            let _old = spec
+                .devices
+                .network_devices
+                .insert(nic.device_name, nic.device_spec);
+
+            assert!(_old.is_none());
+
+            let _old = spec
+                .backends
+                .network_backends
+                .insert(nic.backend_name, nic.backend_spec);
+
+            assert!(_old.is_none());
+        }
+
+        for (index, serial) in val.serial.iter().enumerate() {
+            if *serial == SerialPort::Enabled {
+                let _old = spec.devices.serial_ports.insert(
+                    format!("com{}", index + 1),
+                    SerialPortSpec {
+                        num: match index {
+                            0 => SerialPortNumber::Com1,
+                            1 => SerialPortNumber::Com2,
+                            2 => SerialPortNumber::Com3,
+                            3 => SerialPortNumber::Com4,
+                            _ => unreachable!(),
+                        },
+                    },
+                );
+
+                assert!(_old.is_none());
+            }
+        }
+
+        for bridge in val.pci_pci_bridges {
+            let _old =
+                spec.devices.pci_pci_bridges.insert(bridge.name(), bridge.0);
+
+            assert!(_old.is_none());
+        }
+
+        spec.devices.qemu_pvpanic = val.pvpanic.map(|pvpanic| pvpanic.0);
+
+        #[cfg(feature = "falcon")]
+        {
+            spec.devices.softnpu_pci_port = val.softnpu.pci_port;
+            spec.devices.softnpu_p9 = val.softnpu.p9_device;
+            spec.devices.p9fs = val.softnpu.p9fs;
+            for port in val.softnpu.ports {
+                let _old = spec.devices.softnpu_ports.insert(
+                    port.name.clone(),
+                    SoftNpuPortSpec {
+                        name: port.name,
+                        backend_name: port.backend_name.clone(),
+                    },
+                );
+
+                assert!(_old.is_none());
+
+                let _old = spec.backends.network_backends.insert(
+                    port.backend_name,
+                    NetworkBackendV0::Dlpi(port.backend_spec),
+                );
+
+                assert!(_old.is_none());
+            }
+        }
+
+        spec
+    }
+}
+
+impl TryFrom<InstanceSpecV0> for Spec {
+    type Error = ApiSpecParseError;
+
+    fn try_from(mut value: InstanceSpecV0) -> Result<Self, Self::Error> {
+        let mut builder = SpecBuilder::with_board(value.devices.board);
+        for (device_name, device_spec) in value.devices.storage_devices {
+            let backend_name = match &device_spec {
+                StorageDeviceV0::VirtioDisk(disk) => &disk.backend_name,
+                StorageDeviceV0::NvmeDisk(disk) => &disk.backend_name,
+            };
+
+            let (backend_name, backend_spec) = value
+                .backends
+                .storage_backends
+                .remove_entry(backend_name)
+                .ok_or_else(|| {
+                    ApiSpecParseError::BackendNotFound(
+                        backend_name.to_owned(),
+                        device_name.clone(),
+                    )
+                })?;
+
+            builder.add_storage_device(Disk {
+                device_name,
+                device_spec,
+                backend_name,
+                backend_spec,
+            })?;
+        }
+
+        if let Some(backend) = value.backends.storage_backends.keys().next() {
+            return Err(ApiSpecParseError::BackendNotUsed(backend.to_owned()));
+        }
+
+        for (device_name, device_spec) in value.devices.network_devices {
+            let backend_name = match &device_spec {
+                NetworkDeviceV0::VirtioNic(nic) => &nic.backend_name,
+            };
+
+            let (backend_name, backend_spec) = value
+                .backends
+                .network_backends
+                .remove_entry(backend_name)
+                .ok_or_else(|| {
+                    ApiSpecParseError::BackendNotFound(
+                        backend_name.to_owned(),
+                        device_name.clone(),
+                    )
+                })?;
+
+            builder.add_network_device(Nic {
+                device_name,
+                device_spec,
+                backend_name,
+                backend_spec,
+            })?;
+        }
+
+        // SoftNPU ports can have network backends, so consume the SoftNPU
+        // device fields before checking to see if the network backend list is
+        // empty.
+        #[cfg(feature = "falcon")]
+        {
+            if let Some(softnpu_pci) = value.devices.softnpu_pci_port {
+                builder.set_softnpu_pci_port(softnpu_pci)?;
+            }
+
+            if let Some(softnpu_p9) = value.devices.softnpu_p9 {
+                builder.set_softnpu_p9(softnpu_p9)?;
+            }
+
+            if let Some(p9fs) = value.devices.p9fs {
+                builder.set_p9fs(p9fs)?;
+            }
+
+            for (port_name, port) in value.devices.softnpu_ports {
+                let (backend_name, backend_spec) = value
+                    .backends
+                    .network_backends
+                    .remove_entry(&port.backend_name)
+                    .ok_or_else(|| {
+                        ApiSpecParseError::BackendNotFound(
+                            port.backend_name,
+                            port_name.clone(),
+                        )
+                    })?;
+
+                let NetworkBackendV0::Dlpi(backend_spec) = backend_spec else {
+                    return Err(ApiSpecParseError::NotDlpiBackend(port_name));
+                };
+
+                builder.add_softnpu_port(SoftNpuPort {
+                    name: port_name,
+                    backend_name,
+                    backend_spec,
+                })?;
+            }
+        }
+
+        if let Some(backend) = value.backends.network_backends.keys().next() {
+            return Err(ApiSpecParseError::BackendNotUsed(backend.to_owned()));
+        }
+
+        // TODO(gjc) do more to preserve names
+        for serial_port in value.devices.serial_ports.values() {
+            builder.add_serial_port(serial_port.num)?;
+        }
+
+        // TODO(gjc) do more to preserve names
+        for bridge in value.devices.pci_pci_bridges.into_values() {
+            builder.add_pci_bridge(PciPciBridge(bridge))?;
+        }
+
+        if let Some(pvpanic) = value.devices.qemu_pvpanic {
+            builder.add_pvpanic_device(QemuPvpanic(pvpanic))?;
+        }
+
+        Ok(builder.finish())
+    }
+}

--- a/bin/propolis-server/src/lib/spec/api_spec_v0.rs
+++ b/bin/propolis-server/src/lib/spec/api_spec_v0.rs
@@ -51,6 +51,7 @@ impl From<Spec> for InstanceSpecV0 {
         // This assertion is valid because internal instance specs should assign
         // a unique name to each component they describe. The spec builder
         // upholds this invariant at spec creation time.
+        #[track_caller]
         fn insert_component<T>(
             map: &mut HashMap<String, T>,
             key: String,

--- a/bin/propolis-server/src/lib/spec/builder.rs
+++ b/bin/propolis-server/src/lib/spec/builder.rs
@@ -10,11 +10,9 @@ use propolis_api_types::{
     instance_spec::{
         components::{
             board::{Board, Chipset, I440Fx},
-            devices::{
-                PciPciBridge, QemuPvpanic, SerialPort, SerialPortNumber,
-            },
+            devices::SerialPortNumber,
         },
-        v0::{DeviceSpecV0, InstanceSpecV0, NetworkDeviceV0, StorageDeviceV0},
+        v0::{NetworkDeviceV0, StorageDeviceV0},
         PciPath,
     },
     DiskRequest, InstanceProperties, NetworkInterfaceRequest,
@@ -22,12 +20,8 @@ use propolis_api_types::{
 use thiserror::Error;
 
 #[cfg(feature = "falcon")]
-use propolis_api_types::instance_spec::{
-    components::{
-        backends::DlpiNetworkBackend,
-        devices::{P9fs, SoftNpuP9, SoftNpuPciPort, SoftNpuPort},
-    },
-    v0::NetworkBackendV0,
+use propolis_api_types::instance_spec::components::devices::{
+    P9fs, SoftNpuP9, SoftNpuPciPort,
 };
 
 use crate::config;
@@ -35,14 +29,13 @@ use crate::config;
 use super::{
     api_request::{self, DeviceRequestError},
     config_toml::{ConfigTomlError, ParsedConfig},
-    ParsedNetworkDevice, ParsedStorageDevice,
+    Disk, Nic, PciPciBridge, QemuPvpanic,
 };
 
 #[cfg(feature = "falcon")]
-use super::ParsedSoftNpu;
+use super::{SoftNpu, SoftNpuPort};
 
 /// Errors that can arise while building an instance spec from component parts.
-#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Error)]
 pub(crate) enum SpecBuilderError {
     #[error("error parsing config TOML")]
@@ -51,11 +44,8 @@ pub(crate) enum SpecBuilderError {
     #[error("error parsing device in ensure request")]
     DeviceRequest(#[from] DeviceRequestError),
 
-    #[error("A device with name {0} already exists")]
-    DeviceNameInUse(String),
-
-    #[error("A backend with name {0} already exists")]
-    BackendNameInUse(String),
+    #[error("A component with name {0} already exists")]
+    ComponentNameInUse(String),
 
     #[error("A PCI device is already attached at {0:?}")]
     PciPathInUse(PciPath),
@@ -63,14 +53,15 @@ pub(crate) enum SpecBuilderError {
     #[error("Serial port {0:?} is already specified")]
     SerialPortInUse(SerialPortNumber),
 
-    #[cfg(feature = "falcon")]
-    #[error("SoftNpu port {0:?} is already specified")]
-    SoftNpuPortInUse(String),
+    #[error("pvpanic device already specified")]
+    PvpanicInUse,
 }
 
+#[derive(Debug, Default)]
 pub(crate) struct SpecBuilder {
-    spec: InstanceSpecV0,
+    spec: super::Spec,
     pci_paths: BTreeSet<PciPath>,
+    component_names: BTreeSet<String>,
 }
 
 trait PciComponent {
@@ -103,11 +94,15 @@ impl SpecBuilder {
         };
 
         Self {
-            spec: InstanceSpecV0 {
-                devices: DeviceSpecV0 { board, ..Default::default() },
-                backends: Default::default(),
-            },
-            pci_paths: Default::default(),
+            spec: super::Spec { board, ..Default::default() },
+            ..Default::default()
+        }
+    }
+
+    pub(super) fn with_board(board: Board) -> Self {
+        Self {
+            spec: super::Spec { board, ..Default::default() },
+            ..Default::default()
         }
     }
 
@@ -152,7 +147,7 @@ impl SpecBuilder {
     ) -> Result<(), SpecBuilderError> {
         let parsed = ParsedConfig::try_from(config)?;
 
-        let Chipset::I440Fx(ref mut i440fx) = self.spec.devices.board.chipset;
+        let Chipset::I440Fx(ref mut i440fx) = self.spec.board.chipset;
         i440fx.enable_pcie = parsed.enable_pcie;
 
         for disk in parsed.disks {
@@ -164,7 +159,7 @@ impl SpecBuilder {
         }
 
         for bridge in parsed.pci_bridges {
-            self.add_pci_bridge(bridge.name, bridge.bridge)?;
+            self.add_pci_bridge(bridge)?;
         }
 
         #[cfg(feature = "falcon")]
@@ -176,21 +171,21 @@ impl SpecBuilder {
     #[cfg(feature = "falcon")]
     fn add_parsed_softnpu_devices(
         &mut self,
-        devices: ParsedSoftNpu,
+        devices: SoftNpu,
     ) -> Result<(), SpecBuilderError> {
-        for pci_port in devices.pci_ports {
+        if let Some(pci_port) = devices.pci_port {
             self.set_softnpu_pci_port(pci_port)?;
         }
 
         for port in devices.ports {
-            self.add_softnpu_port(port.name.clone(), port)?;
+            self.add_softnpu_port(port)?;
         }
 
-        for p9 in devices.p9_devices {
+        if let Some(p9) = devices.p9_device {
             self.set_softnpu_p9(p9)?;
         }
 
-        for p9fs in devices.p9fs {
+        if let Some(p9fs) = devices.p9fs {
             self.set_p9fs(p9fs)?;
         }
 
@@ -214,83 +209,57 @@ impl SpecBuilder {
     /// Adds a storage device with an associated backend.
     pub(super) fn add_storage_device(
         &mut self,
-        ParsedStorageDevice {
-            device_name,
-            device_spec,
-            backend_name,
-            backend_spec,
-        }: ParsedStorageDevice,
+        disk: Disk,
     ) -> Result<&Self, SpecBuilderError> {
-        if self.spec.devices.storage_devices.contains_key(&device_name) {
-            return Err(SpecBuilderError::DeviceNameInUse(device_name));
+        if self.component_names.contains(&disk.device_name) {
+            return Err(SpecBuilderError::ComponentNameInUse(disk.device_name));
         }
 
-        if self.spec.backends.storage_backends.contains_key(&backend_name) {
-            return Err(SpecBuilderError::BackendNameInUse(backend_name));
+        if self.component_names.contains(&disk.backend_name) {
+            return Err(SpecBuilderError::ComponentNameInUse(
+                disk.backend_name,
+            ));
         }
-        self.register_pci_device(device_spec.pci_path())?;
-        let _old =
-            self.spec.devices.storage_devices.insert(device_name, device_spec);
 
-        assert!(_old.is_none());
-        let _old = self
-            .spec
-            .backends
-            .storage_backends
-            .insert(backend_name, backend_spec);
-
-        assert!(_old.is_none());
+        self.register_pci_device(disk.device_spec.pci_path())?;
+        self.component_names.insert(disk.device_name.clone());
+        self.component_names.insert(disk.backend_name.clone());
+        self.spec.disks.push(disk);
         Ok(self)
     }
 
     /// Adds a network device with an associated backend.
     pub(super) fn add_network_device(
         &mut self,
-        ParsedNetworkDevice {
-            device_name,
-            device_spec,
-            backend_name,
-            backend_spec,
-        }: ParsedNetworkDevice,
+        nic: Nic,
     ) -> Result<&Self, SpecBuilderError> {
-        if self.spec.devices.network_devices.contains_key(&device_name) {
-            return Err(SpecBuilderError::DeviceNameInUse(device_name));
+        if self.component_names.contains(&nic.device_name) {
+            return Err(SpecBuilderError::ComponentNameInUse(nic.device_name));
         }
 
-        if self.spec.backends.network_backends.contains_key(&backend_name) {
-            return Err(SpecBuilderError::BackendNameInUse(backend_name));
+        if self.component_names.contains(&nic.backend_name) {
+            return Err(SpecBuilderError::ComponentNameInUse(nic.backend_name));
         }
 
-        self.register_pci_device(device_spec.pci_path())?;
-        let _old =
-            self.spec.devices.network_devices.insert(device_name, device_spec);
-
-        assert!(_old.is_none());
-        let _old = self
-            .spec
-            .backends
-            .network_backends
-            .insert(backend_name, backend_spec);
-
-        assert!(_old.is_none());
+        self.register_pci_device(nic.device_spec.pci_path())?;
+        self.component_names.insert(nic.device_name.clone());
+        self.component_names.insert(nic.backend_name.clone());
+        self.spec.nics.push(nic);
         Ok(self)
     }
 
     /// Adds a PCI-PCI bridge.
     pub fn add_pci_bridge(
         &mut self,
-        bridge_name: String,
-        bridge_spec: PciPciBridge,
+        bridge: PciPciBridge,
     ) -> Result<&Self, SpecBuilderError> {
-        if self.spec.devices.pci_pci_bridges.contains_key(&bridge_name) {
-            return Err(SpecBuilderError::DeviceNameInUse(bridge_name));
+        let name = bridge.name();
+        if self.component_names.contains(&name) {
+            return Err(SpecBuilderError::ComponentNameInUse(name));
         }
 
-        self.register_pci_device(bridge_spec.pci_path)?;
-        let _old =
-            self.spec.devices.pci_pci_bridges.insert(bridge_name, bridge_spec);
-
-        assert!(_old.is_none());
+        self.register_pci_device(bridge.0.pci_path)?;
+        self.spec.pci_pci_bridges.push(bridge);
         Ok(self)
     }
 
@@ -299,24 +268,17 @@ impl SpecBuilder {
         &mut self,
         port: SerialPortNumber,
     ) -> Result<&Self, SpecBuilderError> {
-        if self
-            .spec
-            .devices
-            .serial_ports
-            .insert(
-                match port {
-                    SerialPortNumber::Com1 => "com1",
-                    SerialPortNumber::Com2 => "com2",
-                    SerialPortNumber::Com3 => "com3",
-                    SerialPortNumber::Com4 => "com4",
-                }
-                .to_string(),
-                SerialPort { num: port },
-            )
-            .is_some()
-        {
+        let idx = match port {
+            SerialPortNumber::Com1 => 0,
+            SerialPortNumber::Com2 => 1,
+            SerialPortNumber::Com3 => 2,
+            SerialPortNumber::Com4 => 3,
+        };
+
+        if self.spec.serial[idx] != super::SerialPort::Disabled {
             Err(SpecBuilderError::SerialPortInUse(port))
         } else {
+            self.spec.serial[idx] = super::SerialPort::Enabled;
             Ok(self)
         }
     }
@@ -325,15 +287,22 @@ impl SpecBuilder {
         &mut self,
         pvpanic: QemuPvpanic,
     ) -> Result<&Self, SpecBuilderError> {
-        if self.spec.devices.qemu_pvpanic.is_some() {
-            return Err(SpecBuilderError::DeviceNameInUse(
-                "pvpanic".to_string(),
-            ));
+        if self.spec.pvpanic.is_some() {
+            return Err(SpecBuilderError::PvpanicInUse);
         }
 
-        self.spec.devices.qemu_pvpanic = Some(pvpanic);
-
+        self.spec.pvpanic = Some(pvpanic);
         Ok(self)
+    }
+
+    #[cfg(feature = "falcon")]
+    pub fn set_softnpu_com4(&mut self) -> Result<&Self, SpecBuilderError> {
+        if self.spec.serial[3] != super::SerialPort::Disabled {
+            Err(SpecBuilderError::SerialPortInUse(SerialPortNumber::Com4))
+        } else {
+            self.spec.serial[3] = super::SerialPort::SoftNpu;
+            Ok(self)
+        }
     }
 
     #[cfg(feature = "falcon")]
@@ -342,7 +311,7 @@ impl SpecBuilder {
         pci_port: SoftNpuPciPort,
     ) -> Result<&Self, SpecBuilderError> {
         self.register_pci_device(pci_port.pci_path)?;
-        self.spec.devices.softnpu_pci_port = Some(pci_port);
+        self.spec.softnpu.pci_port = Some(pci_port);
         Ok(self)
     }
 
@@ -352,39 +321,38 @@ impl SpecBuilder {
         p9: SoftNpuP9,
     ) -> Result<&Self, SpecBuilderError> {
         self.register_pci_device(p9.pci_path)?;
-        self.spec.devices.softnpu_p9 = Some(p9);
+        self.spec.softnpu.p9_device = Some(p9);
         Ok(self)
     }
 
     #[cfg(feature = "falcon")]
     pub fn set_p9fs(&mut self, p9fs: P9fs) -> Result<&Self, SpecBuilderError> {
         self.register_pci_device(p9fs.pci_path)?;
-        self.spec.devices.p9fs = Some(p9fs);
+        self.spec.softnpu.p9fs = Some(p9fs);
         Ok(self)
     }
 
     #[cfg(feature = "falcon")]
     pub fn add_softnpu_port(
         &mut self,
-        key: String,
         port: SoftNpuPort,
     ) -> Result<&Self, SpecBuilderError> {
-        let _old = self.spec.backends.network_backends.insert(
-            port.backend_name.clone(),
-            NetworkBackendV0::Dlpi(DlpiNetworkBackend {
-                vnic_name: port.backend_name.clone(),
-            }),
-        );
-        assert!(_old.is_none());
-        if self.spec.devices.softnpu_ports.insert(key, port.clone()).is_some() {
-            Err(SpecBuilderError::SoftNpuPortInUse(port.name))
-        } else {
-            Ok(self)
+        if self.component_names.contains(&port.name) {
+            return Err(SpecBuilderError::ComponentNameInUse(port.name));
         }
+
+        if self.component_names.contains(&port.backend_name) {
+            return Err(SpecBuilderError::ComponentNameInUse(
+                port.backend_name,
+            ));
+        }
+
+        self.spec.softnpu.ports.push(port);
+        Ok(self)
     }
 
     /// Yields the completed spec, consuming the builder.
-    pub fn finish(self) -> InstanceSpecV0 {
+    pub fn finish(self) -> super::Spec {
         self.spec
     }
 }

--- a/bin/propolis-server/src/lib/spec/builder.rs
+++ b/bin/propolis-server/src/lib/spec/builder.rs
@@ -12,7 +12,6 @@ use propolis_api_types::{
             board::{Board, Chipset, I440Fx},
             devices::{PciPciBridge, SerialPortNumber},
         },
-        v0::{NetworkDeviceV0, StorageDeviceV0},
         PciPath,
     },
     DiskRequest, InstanceProperties, NetworkInterfaceRequest,
@@ -62,27 +61,6 @@ pub(crate) struct SpecBuilder {
     spec: super::Spec,
     pci_paths: BTreeSet<PciPath>,
     component_names: BTreeSet<String>,
-}
-
-trait PciComponent {
-    fn pci_path(&self) -> PciPath;
-}
-
-impl PciComponent for StorageDeviceV0 {
-    fn pci_path(&self) -> PciPath {
-        match self {
-            StorageDeviceV0::VirtioDisk(disk) => disk.pci_path,
-            StorageDeviceV0::NvmeDisk(disk) => disk.pci_path,
-        }
-    }
-}
-
-impl PciComponent for NetworkDeviceV0 {
-    fn pci_path(&self) -> PciPath {
-        match self {
-            NetworkDeviceV0::VirtioNic(nic) => nic.pci_path,
-        }
-    }
 }
 
 impl SpecBuilder {
@@ -244,7 +222,7 @@ impl SpecBuilder {
             return Err(SpecBuilderError::ComponentNameInUse(nic.backend_name));
         }
 
-        self.register_pci_device(nic.device_spec.pci_path())?;
+        self.register_pci_device(nic.device_spec.pci_path)?;
         self.component_names.insert(nic_name.clone());
         self.component_names.insert(nic.backend_name.clone());
         let _old = self.spec.nics.insert(nic_name, nic);

--- a/bin/propolis-server/src/lib/spec/builder.rs
+++ b/bin/propolis-server/src/lib/spec/builder.rs
@@ -23,7 +23,7 @@ use propolis_api_types::instance_spec::components::devices::{
     P9fs, SoftNpuP9, SoftNpuPciPort,
 };
 
-use crate::{config, spec::SerialPortUser};
+use crate::{config, spec::SerialPortDevice};
 
 use super::{
     api_request::{self, DeviceRequestError},
@@ -251,7 +251,7 @@ impl SpecBuilder {
         &mut self,
         port: SerialPortNumber,
     ) -> Result<&Self, SpecBuilderError> {
-        if self.spec.serial.insert(port, SerialPortUser::Standard).is_some() {
+        if self.spec.serial.insert(port, SerialPortDevice::Uart).is_some() {
             Err(SpecBuilderError::SerialPortInUse(port))
         } else {
             Ok(self)
@@ -273,7 +273,7 @@ impl SpecBuilder {
     #[cfg(feature = "falcon")]
     pub fn set_softnpu_com4(&mut self) -> Result<&Self, SpecBuilderError> {
         let port = SerialPortNumber::Com4;
-        if self.spec.serial.insert(port, SerialPortUser::SoftNpu).is_some() {
+        if self.spec.serial.insert(port, SerialPortDevice::SoftNpu).is_some() {
             Err(SpecBuilderError::SerialPortInUse(port))
         } else {
             Ok(self)

--- a/bin/propolis-server/src/lib/spec/config_toml.rs
+++ b/bin/propolis-server/src/lib/spec/config_toml.rs
@@ -13,9 +13,7 @@ use propolis_api_types::instance_spec::{
             NvmeDisk, PciPciBridge as BridgeSpec, VirtioDisk, VirtioNic,
         },
     },
-    v0::{
-        NetworkBackendV0, NetworkDeviceV0, StorageBackendV0, StorageDeviceV0,
-    },
+    v0::{NetworkDeviceV0, StorageBackendV0, StorageDeviceV0},
     PciPath,
 };
 use thiserror::Error;
@@ -296,9 +294,7 @@ pub(super) fn parse_network_device_from_config(
         .ok_or_else(|| ConfigTomlError::InvalidPciPath(name.to_owned()))?;
 
     let (device_name, backend_name) = super::pci_path_to_nic_names(pci_path);
-    let backend_spec = NetworkBackendV0::Virtio(VirtioNetworkBackend {
-        vnic_name: vnic_name.to_owned(),
-    });
+    let backend_spec = VirtioNetworkBackend { vnic_name: vnic_name.to_owned() };
 
     let device_spec = NetworkDeviceV0::VirtioNic(VirtioNic {
         backend_name: backend_name.clone(),

--- a/bin/propolis-server/src/lib/spec/config_toml.rs
+++ b/bin/propolis-server/src/lib/spec/config_toml.rs
@@ -9,7 +9,9 @@ use std::str::{FromStr, ParseBoolError};
 use propolis_api_types::instance_spec::{
     components::{
         backends::{FileStorageBackend, VirtioNetworkBackend},
-        devices::{NvmeDisk, PciPciBridge, VirtioDisk, VirtioNic},
+        devices::{
+            NvmeDisk, PciPciBridge as BridgeSpec, VirtioDisk, VirtioNic,
+        },
     },
     v0::{
         NetworkBackendV0, NetworkDeviceV0, StorageBackendV0, StorageDeviceV0,
@@ -20,15 +22,18 @@ use thiserror::Error;
 
 #[cfg(feature = "falcon")]
 use propolis_api_types::instance_spec::components::devices::{
-    P9fs, SoftNpuP9, SoftNpuPciPort, SoftNpuPort,
+    P9fs, SoftNpuP9, SoftNpuPciPort,
 };
+
+#[cfg(feature = "falcon")]
+use super::SoftNpuPort;
 
 use crate::config;
 
-use super::{ParsedNetworkDevice, ParsedStorageDevice};
+use super::{Disk, Nic, PciPciBridge};
 
 #[cfg(feature = "falcon")]
-use super::ParsedSoftNpu;
+use super::SoftNpu;
 
 #[derive(Debug, Error)]
 pub(crate) enum ConfigTomlError {
@@ -77,12 +82,12 @@ pub(crate) enum ConfigTomlError {
 #[derive(Default)]
 pub(super) struct ParsedConfig {
     pub(super) enable_pcie: bool,
-    pub(super) disks: Vec<ParsedStorageDevice>,
-    pub(super) nics: Vec<ParsedNetworkDevice>,
-    pub(super) pci_bridges: Vec<ParsedPciPciBridge>,
+    pub(super) disks: Vec<Disk>,
+    pub(super) nics: Vec<Nic>,
+    pub(super) pci_bridges: Vec<PciPciBridge>,
 
     #[cfg(feature = "falcon")]
-    pub(super) softnpu: ParsedSoftNpu,
+    pub(super) softnpu: SoftNpu,
 }
 
 impl TryFrom<&config::Config> for ParsedConfig {
@@ -135,7 +140,7 @@ impl TryFrom<&config::Config> for ParsedConfig {
                         backend_config,
                     )?;
 
-                    parsed.disks.push(ParsedStorageDevice {
+                    parsed.disks.push(Disk {
                         device_name: device_name.to_owned(),
                         device_spec,
                         backend_name,
@@ -150,12 +155,11 @@ impl TryFrom<&config::Config> for ParsedConfig {
                 }
                 #[cfg(feature = "falcon")]
                 "softnpu-pci-port" => {
-                    parsed.softnpu.pci_ports.push(
-                        parse_softnpu_pci_port_from_config(
+                    parsed.softnpu.pci_port =
+                        Some(parse_softnpu_pci_port_from_config(
                             device_name,
                             device,
-                        )?,
-                    );
+                        )?);
                 }
                 #[cfg(feature = "falcon")]
                 "softnpu-port" => {
@@ -166,16 +170,14 @@ impl TryFrom<&config::Config> for ParsedConfig {
                 }
                 #[cfg(feature = "falcon")]
                 "softnpu-p9" => {
-                    parsed.softnpu.p9_devices.push(
+                    parsed.softnpu.p9_device = Some(
                         parse_softnpu_p9_from_config(device_name, device)?,
                     );
                 }
                 #[cfg(feature = "falcon")]
                 "pci-virtio-9p" => {
-                    parsed
-                        .softnpu
-                        .p9fs
-                        .push(parse_p9fs_from_config(device_name, device)?);
+                    parsed.softnpu.p9fs =
+                        Some(parse_p9fs_from_config(device_name, device)?);
                 }
                 _ => {
                     return Err(ConfigTomlError::UnrecognizedDeviceType(
@@ -284,7 +286,7 @@ pub(super) fn parse_storage_device_from_config(
 pub(super) fn parse_network_device_from_config(
     name: &str,
     device: &config::Device,
-) -> Result<ParsedNetworkDevice, ConfigTomlError> {
+) -> Result<Nic, ConfigTomlError> {
     let vnic_name = device
         .get_string("vnic")
         .ok_or_else(|| ConfigTomlError::NoVnicName(name.to_owned()))?;
@@ -306,34 +308,20 @@ pub(super) fn parse_network_device_from_config(
         pci_path,
     });
 
-    Ok(ParsedNetworkDevice {
-        device_name,
-        device_spec,
-        backend_name,
-        backend_spec,
-    })
-}
-
-pub(super) struct ParsedPciPciBridge {
-    pub(super) name: String,
-    pub(super) bridge: PciPciBridge,
+    Ok(Nic { device_name, device_spec, backend_name, backend_spec })
 }
 
 pub(super) fn parse_pci_bridge_from_config(
     bridge: &config::PciBridge,
-) -> Result<ParsedPciPciBridge, ConfigTomlError> {
-    let name = format!("pci-bridge-{}", bridge.downstream_bus);
+) -> Result<PciPciBridge, ConfigTomlError> {
     let pci_path = PciPath::from_str(&bridge.pci_path).map_err(|e| {
         ConfigTomlError::PciPathParseFailed(bridge.pci_path.to_string(), e)
     })?;
 
-    Ok(ParsedPciPciBridge {
-        name,
-        bridge: PciPciBridge {
-            downstream_bus: bridge.downstream_bus,
-            pci_path,
-        },
-    })
+    Ok(PciPciBridge(BridgeSpec {
+        downstream_bus: bridge.downstream_bus,
+        pci_path,
+    }))
 }
 
 #[cfg(feature = "falcon")]
@@ -365,6 +353,8 @@ pub(super) fn parse_softnpu_port_from_config(
     name: &str,
     device: &config::Device,
 ) -> Result<SoftNpuPort, ConfigTomlError> {
+    use propolis_api_types::instance_spec::components::backends::DlpiNetworkBackend;
+
     let vnic_name = device
         .get_string("vnic")
         .ok_or_else(|| ConfigTomlError::NoVnicName(name.to_owned()))?;
@@ -372,6 +362,7 @@ pub(super) fn parse_softnpu_port_from_config(
     Ok(SoftNpuPort {
         name: name.to_owned(),
         backend_name: vnic_name.to_owned(),
+        backend_spec: DlpiNetworkBackend { vnic_name: vnic_name.to_owned() },
     })
 }
 

--- a/bin/propolis-server/src/lib/spec/mod.rs
+++ b/bin/propolis-server/src/lib/spec/mod.rs
@@ -15,6 +15,7 @@
 
 use propolis_api_types::instance_spec::{
     components::{
+        backends::VirtioNetworkBackend,
         board::Board,
         devices::{
             PciPciBridge as PciPciBridgeSpec, QemuPvpanic as QemuPvpanicSpec,
@@ -37,19 +38,19 @@ mod config_toml;
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct Spec {
-    board: Board,
-    disks: Vec<Disk>,
-    nics: Vec<Nic>,
+    pub board: Board,
+    pub disks: Vec<Disk>,
+    pub nics: Vec<Nic>,
 
     // TODO(#735): Preserve device names for identification purposes.
-    serial: [SerialPort; 4],
+    pub serial: [SerialPort; 4],
 
     // TODO(#735): Preserve device names for identification purposes.
-    pci_pci_bridges: Vec<PciPciBridge>,
-    pvpanic: Option<QemuPvpanic>,
+    pub pci_pci_bridges: Vec<PciPciBridge>,
+    pub pvpanic: Option<QemuPvpanic>,
 
     #[cfg(feature = "falcon")]
-    softnpu: SoftNpu,
+    pub softnpu: SoftNpu,
 }
 
 /// Describes a storage device/backend pair parsed from an input source like an
@@ -62,14 +63,12 @@ pub struct Disk {
     pub backend_spec: StorageBackendV0,
 }
 
-/// Describes a network device/backend pair parsed from an input source like an
-/// API request or a config TOML entry.
 #[derive(Clone, Debug)]
 pub struct Nic {
     pub device_name: String,
     pub device_spec: NetworkDeviceV0,
     pub backend_name: String,
-    pub backend_spec: NetworkBackendV0,
+    pub backend_spec: VirtioNetworkBackend,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/bin/propolis-server/src/lib/spec/mod.rs
+++ b/bin/propolis-server/src/lib/spec/mod.rs
@@ -58,7 +58,7 @@ pub(crate) struct Spec {
     pub disks: HashMap<String, Disk>,
     pub nics: HashMap<String, Nic>,
 
-    pub serial: HashMap<SerialPortNumber, SerialPortUser>,
+    pub serial: HashMap<SerialPortNumber, SerialPortDevice>,
 
     pub pci_pci_bridges: HashMap<String, PciPciBridge>,
     pub pvpanic: Option<QemuPvpanic>,
@@ -143,9 +143,10 @@ pub struct Nic {
     pub backend_spec: VirtioNetworkBackend,
 }
 
+/// A kind of device to install as the listener on a COM port.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum SerialPortUser {
-    Standard,
+pub enum SerialPortDevice {
+    Uart,
 
     #[cfg(feature = "falcon")]
     SoftNpu,

--- a/bin/propolis-server/src/lib/stats/mod.rs
+++ b/bin/propolis-server/src/lib/stats/mod.rs
@@ -18,7 +18,7 @@ use propolis_api_types::InstanceProperties;
 use slog::Logger;
 use uuid::Uuid;
 
-use crate::spec;
+use crate::spec::Spec;
 use crate::{server::MetricsEndpointConfig, vm::NetworkInterfaceIds};
 
 mod network_interface;
@@ -189,7 +189,7 @@ pub fn start_oximeter_server(
 pub(crate) fn create_kstat_sampler(
     log: &Logger,
     properties: &InstanceProperties,
-    spec: &spec::Spec,
+    spec: &Spec,
 ) -> Option<KstatSampler> {
     let kstat_limit = usize::try_from(
         (u32::from(properties.vcpus) * KSTAT_LIMIT_PER_VCPU)

--- a/bin/propolis-server/src/lib/stats/mod.rs
+++ b/bin/propolis-server/src/lib/stats/mod.rs
@@ -14,12 +14,11 @@ use oximeter::{
 };
 use oximeter_instruments::kstat::KstatSampler;
 use oximeter_producer::{Config, Error, Server};
-use propolis_api_types::{
-    instance_spec::v0::InstanceSpecV0, InstanceProperties,
-};
+use propolis_api_types::InstanceProperties;
 use slog::Logger;
 use uuid::Uuid;
 
+use crate::spec;
 use crate::{server::MetricsEndpointConfig, vm::NetworkInterfaceIds};
 
 mod network_interface;
@@ -190,11 +189,11 @@ pub fn start_oximeter_server(
 pub(crate) fn create_kstat_sampler(
     log: &Logger,
     properties: &InstanceProperties,
-    spec: &InstanceSpecV0,
+    spec: &spec::Spec,
 ) -> Option<KstatSampler> {
     let kstat_limit = usize::try_from(
         (u32::from(properties.vcpus) * KSTAT_LIMIT_PER_VCPU)
-            + (spec.devices.network_devices.len() as u32 * SAMPLE_BUFFER),
+            + (spec.nics.len() as u32 * SAMPLE_BUFFER),
     )
     .unwrap();
 

--- a/bin/propolis-server/src/lib/vm/ensure.rs
+++ b/bin/propolis-server/src/lib/vm/ensure.rs
@@ -39,7 +39,7 @@ use crate::{
     initializer::{
         build_instance, MachineInitializer, MachineInitializerState,
     },
-    spec,
+    spec::Spec,
     stats::create_kstat_sampler,
     vm::request_queue::InstanceAutoStart,
 };
@@ -55,7 +55,7 @@ use super::{
 pub(crate) struct VmEnsureRequest {
     pub(crate) properties: InstanceProperties,
     pub(crate) migrate: Option<InstanceMigrateInitiateRequest>,
-    pub(crate) instance_spec: spec::Spec,
+    pub(crate) instance_spec: Spec,
 }
 
 /// Holds state about an instance ensure request that has not yet produced any
@@ -88,7 +88,7 @@ impl<'a> VmEnsureNotStarted<'a> {
         }
     }
 
-    pub(crate) fn instance_spec(&self) -> &spec::Spec {
+    pub(crate) fn instance_spec(&self) -> &Spec {
         &self.ensure_request.instance_spec
     }
 
@@ -379,7 +379,7 @@ impl<'a> VmEnsureActive<'a> {
 fn initialize_kstat_sampler(
     log: &slog::Logger,
     properties: &InstanceProperties,
-    spec: &spec::Spec,
+    spec: &Spec,
     producer_registry: Option<ProducerRegistry>,
 ) -> Option<KstatSampler> {
     let registry = producer_registry?;

--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -95,7 +95,7 @@ use state_driver::StateDriverOutput;
 use state_publisher::StatePublisher;
 use tokio::sync::{oneshot, watch, RwLock, RwLockReadGuard};
 
-use crate::{server::MetricsEndpointConfig, spec, vnc::VncServer};
+use crate::{server::MetricsEndpointConfig, spec::Spec, vnc::VncServer};
 
 mod active;
 pub(crate) mod ensure;
@@ -219,7 +219,7 @@ struct VmDescription {
     properties: InstanceProperties,
 
     /// The VM's last-known instance specification.
-    spec: spec::Spec,
+    spec: Spec,
 
     /// The runtime on which the VM's state driver is running (or on which it
     /// ran).

--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -82,13 +82,13 @@
 use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
 
 use active::ActiveVm;
+use ensure::VmEnsureRequest;
 use oximeter::types::ProducerRegistry;
 use propolis_api_types::{
     instance_spec::{v0::InstanceSpecV0, VersionedInstanceSpec},
     InstanceEnsureResponse, InstanceMigrateStatusResponse,
-    InstanceMigrationStatus, InstanceProperties, InstanceSpecEnsureRequest,
-    InstanceSpecGetResponse, InstanceState, InstanceStateMonitorResponse,
-    MigrationState,
+    InstanceMigrationStatus, InstanceProperties, InstanceSpecGetResponse,
+    InstanceState, InstanceStateMonitorResponse, MigrationState,
 };
 use slog::info;
 use state_driver::StateDriverOutput;
@@ -503,7 +503,7 @@ impl Vm {
     pub(crate) async fn ensure(
         self: &Arc<Self>,
         log: &slog::Logger,
-        ensure_request: InstanceSpecEnsureRequest,
+        ensure_request: VmEnsureRequest,
         options: EnsureOptions,
     ) -> Result<InstanceEnsureResponse, VmError> {
         let log_for_driver =
@@ -554,8 +554,8 @@ impl Vm {
                 _ => {}
             };
 
-            let VersionedInstanceSpec::V0(v0_spec) =
-                ensure_request.instance_spec.clone();
+            let v0_spec: InstanceSpecV0 =
+                ensure_request.instance_spec.clone().into();
 
             let thread_count = usize::max(
                 VMM_MIN_RT_THREADS,

--- a/bin/propolis-server/src/lib/vm/objects.rs
+++ b/bin/propolis-server/src/lib/vm/objects.rs
@@ -20,7 +20,7 @@ use propolis::{
 use slog::{error, info};
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-use crate::{serial::Serial, spec, vcpu_tasks::VcpuTaskController};
+use crate::{serial::Serial, spec::Spec, vcpu_tasks::VcpuTaskController};
 
 use super::{
     state_driver::VmStartReason, BlockBackendMap, CrucibleBackendMap, DeviceMap,
@@ -43,7 +43,7 @@ pub(crate) struct VmObjects {
 /// A collection of objects that should eventually be wrapped in a lock and
 /// stored in a `VmObjects` structure. See [`VmObjectsLocked`].
 pub(super) struct InputVmObjects {
-    pub instance_spec: spec::Spec,
+    pub instance_spec: Spec,
     pub vcpu_tasks: Box<dyn VcpuTaskController>,
     pub machine: Machine,
     pub devices: DeviceMap,
@@ -60,7 +60,7 @@ pub(crate) struct VmObjectsLocked {
     log: slog::Logger,
 
     /// The instance spec that describes this collection of objects.
-    instance_spec: spec::Spec,
+    instance_spec: Spec,
 
     /// The set of tasks that run this VM's vCPUs.
     vcpu_tasks: Box<dyn VcpuTaskController>,
@@ -131,12 +131,12 @@ impl VmObjectsLocked {
     }
 
     /// Yields the VM's current instance spec.
-    pub(crate) fn instance_spec(&self) -> &spec::Spec {
+    pub(crate) fn instance_spec(&self) -> &Spec {
         &self.instance_spec
     }
 
     /// Yields a mutable reference to the VM's current instance spec.
-    pub(crate) fn instance_spec_mut(&mut self) -> &mut spec::Spec {
+    pub(crate) fn instance_spec_mut(&mut self) -> &mut Spec {
         &mut self.instance_spec
     }
 

--- a/bin/propolis-server/src/lib/vm/objects.rs
+++ b/bin/propolis-server/src/lib/vm/objects.rs
@@ -17,11 +17,10 @@ use propolis::{
     vmm::VmmHdl,
     Machine,
 };
-use propolis_api_types::instance_spec::v0::InstanceSpecV0;
 use slog::{error, info};
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-use crate::{serial::Serial, vcpu_tasks::VcpuTaskController};
+use crate::{serial::Serial, spec, vcpu_tasks::VcpuTaskController};
 
 use super::{
     state_driver::VmStartReason, BlockBackendMap, CrucibleBackendMap, DeviceMap,
@@ -44,7 +43,7 @@ pub(crate) struct VmObjects {
 /// A collection of objects that should eventually be wrapped in a lock and
 /// stored in a `VmObjects` structure. See [`VmObjectsLocked`].
 pub(super) struct InputVmObjects {
-    pub instance_spec: InstanceSpecV0,
+    pub instance_spec: spec::Spec,
     pub vcpu_tasks: Box<dyn VcpuTaskController>,
     pub machine: Machine,
     pub devices: DeviceMap,
@@ -61,7 +60,7 @@ pub(crate) struct VmObjectsLocked {
     log: slog::Logger,
 
     /// The instance spec that describes this collection of objects.
-    instance_spec: InstanceSpecV0,
+    instance_spec: spec::Spec,
 
     /// The set of tasks that run this VM's vCPUs.
     vcpu_tasks: Box<dyn VcpuTaskController>,
@@ -132,12 +131,12 @@ impl VmObjectsLocked {
     }
 
     /// Yields the VM's current instance spec.
-    pub(crate) fn instance_spec(&self) -> &InstanceSpecV0 {
+    pub(crate) fn instance_spec(&self) -> &spec::Spec {
         &self.instance_spec
     }
 
     /// Yields a mutable reference to the VM's current instance spec.
-    pub(crate) fn instance_spec_mut(&mut self) -> &mut InstanceSpecV0 {
+    pub(crate) fn instance_spec_mut(&mut self) -> &mut spec::Spec {
         &mut self.instance_spec
     }
 

--- a/bin/propolis-server/src/lib/vm/state_driver.rs
+++ b/bin/propolis-server/src/lib/vm/state_driver.rs
@@ -14,7 +14,7 @@ use propolis_api_types::{
     instance_spec::{
         components::backends::CrucibleStorageBackend, v0::StorageBackendV0,
     },
-    InstanceSpecEnsureRequest, InstanceState, MigrationState,
+    InstanceState, MigrationState,
 };
 use slog::{error, info};
 use tokio::sync::Notify;
@@ -28,7 +28,7 @@ use crate::{
 };
 
 use super::{
-    ensure::{VmEnsureActive, VmEnsureNotStarted},
+    ensure::{VmEnsureActive, VmEnsureNotStarted, VmEnsureRequest},
     guest_event::{self, GuestEvent},
     objects::VmObjects,
     request_queue::{self, ExternalRequest, InstanceAutoStart},
@@ -261,7 +261,7 @@ pub(super) async fn run_state_driver(
     log: slog::Logger,
     vm: Arc<super::Vm>,
     mut state_publisher: StatePublisher,
-    ensure_request: InstanceSpecEnsureRequest,
+    ensure_request: VmEnsureRequest,
     ensure_result_tx: InstanceEnsureResponseTx,
     ensure_options: super::EnsureOptions,
 ) -> StateDriverOutput {
@@ -308,7 +308,7 @@ async fn create_and_activate_vm<'a>(
     log: &'a slog::Logger,
     vm: &'a Arc<super::Vm>,
     state_publisher: &'a mut StatePublisher,
-    ensure_request: &'a InstanceSpecEnsureRequest,
+    ensure_request: &'a VmEnsureRequest,
     ensure_result_tx: InstanceEnsureResponseTx,
     ensure_options: &'a super::EnsureOptions,
 ) -> anyhow::Result<VmEnsureActive<'a>> {

--- a/bin/propolis-server/src/lib/vm/state_driver.rs
+++ b/bin/propolis-server/src/lib/vm/state_driver.rs
@@ -670,13 +670,7 @@ impl StateDriver {
             })?
             .clone();
 
-        // TODO(gjc) would be better off with a map in the spec type, but this
-        // will do for now
-        let Some(disk) = objects
-            .instance_spec_mut()
-            .disks
-            .iter_mut()
-            .find(|disk| disk.device_name == disk_name)
+        let Some(disk) = objects.instance_spec_mut().disks.get_mut(&disk_name)
         else {
             return Err(spec_element_not_found(&disk_name));
         };

--- a/bin/propolis-server/src/lib/vm/state_driver.rs
+++ b/bin/propolis-server/src/lib/vm/state_driver.rs
@@ -11,10 +11,8 @@ use std::{
 
 use anyhow::Context;
 use propolis_api_types::{
-    instance_spec::{
-        components::backends::CrucibleStorageBackend, v0::StorageBackendV0,
-    },
-    InstanceState, MigrationState,
+    instance_spec::components::backends::CrucibleStorageBackend, InstanceState,
+    MigrationState,
 };
 use slog::{error, info};
 use tokio::sync::Notify;
@@ -24,6 +22,7 @@ use crate::{
     migrate::{
         destination::DestinationProtocol, source::SourceProtocol, MigrateRole,
     },
+    spec::StorageBackend,
     vm::state_publisher::ExternalStateUpdate,
 };
 
@@ -675,7 +674,7 @@ impl StateDriver {
             return Err(spec_element_not_found(&disk_name));
         };
 
-        let StorageBackendV0::Crucible(CrucibleStorageBackend {
+        let StorageBackend::Crucible(CrucibleStorageBackend {
             request_json: old_vcr_json,
             readonly,
         }) = &disk.backend_spec
@@ -693,11 +692,10 @@ impl StateDriver {
                 )
             })?;
 
-        disk.backend_spec =
-            StorageBackendV0::Crucible(CrucibleStorageBackend {
-                readonly: *readonly,
-                request_json: new_vcr_json,
-            });
+        disk.backend_spec = StorageBackend::Crucible(CrucibleStorageBackend {
+            readonly: *readonly,
+            request_json: new_vcr_json,
+        });
 
         info!(self.log, "replaced Crucible VCR"; "backend_id" => %backend_id);
 

--- a/crates/propolis-api-types/src/instance_spec/components/devices.rs
+++ b/crates/propolis-api-types/src/instance_spec/components/devices.rs
@@ -125,7 +125,7 @@ impl MigrationElement for VirtioNic {
 /// A serial port identifier, which determines what I/O ports a guest can use to
 /// access a port.
 #[derive(
-    Clone, Copy, Deserialize, Serialize, Debug, PartialEq, Eq, JsonSchema,
+    Clone, Copy, Deserialize, Serialize, Debug, PartialEq, Eq, JsonSchema, Hash,
 )]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum SerialPortNumber {


### PR DESCRIPTION
(Part 6/X in the instance spec rework; see #735.)

Define propolis-server's internal representation of a VM component manifest (the `Spec` type) and switch almost everyone in the server over to it. (The exception is the live migration preamble; this will be dealt with in a future PR that moves migration compatibility checks from api-types to server.)

- Define the internal `spec::Spec` type and some helper types, like internal representations of a `Disk` and a `Nic`.
  - This PR starts to show some of the benefits of this series of changes (finally!): now a regular guest VNIC, which is only ever supposed to have a viona backend, is guaranteed by construction to have one, so the machine initializer doesn't need to handle the "oops wait you specified an invalid backend type here" case.
- Add conversion functions to/from the `InstanceSpecV0` public-API type. Converting to a versioned spec is infallible, but conversion from a versioned spec (which can be well-formed but not valid) is fallible.
- Represent Falcon devices with a little more care:
  - The parsed SoftNPU device collection now uses `Option`s for components (the main PCI device, the P9 device, and the P9 filesystem adapter) with a maximum cardinality of 1.
  - When enabling SoftNPU, explicitly denote in the instance spec that SoftNPU expects to use COM4 instead of excluding it from the spec entirely.

Known warts in this change that are on deck to be fixed later in this series:

* In the new internal spec type, serial devices don't have names yet (they still use port numbers as a key and convert these to implicit names).
* The new `Disk` and `Nic` types duplicate backend names: both the types themselves and their `device_spec` members contain `backend_name` fields, and these need to be identical or hilarity will ensue. Subsequent changes will remove the `backend_name` field from these types and just rely on the backend name that's in the device spec.

Tests: cargo test, PHD. (It probably wouldn't hurt for me to run this in an Omicron dev cluster, either. I can give that a try before merging.)