### PR TITLE
instance spec rework: tighten up component naming

### DIFF
--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -133,19 +133,19 @@ fn instance_spec_from_request(
         spec_builder.add_cloud_init_from_request(base64.clone())?;
     }
 
-    for port in [
-        instance_spec::components::devices::SerialPortNumber::Com1,
-        instance_spec::components::devices::SerialPortNumber::Com2,
-        instance_spec::components::devices::SerialPortNumber::Com3,
+    for (name, port) in [
+        ("com1", instance_spec::components::devices::SerialPortNumber::Com1),
+        ("com2", instance_spec::components::devices::SerialPortNumber::Com2),
+        ("com3", instance_spec::components::devices::SerialPortNumber::Com3),
         // SoftNpu uses this port for ASIC management.
         #[cfg(not(feature = "falcon"))]
-        instance_spec::components::devices::SerialPortNumber::Com4,
+        ("com4", instance_spec::components::devices::SerialPortNumber::Com4),
     ] {
-        spec_builder.add_serial_port(port)?;
+        spec_builder.add_serial_port(name.to_owned(), port)?;
     }
 
     #[cfg(feature = "falcon")]
-    spec_builder.set_softnpu_com4()?;
+    spec_builder.set_softnpu_com4("com4".to_owned())?;
 
     spec_builder.add_pvpanic_device(spec::QemuPvpanic {
         name: "pvpanic".to_string(),

--- a/bin/propolis-server/src/lib/spec/api_spec_v0.rs
+++ b/bin/propolis-server/src/lib/spec/api_spec_v0.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 
 use propolis_api_types::instance_spec::{
-    components::devices::{SerialPort as SerialPortDesc, SerialPortNumber},
+    components::devices::SerialPort as SerialPortDesc,
     v0::{InstanceSpecV0, NetworkBackendV0, NetworkDeviceV0, StorageDeviceV0},
 };
 use thiserror::Error;
@@ -95,19 +95,12 @@ impl From<Spec> for InstanceSpecV0 {
             );
         }
 
-        for (num, user) in val.serial.iter() {
-            if *user == SerialPortDevice::Uart {
-                let name = match num {
-                    SerialPortNumber::Com1 => "com1",
-                    SerialPortNumber::Com2 => "com2",
-                    SerialPortNumber::Com3 => "com3",
-                    SerialPortNumber::Com4 => "com4",
-                };
-
+        for (name, desc) in val.serial {
+            if desc.device == SerialPortDevice::Uart {
                 insert_component(
                     &mut spec.devices.serial_ports,
-                    name.to_owned(),
-                    SerialPortDesc { num: *num },
+                    name,
+                    SerialPortDesc { num: desc.num },
                 );
             }
         }
@@ -253,9 +246,8 @@ impl TryFrom<InstanceSpecV0> for Spec {
             return Err(ApiSpecError::BackendNotUsed(backend.to_owned()));
         }
 
-        // TODO(#735): Serial ports need to have names like other devices.
-        for serial_port in value.devices.serial_ports.values() {
-            builder.add_serial_port(serial_port.num)?;
+        for (name, serial_port) in value.devices.serial_ports {
+            builder.add_serial_port(name, serial_port.num)?;
         }
 
         for (name, bridge) in value.devices.pci_pci_bridges {

--- a/bin/propolis-server/src/lib/spec/builder.rs
+++ b/bin/propolis-server/src/lib/spec/builder.rs
@@ -195,15 +195,15 @@ impl SpecBuilder {
             return Err(SpecBuilderError::ComponentNameInUse(disk_name));
         }
 
-        if self.component_names.contains(&disk.backend_name) {
+        if self.component_names.contains(disk.device_spec.backend_name()) {
             return Err(SpecBuilderError::ComponentNameInUse(
-                disk.backend_name,
+                disk.device_spec.backend_name().to_owned(),
             ));
         }
 
         self.register_pci_device(disk.device_spec.pci_path())?;
         self.component_names.insert(disk_name.clone());
-        self.component_names.insert(disk.backend_name.clone());
+        self.component_names.insert(disk.device_spec.backend_name().to_owned());
         let _old = self.spec.disks.insert(disk_name, disk);
         assert!(_old.is_none());
         Ok(self)
@@ -219,13 +219,15 @@ impl SpecBuilder {
             return Err(SpecBuilderError::ComponentNameInUse(nic_name));
         }
 
-        if self.component_names.contains(&nic.backend_name) {
-            return Err(SpecBuilderError::ComponentNameInUse(nic.backend_name));
+        if self.component_names.contains(&nic.device_spec.backend_name) {
+            return Err(SpecBuilderError::ComponentNameInUse(
+                nic.device_spec.backend_name,
+            ));
         }
 
         self.register_pci_device(nic.device_spec.pci_path)?;
         self.component_names.insert(nic_name.clone());
-        self.component_names.insert(nic.backend_name.clone());
+        self.component_names.insert(nic.device_spec.backend_name.clone());
         let _old = self.spec.nics.insert(nic_name, nic);
         assert!(_old.is_none());
         Ok(self)

--- a/bin/propolis-server/src/lib/spec/config_toml.rs
+++ b/bin/propolis-server/src/lib/spec/config_toml.rs
@@ -113,15 +113,9 @@ impl TryFrom<&config::Config> for ParsedConfig {
                     let device_spec =
                         parse_storage_device_from_config(device_name, device)?;
 
-                    let backend_name = match &device_spec {
-                        StorageDevice::Virtio(disk) => {
-                            disk.backend_name.clone()
-                        }
-                        StorageDevice::Nvme(disk) => disk.backend_name.clone(),
-                    };
-
+                    let backend_name = device_spec.backend_name();
                     let backend_config =
-                        config.block_devs.get(&backend_name).ok_or_else(
+                        config.block_devs.get(backend_name).ok_or_else(
                             || ConfigTomlError::StorageDeviceBackendNotFound {
                                 device: device_name.to_owned(),
                                 backend: backend_name.to_owned(),
@@ -129,13 +123,13 @@ impl TryFrom<&config::Config> for ParsedConfig {
                         )?;
 
                     let backend_spec = parse_storage_backend_from_config(
-                        &backend_name,
+                        backend_name,
                         backend_config,
                     )?;
 
                     parsed.disks.push(ParsedDiskRequest {
                         name: device_name.to_owned(),
-                        disk: Disk { device_spec, backend_name, backend_spec },
+                        disk: Disk { device_spec, backend_spec },
                     });
                 }
                 "pci-virtio-viona" => {
@@ -298,7 +292,7 @@ pub(super) fn parse_network_device_from_config(
 
     Ok(ParsedNicRequest {
         name: device_name,
-        nic: Nic { device_spec, backend_name, backend_spec },
+        nic: Nic { device_spec, backend_spec },
     })
 }
 

--- a/bin/propolis-server/src/lib/spec/mod.rs
+++ b/bin/propolis-server/src/lib/spec/mod.rs
@@ -81,6 +81,13 @@ impl StorageDevice {
             StorageDevice::Nvme(disk) => disk.pci_path,
         }
     }
+
+    pub fn backend_name(&self) -> &str {
+        match self {
+            StorageDevice::Virtio(disk) => &disk.backend_name,
+            StorageDevice::Nvme(disk) => &disk.backend_name,
+        }
+    }
 }
 
 impl From<StorageDevice> for StorageDeviceV0 {
@@ -132,14 +139,12 @@ impl From<StorageBackendV0> for StorageBackend {
 #[derive(Clone, Debug)]
 pub struct Disk {
     pub device_spec: StorageDevice,
-    pub backend_name: String,
     pub backend_spec: StorageBackend,
 }
 
 #[derive(Clone, Debug)]
 pub struct Nic {
     pub device_spec: VirtioNic,
-    pub backend_name: String,
     pub backend_spec: VirtioNetworkBackend,
 }
 

--- a/bin/propolis-server/src/lib/spec/mod.rs
+++ b/bin/propolis-server/src/lib/spec/mod.rs
@@ -58,7 +58,7 @@ pub(crate) struct Spec {
     pub disks: HashMap<String, Disk>,
     pub nics: HashMap<String, Nic>,
 
-    pub serial: HashMap<SerialPortNumber, SerialPortDevice>,
+    pub serial: HashMap<String, SerialPort>,
 
     pub pci_pci_bridges: HashMap<String, PciPciBridge>,
     pub pvpanic: Option<QemuPvpanic>,
@@ -150,6 +150,12 @@ pub enum SerialPortDevice {
 
     #[cfg(feature = "falcon")]
     SoftNpu,
+}
+
+#[derive(Clone, Debug)]
+pub struct SerialPort {
+    pub num: SerialPortNumber,
+    pub device: SerialPortDevice,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
(7/X in the instance spec rework; see #735.)

Fix a few problems with the way components are named in propolis-server `Spec`s:

- Don't duplicate backend names in disk and NIC elements
- Use names as keys in the serial port map instead of deriving names from serial port numbers
- Properly register the names of bridges when adding them to the spec builder
- Make the builder reject requests to add a device/backend pair where the device and backend have the same name (and stop requesting this for cloud-init disks...)

Tests: cargo test, PHD.