### PR TITLE
fix new 1.81.0 warning and clippy error

### DIFF
--- a/bin/propolis-cli/src/main.rs
+++ b/bin/propolis-cli/src/main.rs
@@ -595,7 +595,7 @@ async fn migrate_instance(
         .collect::<Result<Vec<_>, _>>()?
         // Then any errors from polling the source/destination
         .into_iter()
-        .collect::<anyhow::Result<_>>()?;
+        .collect::<anyhow::Result<()>>()?;
 
     Ok(())
 }

--- a/lib/propolis/src/firmware/smbios/bits.rs
+++ b/lib/propolis/src/firmware/smbios/bits.rs
@@ -140,9 +140,11 @@ pub(crate) struct Type1 {
 }
 raw_table_impl!(Type1, 1);
 
+// We don't create type 2 tables yet, but it's nice to have the definition on hand.
 /// Type 2 (Baseboard Information)
 #[derive(Copy, Clone)]
 #[repr(C, packed)]
+#[allow(dead_code)]
 pub(crate) struct Type2 {
     pub header: StructureHeader,
     pub manufacturer: u8,
@@ -159,9 +161,11 @@ pub(crate) struct Type2 {
 }
 raw_table_impl!(Type2, 2);
 
+// We don't create type 2 tables yet, but it's nice to have the definition on hand.
 /// Type 3 (System Enclosure) - Version 2.7
 #[derive(Copy, Clone)]
 #[repr(C, packed)]
+#[allow(dead_code)]
 pub(crate) struct Type3 {
     pub header: StructureHeader,
     pub manufacturer: u8,

--- a/lib/propolis/src/firmware/smbios/bits.rs
+++ b/lib/propolis/src/firmware/smbios/bits.rs
@@ -161,7 +161,7 @@ pub(crate) struct Type2 {
 }
 raw_table_impl!(Type2, 2);
 
-// We don't create type 2 tables yet, but it's nice to have the definition on hand.
+// We don't create type 3 tables yet, but it's nice to have the definition on hand.
 /// Type 3 (System Enclosure) - Version 2.7
 #[derive(Copy, Clone)]
 #[repr(C, packed)]


### PR DESCRIPTION
on 1.81, this expression caused a rustc warning, and clippy error:

```
warning: this function depends on never type fallback being `()`
   --> bin/propolis-cli/src/main.rs:497:1
    |
497 | / async fn migrate_instance(
498 | |     src_client: Client,
499 | |     dst_client: Client,
500 | |     src_addr: SocketAddr,
501 | |     dst_uuid: Uuid,
502 | |     disks: Vec<DiskRequest>,
503 | | ) -> anyhow::Result<()> {
    | |_______________________^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
note: in edition 2024, the requirement `!: FromIterator<()>` will fail
   --> bin/propolis-cli/src/main.rs:598:20
    |
598 |         .collect::<anyhow::Result<_>>()?;
    |                    ^^^^^^^^^^^^^^^^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default

warning: `propolis-cli` (bin "propolis-cli") generated 1 warning
```

i am, honestly, entirely missing how the never type is involved here, or how changing the `collect`'s type from `anyhow::Result<_>` to `anyhow::Result<()>` changes things in a direction to satisfy rustc. but bounding the type further doesn't seem like it would cause a problem?

it made my totally unrelated change in #759 [fail](https://github.com/oxidecomputer/propolis/actions/runs/10725473545/job/29743369257?pr=759) :(

edit: there were a few new warnings that also get denied in CI and are fixed here, but the one in this message is still especially confusing.