### PR TITLE
server: add a first-class error type to machine init

### DIFF
--- a/bin/propolis-server/src/lib/vm/ensure.rs
+++ b/bin/propolis-server/src/lib/vm/ensure.rs
@@ -200,16 +200,16 @@ impl<'a> VmEnsureNotStarted<'a> {
         )?;
 
         init.initialize_rtc(&chipset)?;
-        init.initialize_hpet()?;
+        init.initialize_hpet();
 
-        let com1 = Arc::new(init.initialize_uart(&chipset)?);
-        let ps2ctrl = init.initialize_ps2(&chipset)?;
+        let com1 = Arc::new(init.initialize_uart(&chipset));
+        let ps2ctrl = init.initialize_ps2(&chipset);
         init.initialize_qemu_debug_port()?;
         init.initialize_qemu_pvpanic(properties.into())?;
         init.initialize_network_devices(&chipset).await?;
 
         #[cfg(not(feature = "omicron-build"))]
-        init.initialize_test_devices(&options.toml_config.devices)?;
+        init.initialize_test_devices(&options.toml_config.devices);
         #[cfg(feature = "omicron-build")]
         info!(
             self.log,
@@ -219,7 +219,7 @@ impl<'a> VmEnsureNotStarted<'a> {
         #[cfg(feature = "falcon")]
         {
             init.initialize_softnpu_ports(&chipset)?;
-            init.initialize_9pfs(&chipset)?;
+            init.initialize_9pfs(&chipset);
         }
 
         init.initialize_storage_devices(&chipset, options.nexus_client.clone())


### PR DESCRIPTION
Add a `MachineInitError` type and make `MachineInitializer` functions return it. This makes it more convenient to handle new logic errors in initializer functions. To handle the (many) cases where the initializer calls bhyve ioctls or filesystem functions that return `std::io:Error`, `MachineInitError` has a catchall `anyhow::Error` variant; this encourages calls that produce I/O errors to call `context` or `with_context` to better describe those errors.

Tested by running propolis-server ad hoc in a couple of invalid configurations (file backend not pointing to an actual file; too many vCPUs; more guest memory than the host has available) and verified that the error chains (and contexts, if applicable) show up in the Propolis logs.