### PR TITLE
lib: move cpuid::Set to cpuid_utils; prevent semantic subleaf conflicts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +775,7 @@ dependencies = [
  "bitflags 2.6.0",
  "propolis_api_types",
  "propolis_types",
+ "proptest",
  "thiserror",
 ]
 
@@ -4457,6 +4473,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.6.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.8.4",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4553,6 +4589,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -5015,6 +5060,18 @@ source = "git+https://github.com/oxidecomputer/rusty-doors#0e3a1495dcf8b7b5e11a6
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -6459,6 +6516,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6769,6 +6832,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,7 @@ dependencies = [
 name = "cpuid_utils"
 version = "0.0.0"
 dependencies = [
+ "bhyve_api 0.0.0",
  "bitflags 2.6.0",
  "propolis_api_types",
  "propolis_types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ pin-project-lite = "0.2.13"
 proc-macro2 = "1.0"
 proc-macro-error = "1"
 progenitor = "0.8.0"
+proptest = "1.5.0"
 quote = "1.0"
 rand = "0.8"
 reqwest = { version = "0.12.0", default-features = false }

--- a/bin/propolis-server/src/lib/migrate/compat.rs
+++ b/bin/propolis-server/src/lib/migrate/compat.rs
@@ -259,10 +259,10 @@ impl spec::Spec {
                 })
             }
             (Some(this), Some(other)) => {
-                if this.vendor != other.vendor {
+                if this.vendor() != other.vendor() {
                     return Err(CpuidMismatch::Vendor {
-                        this: this.vendor,
-                        other: other.vendor,
+                        this: this.vendor(),
+                        other: other.vendor(),
                     });
                 }
 

--- a/bin/propolis-server/src/lib/spec/api_spec_v0.rs
+++ b/bin/propolis-server/src/lib/spec/api_spec_v0.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use propolis_api_types::instance_spec::{
     components::{
         backends::{DlpiNetworkBackend, VirtioNetworkBackend},
-        board::{Board as InstanceSpecBoard, Cpuid},
+        board::Board as InstanceSpecBoard,
         devices::{BootSettings, SerialPort as SerialPortDesc},
     },
     v0::{ComponentV0, InstanceSpecV0},
@@ -89,10 +89,7 @@ impl From<Spec> for InstanceSpecV0 {
             cpus: board.cpus,
             memory_mb: board.memory_mb,
             chipset: board.chipset,
-            cpuid: cpuid.map(|set| {
-                let (map, vendor) = set.into_inner();
-                Cpuid { entries: map.into(), vendor }
-            }),
+            cpuid: cpuid.map(|set| set.into_instance_spec_cpuid()),
         };
         let mut spec = InstanceSpecV0 { board, components: Default::default() };
 

--- a/bin/propolis-server/src/lib/spec/builder.rs
+++ b/bin/propolis-server/src/lib/spec/builder.rs
@@ -105,10 +105,10 @@ impl SpecBuilder {
                     .cpuid
                     .map(|cpuid| -> Result<_, CpuidMapConversionError> {
                         {
-                            Ok(propolis::cpuid::Set::new_from_map(
+                            Ok(cpuid_utils::CpuidSet::from_map(
                                 cpuid.entries.try_into()?,
                                 cpuid.vendor,
-                            ))
+                            )?)
                         }
                     })
                     .transpose()?,

--- a/bin/propolis-server/src/lib/spec/mod.rs
+++ b/bin/propolis-server/src/lib/spec/mod.rs
@@ -16,7 +16,7 @@
 
 use std::collections::HashMap;
 
-use propolis::cpuid::Set as CpuidSet;
+use cpuid_utils::CpuidSet;
 use propolis_api_types::instance_spec::{
     components::{
         backends::{

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -1345,7 +1345,7 @@ fn setup_instance(
         } else {
             // An empty set will instruct the kernel to use the legacy
             // fallback behavior
-            propolis::cpuid::Set::new_host()
+            cpuid_utils::CpuidSet::new_host()
         };
         vcpu.set_cpuid(vcpu_profile)?;
         vcpu.set_default_capabs()?;

--- a/crates/cpuid-utils/Cargo.toml
+++ b/crates/cpuid-utils/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 bitflags.workspace = true
+bhyve_api.workspace = true
 propolis_api_types = {workspace = true, optional = true}
 propolis_types.workspace = true
 thiserror.workspace = true

--- a/crates/cpuid-utils/Cargo.toml
+++ b/crates/cpuid-utils/Cargo.toml
@@ -11,5 +11,8 @@ propolis_api_types = {workspace = true, optional = true}
 propolis_types.workspace = true
 thiserror.workspace = true
 
+[dev-dependencies]
+proptest.workspace = true
+
 [features]
 instance-spec = ["propolis_api_types"]

--- a/crates/cpuid-utils/src/lib.rs
+++ b/crates/cpuid-utils/src/lib.rs
@@ -125,7 +125,7 @@ impl CpuidMap {
         .flatten()
     }
 
-    /// Retrives a mutable reference to the values associated with the supplied
+    /// Retrieves a mutable reference to the values associated with the supplied
     /// `ident`, or `None` if the identifier is not present in the map.
     pub fn get_mut(&mut self, ident: CpuidIdent) -> Option<&mut CpuidValues> {
         match ident.subleaf {

--- a/crates/cpuid-utils/src/lib.rs
+++ b/crates/cpuid-utils/src/lib.rs
@@ -261,6 +261,20 @@ impl CpuidMap {
     /// Passes each leaf number in the map to `f` and removes any leaf entries
     /// for which `f` returns `false`. If a removed leaf has subleaves, all
     /// their entries are removed.
+    //
+    // This function can be made to consider subleaves by changing `f` to take a
+    // `CpuidIdent` and then writing the call to `retain` with a `match`:
+    //
+    // - If the leaf has `Subleaves::Absent`, pass the leaf ID through to `f`
+    //   directly and return the result to `retain`.
+    // - If the leaf has `Subleaves::Present`, call `retain` on the subleaf map,
+    //   passing each subleaf to `f`, then return `!map.is_empty()` to the outer
+    //   call to `retain` (i.e. keep the leaf entry if the subleaf map still has
+    //   entries in it).
+    //
+    // The cost of doing this is that the function now needs to visit every
+    // subleaf entry in the map, even if the caller doesn't care about subleaf
+    // IDs. So it may be better to break this out into a separate function.
     pub fn retain_by_leaf<F>(&mut self, mut f: F)
     where
         F: FnMut(u32) -> bool,

--- a/crates/cpuid-utils/src/lib.rs
+++ b/crates/cpuid-utils/src/lib.rs
@@ -99,12 +99,19 @@ pub enum SubleafInsertConflict {
 /// Tracking CPUID values in a simple `BTreeMap` from [`CpuidIdent`] to
 /// [`CpuidValues`] allows a single leaf to use both options at once, because
 /// `CpuidIdent { leaf: x, subleaf: None }` is not the same as `CpuidIdent {
-/// leaf: x, subleaf: Some(y) }`.
+/// leaf: x, subleaf: Some(y) }`. To avoid this kind of semantic confusion, this
+/// type's `insert` method returns a `Result` that indicates whether inserting
+/// the requested leaf/subleaf identifier would produce a semantic conflict
+/// between a subleaf-bearing and subleaf-free entry.
 ///
-/// To avoid this kind of semantic confusion, this type's `insert` method
-/// returns a `Result` that indicates whether inserting the requested
-/// leaf/subleaf identifier would produce a semantic conflict between a
-/// subleaf-bearing and subleaf-free entry.
+/// This structure allows "holes" in a leaf's subleaf IDs; that is, the
+/// structure permits `leaf: 0, subleaf: Some(0)` and `subleaf: Some(2)` to
+/// appear in a map where `subleaf: Some(1)` is absent. This is mostly for
+/// simplicity (it saves the map type from having to check for discontiguous
+/// subleaf domains); the existing subleaf-having CPUID leaves in the Intel and
+/// AMD manuals all specify contiguous subleaf domains, and a client who
+/// specifies a discontiguous subleaf set may find itself with unhappy guest
+/// operating systems.
 #[derive(Clone, Debug, Default)]
 pub struct CpuidMap(BTreeMap<u32, Subleaves>);
 

--- a/crates/cpuid-utils/src/lib.rs
+++ b/crates/cpuid-utils/src/lib.rs
@@ -4,6 +4,43 @@
 
 //! Utility functions and types for working with CPUID values.
 //!
+//! # The `CPUID` instruction
+//!
+//! The x86 CPUID instruction returns information about the executing processor.
+//! This information can range from a manufacturer ID to a model number to the
+//! processor's supported feature set to the calling logical processor's APIC
+//! ID.
+//!
+//! CPUID takes as input a "leaf" or "function" value, passed in the eax
+//! register, which determines what information the processor should return.
+//! Some leaves accept a "subleaf" or "index" value, specified in ecx, that
+//! further qualifies the information class supplied in eax. For example, leaf 4
+//! returns information about a processor's cache topology; it uses the subleaf
+//! value as an index that identifies a particular type and level of cache.
+//!
+//! The CPUID leaf space is divided into "standard" and "extended" regions.
+//! Leaves in the standard region (0 to 0xFFFF) have architecturally-defined
+//! semantics. Leaves in the extended region (0x80000000 to 0x8000FFFF) have
+//! vendor-specific semantics.
+//!
+//! `propolis-server` can accept a list of CPUID leaf/subleaf/value tuples as
+//! part of an instance specification. If a client supplies one, Propolis will
+//! initialize each vCPU so that CPUID instructions executed there will return
+//! the supplied values, possibly with some adjustments (substituting vCPU
+//! numbers into those leaves that return them, adjusting CPU topology leaves
+//! based on other settings in the spec, etc.).
+//!
+//! This module implements two collections that Propolis components can use to
+//! hold CPUID information:
+//!
+//! - [`CpuidMap`] maps from CPUID leaf and subleaf pairs to their associated
+//!   values, taking care to ensure that a single leaf is marked either as
+//!   ignoring or honoring the subleaf number, but not both.
+//! - [`CpuidSet`] pairs a `CpuidMap` with a [`CpuidVendor`] that Propolis can
+//!   use to interpret the values of the map leaves in the extended region.
+//!
+//! # The `instance-spec` feature
+//!
 //! If this crate is built with the `instance-spec` feature, this module
 //! includes mechanisms for converting from instance spec CPUID entries to and
 //! from the CPUID map types in the crate. This is feature-gated so that the
@@ -11,7 +48,10 @@
 //! `propolis-api-types`.
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{
+        btree_map::{self, Entry},
+        BTreeMap, BTreeSet,
+    },
     ops::RangeInclusive,
 };
 
@@ -23,53 +63,473 @@ pub mod bits;
 #[cfg(feature = "instance-spec")]
 mod instance_spec;
 
-#[cfg(feature = "instance-spec")]
-pub use instance_spec::*;
+type CpuidSubleafMap = BTreeMap<u32, CpuidValues>;
+type CpuidMapInsertResult = Result<Option<CpuidValues>, SubleafInsertConflict>;
 
-/// A map from CPUID leaves to CPUID values.
-#[derive(Clone, Debug, Default)]
-pub struct CpuidMap(pub BTreeMap<CpuidIdent, CpuidValues>);
+/// Denotes the presence or absence of subleaves for a given CPUID leaf.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Subleaves {
+    /// This leaf is configured to have subleaves, whose values are stored in
+    /// the inner map.
+    Present(CpuidSubleafMap),
 
-#[derive(Debug, Error)]
-pub enum CpuidMapMismatch {
-    #[error("CPUID leaves not found in both sets ({0:?})")]
-    MismatchedLeaves(Vec<CpuidIdent>),
-
-    #[error("CPUID leaves have different values in different sets ({0:?})")]
-    MismatchedValues(Vec<(CpuidIdent, CpuidValues, CpuidValues)>),
+    /// This leaf does not have subleaves.
+    Absent(CpuidValues),
 }
 
+/// [`CpuidMap`]'s insert functions return this error if a request to insert a
+/// new value would produce a leaf that has both per-subleaf values and a
+/// no-subleaf value.
+#[derive(Debug, Error)]
+pub enum SubleafInsertConflict {
+    #[error("leaf {0:x} has entries with subleaves")]
+    SubleavesAlreadyPresent(u32),
+
+    #[error("leaf {0:x} has an entry with no subleaves")]
+    SubleavesAlreadyAbsent(u32),
+}
+
+/// A mapping from CPUID leaf/subleaf pairs to CPUID return values. This struct
+/// allows each registered leaf either to have or not to have subleaf values,
+/// but not both at once.
+///
+/// Some CPUID leaves completely ignore the subleaf value passed in ecx. Others
+/// pay attention to it and have their own per-leaf semantics that govern what
+/// happens if the supplied ecx value is out of the function's expected range.
+/// Tracking CPUID values in a simple `BTreeMap` from [`CpuidIdent`] to
+/// [`CpuidValues`] allows a single leaf to use both options at once, because
+/// `CpuidIdent { leaf: x, subleaf: None }` is not the same as `CpuidIdent {
+/// leaf: x, subleaf: Some(y) }`.
+///
+/// To avoid this kind of semantic confusion, this type's `insert` method
+/// returns a `Result` that indicates whether inserting the requested
+/// leaf/subleaf identifier would produce a semantic conflict between a
+/// subleaf-bearing and subleaf-free entry.
+#[derive(Clone, Debug, Default)]
+pub struct CpuidMap(BTreeMap<u32, Subleaves>);
+
 impl CpuidMap {
+    /// Retrieves the values associated with the supplied `ident`, or `None` if
+    /// the identifier is not present in the map.
+    pub fn get(&self, ident: CpuidIdent) -> Option<&CpuidValues> {
+        match ident.subleaf {
+            None => self.0.get(&ident.leaf).map(|ent| match ent {
+                Subleaves::Present(_) => None,
+                Subleaves::Absent(val) => Some(val),
+            }),
+            Some(sl) => self.0.get(&ident.leaf).map(|ent| match ent {
+                Subleaves::Absent(_) => None,
+                Subleaves::Present(sl_map) => sl_map.get(&sl),
+            }),
+        }
+        .flatten()
+    }
+
+    /// Retrives a mutable reference to the values associated with the supplied
+    /// `ident`, or `None` if the identifier is not present in the map.
+    pub fn get_mut(&mut self, ident: CpuidIdent) -> Option<&mut CpuidValues> {
+        match ident.subleaf {
+            None => self.0.get_mut(&ident.leaf).map(|ent| match ent {
+                Subleaves::Present(_) => None,
+                Subleaves::Absent(val) => Some(val),
+            }),
+            Some(sl) => self.0.get_mut(&ident.leaf).map(|ent| match ent {
+                Subleaves::Absent(_) => None,
+                Subleaves::Present(sl_map) => sl_map.get_mut(&sl),
+            }),
+        }
+        .flatten()
+    }
+
+    fn insert_leaf_no_subleaf(
+        &mut self,
+        leaf: u32,
+        values: CpuidValues,
+    ) -> CpuidMapInsertResult {
+        match self.0.entry(leaf) {
+            Entry::Vacant(e) => {
+                e.insert(Subleaves::Absent(values));
+                Ok(None)
+            }
+            Entry::Occupied(mut e) => match e.get_mut() {
+                Subleaves::Present(_) => {
+                    Err(SubleafInsertConflict::SubleavesAlreadyPresent(leaf))
+                }
+                Subleaves::Absent(v) => Ok(Some(std::mem::replace(v, values))),
+            },
+        }
+    }
+
+    fn insert_leaf_subleaf(
+        &mut self,
+        leaf: u32,
+        subleaf: u32,
+        values: CpuidValues,
+    ) -> CpuidMapInsertResult {
+        match self.0.entry(leaf) {
+            Entry::Vacant(e) => {
+                e.insert(Subleaves::Present(
+                    [(subleaf, values)].into_iter().collect(),
+                ));
+                Ok(None)
+            }
+            Entry::Occupied(mut e) => match e.get_mut() {
+                Subleaves::Absent(_) => {
+                    Err(SubleafInsertConflict::SubleavesAlreadyAbsent(leaf))
+                }
+                Subleaves::Present(sl_map) => {
+                    Ok(sl_map.insert(subleaf, values))
+                }
+            },
+        }
+    }
+
+    /// Inserts the supplied (`ident`, `values`) pair into the map.
+    ///
+    /// # Return value
+    ///
+    /// - `Ok(None)` if the supplied leaf/subleaf pair was not present in the
+    ///   map.
+    /// - `Ok(Some)` if the supplied leaf/subleaf pair was present in the map.
+    ///   The wrapped value is the previous value set for this pair, which is
+    ///   replaced by the supplied `values`.
+    /// - `Err` if the insert would cause the selected leaf to have one entry
+    ///   with no subleaf and one entry with a subleaf.
+    pub fn insert(
+        &mut self,
+        ident: CpuidIdent,
+        values: CpuidValues,
+    ) -> CpuidMapInsertResult {
+        match ident.subleaf {
+            Some(sl) => self.insert_leaf_subleaf(ident.leaf, sl, values),
+            None => self.insert_leaf_no_subleaf(ident.leaf, values),
+        }
+    }
+
+    /// Removes the entry with the supplied `ident` from the map if it is
+    /// present, returning its value.
+    ///
+    /// If `ident.subleaf` is `None`, this routine will only match leaf entries
+    /// that don't specify per-subleaf values.
+    pub fn remove(&mut self, ident: CpuidIdent) -> Option<CpuidValues> {
+        // If the leaf isn't present there's nothing to return.
+        let Entry::Occupied(mut entry) = self.0.entry(ident.leaf) else {
+            return None;
+        };
+
+        let (val, remove_leaf) = {
+            match (ident.subleaf, entry.get_mut()) {
+                // The caller didn't supply a subleaf, and this leaf doesn't
+                // have a subleaf map. Yank the leaf entry and return the
+                // associated value. (This can't be done inline because the
+                // entry is mutably borrowed.)
+                (None, Subleaves::Absent(val)) => (*val, true),
+                // The caller didn't supply a subleaf, but the leaf has one, so
+                // the keys don't match.
+                (None, Subleaves::Present(_)) => {
+                    return None;
+                }
+                // The caller supplied a subleaf, but the leaf doesn't use
+                // subleaves, so the keys don't match.
+                (Some(_), Subleaves::Absent(_)) => {
+                    return None;
+                }
+                // The caller supplied a subleaf, and this leaf has subleaf
+                // data. If the requested subleaf is in the leaf's subleaf map,
+                // remove the corresponding subleaf entry. If this empties the
+                // subleaf map, also clean up the leaf entry.
+                (Some(subleaf), Subleaves::Present(sl_map)) => {
+                    let val = sl_map.remove(&subleaf)?;
+                    (val, sl_map.is_empty())
+                }
+            }
+        };
+
+        if remove_leaf {
+            entry.remove_entry();
+        }
+
+        Some(val)
+    }
+
+    /// Removes all data for the supplied `leaf`. If the leaf has subleaves, all
+    /// their entries are removed.
+    pub fn remove_leaf(&mut self, leaf: u32) {
+        self.0.remove(&leaf);
+    }
+
+    /// Passes each leaf number in the map to `f` and removes any leaf entries
+    /// for which `f` returns `false`. If a removed leaf has subleaves, all
+    /// their entries are removed.
+    pub fn retain_by_leaf<F>(&mut self, mut f: F)
+    where
+        F: FnMut(u32) -> bool,
+    {
+        self.0.retain(|leaf, _| f(*leaf));
+    }
+
+    /// Clears the entire map.
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Returns `true` if the map has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the total number of leaf/subleaf/value tuples in the map.
+    pub fn len(&self) -> usize {
+        let mut len = 0;
+        for sl in self.0.values() {
+            match sl {
+                Subleaves::Absent(_) => len += 1,
+                Subleaves::Present(sl_map) => len += sl_map.len(),
+            }
+        }
+
+        len
+    }
+
+    /// Returns an iterator over the ([`CpuidIdent`], [`CpuidValues`]) pairs in
+    /// the map.
+    pub fn iter(&self) -> CpuidMapIterator {
+        CpuidMapIterator::new(self)
+    }
+}
+
+/// An iterator over a [`CpuidMap`]'s leaf/subleaf/value tuples.
+pub struct CpuidMapIterator<'a> {
+    leaf_iter: btree_map::Iter<'a, u32, Subleaves>,
+    subleaf_iter: Option<(u32, btree_map::Iter<'a, u32, CpuidValues>)>,
+}
+
+impl<'a> CpuidMapIterator<'a> {
+    fn new(map: &'a CpuidMap) -> Self {
+        Self { leaf_iter: map.0.iter(), subleaf_iter: None }
+    }
+}
+
+impl Iterator for CpuidMapIterator<'_> {
+    type Item = (CpuidIdent, CpuidValues);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // If a subleaf iteration is in progress, try to advance that iterator.
+        // If that produces another subleaf value, return it. Otherwise, clear
+        // the subleaf iterator and move to the next leaf.
+        if let Some((leaf, subleaf_iter)) = &mut self.subleaf_iter {
+            if let Some((subleaf, value)) = subleaf_iter.next() {
+                return Some((CpuidIdent::subleaf(*leaf, *subleaf), *value));
+            };
+
+            self.subleaf_iter = None;
+        }
+
+        // Advance the leaf iterator. If there are no more leaves to iterate,
+        // the entire iteration is over.
+        let (leaf, subleaves) = self.leaf_iter.next()?;
+
+        // Iteration has moved to a new leaf. Consider whether it has any
+        // subleaves. If it doesn't, simply return the leaf and value.
+        // Otherwise, start iterating over subleaves.
+        match subleaves {
+            Subleaves::Absent(val) => Some((CpuidIdent::leaf(*leaf), *val)),
+            Subleaves::Present(sl_map) => {
+                let mut subleaf_iter = sl_map.iter();
+
+                // This invariant is upheld by insert/remove.
+                let (subleaf, value) = subleaf_iter
+                    .next()
+                    .expect("subleaf maps always have at least one entry");
+
+                // Stash the iterator along with the leaf value it
+                // corresponds to so that future iterations can return
+                // the entire leaf/subleaf pair.
+                self.subleaf_iter = Some((*leaf, subleaf_iter));
+                Some((CpuidIdent::subleaf(*leaf, *subleaf), *value))
+            }
+        }
+    }
+}
+
+/// A map from CPUID leaves to CPUID values that includes a vendor ID. Callers
+/// can use the vendor ID to interpret the meanings of any extended leaves
+/// present in the map.
+#[derive(Clone, Debug)]
+pub struct CpuidSet {
+    map: CpuidMap,
+    pub vendor: CpuidVendor,
+}
+
+impl Default for CpuidSet {
+    /// Equivalent to [`Self::new_host`].
+    fn default() -> Self {
+        Self::new_host()
+    }
+}
+
+/// A discrepancy between two [`CpuidSet`]s.
+#[derive(Debug, Error)]
+pub enum CpuidSetMismatch {
+    /// The sets have different CPU vendors.
+    #[error("CPUID set has mismatched vendors (self: {this}, other: {other})")]
+    Vendor { this: CpuidVendor, other: CpuidVendor },
+
+    /// The two sets have different leaves or subleaves. The payload contains
+    /// all of the leaf identifiers that were present in one set but not the
+    /// other.
+    #[error("CPUID leaves not found in both sets ({0:?})")]
+    LeafSet(Vec<CpuidIdent>),
+
+    /// The two sets disagree on the values to return for one or more
+    /// leaf/subleaf pairs. The payload contains the leaf/subleaf ID and values
+    /// for all such pairs.
+    #[error("CPUID leaves have different values in different sets ({0:?})")]
+    Values(Vec<(CpuidIdent, CpuidValues, CpuidValues)>),
+}
+
+impl CpuidSet {
+    /// Creates an empty `CpuidSet` with the supplied `vendor`.
+    pub fn new(vendor: CpuidVendor) -> Self {
+        Self { map: CpuidMap::default(), vendor }
+    }
+
+    /// Creates a new `CpuidSet` with the supplied initial leaf/value `map` and
+    /// `vendor`.
+    pub fn from_map(
+        map: CpuidMap,
+        vendor: CpuidVendor,
+    ) -> Result<Self, SubleafInsertConflict> {
+        Ok(Self { map, vendor })
+    }
+
+    /// Executes the CPUID instruction on the current machine to determine its
+    /// processor vendor, then creates an empty `CpuidSet` with that vendor.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the host is not an Intel or AMD CPU (leaf 0 ebx/ecx/edx
+    /// contain something other than "GenuineIntel" or "AuthenticAMD").
+    pub fn new_host() -> Self {
+        let vendor = CpuidVendor::try_from(host_query(CpuidIdent::leaf(0)))
+            .expect("host CPU should be from recognized vendor");
+        Self::new(vendor)
+    }
+
+    /// See [`CpuidMap::insert`].
+    pub fn insert(
+        &mut self,
+        ident: CpuidIdent,
+        values: CpuidValues,
+    ) -> CpuidMapInsertResult {
+        self.map.insert(ident, values)
+    }
+
+    /// See [`CpuidMap::get`].
+    pub fn get(&self, ident: CpuidIdent) -> Option<&CpuidValues> {
+        self.map.get(ident)
+    }
+
+    /// See [`CpuidMap::get_mut`].
+    pub fn get_mut(&mut self, ident: CpuidIdent) -> Option<&mut CpuidValues> {
+        self.map.get_mut(ident)
+    }
+
+    /// See [`CpuidMap::remove_leaf`].
+    pub fn remove_leaf(&mut self, leaf: u32) {
+        self.map.remove_leaf(leaf);
+    }
+
+    /// See [`CpuidMap::is_empty`].
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// See [`CpuidMap::iter`].
+    pub fn iter(&self) -> CpuidMapIterator {
+        self.map.iter()
+    }
+
     /// Returns `Ok` if `self` is equivalent to `other`; if not, returns a
-    /// [`CpuidMapMismatch`] describing the difference between the maps.
-    pub fn is_equivalent(&self, other: &Self) -> Result<(), CpuidMapMismatch> {
-        let this_set: BTreeSet<_> = self.0.keys().collect();
-        let other_set: BTreeSet<_> = other.0.keys().collect();
+    /// [`CpuidMapMismatch`] describing the first observed difference between
+    /// the two sets.
+    pub fn is_equivalent_to(
+        &self,
+        other: &Self,
+    ) -> Result<(), CpuidSetMismatch> {
+        if self.vendor != other.vendor {
+            return Err(CpuidSetMismatch::Vendor {
+                this: self.vendor,
+                other: other.vendor,
+            });
+        }
+
+        let this_set: BTreeSet<_> =
+            self.map.iter().map(|(ident, _)| ident).collect();
+        let other_set: BTreeSet<_> =
+            other.map.iter().map(|(ident, _)| ident).collect();
         let diff = this_set.symmetric_difference(&other_set);
-        let diff: Vec<CpuidIdent> = diff.copied().copied().collect();
+        let diff: Vec<CpuidIdent> = diff.copied().collect();
 
         if !diff.is_empty() {
-            return Err(CpuidMapMismatch::MismatchedLeaves(diff));
+            return Err(CpuidSetMismatch::LeafSet(diff));
         }
 
         let mut mismatches = vec![];
-        for (this_leaf, this_value) in self.0.iter() {
+        for (this_leaf, this_value) in self.map.iter() {
             let other_value = other
-                .0
+                .map
                 .get(this_leaf)
                 .expect("key sets were already found to be equal");
 
-            if this_value != other_value {
-                mismatches.push((*this_leaf, *this_value, *other_value));
+            if this_value != *other_value {
+                mismatches.push((this_leaf, this_value, *other_value));
             }
         }
 
         if !mismatches.is_empty() {
-            Err(CpuidMapMismatch::MismatchedValues(mismatches))
+            Err(CpuidSetMismatch::Values(mismatches))
         } else {
             Ok(())
         }
     }
+}
+
+impl From<CpuidSet> for Vec<bhyve_api::vcpu_cpuid_entry> {
+    fn from(value: CpuidSet) -> Self {
+        let mut out = Vec::with_capacity(value.map.len());
+        out.extend(value.map.iter().map(|(ident, leaf)| {
+            let vce_flags = match ident.subleaf.as_ref() {
+                Some(_) => bhyve_api::VCE_FLAG_MATCH_INDEX,
+                None => 0,
+            };
+            bhyve_api::vcpu_cpuid_entry {
+                vce_function: ident.leaf,
+                vce_index: ident.subleaf.unwrap_or(0),
+                vce_flags,
+                vce_eax: leaf.eax,
+                vce_ebx: leaf.ebx,
+                vce_ecx: leaf.ecx,
+                vce_edx: leaf.edx,
+                ..Default::default()
+            }
+        }));
+        out
+    }
+}
+
+/// An error that can occur when converting a list of CPUID entries in an
+/// instance spec into a [`CpuidMap`].
+#[derive(Debug, Error)]
+pub enum CpuidMapConversionError {
+    #[error("duplicate leaf and subleaf ({0:x}, {1:?})")]
+    DuplicateLeaf(u32, Option<u32>),
+
+    #[error("leaf {0:x} not in standard or extended range")]
+    LeafOutOfRange(u32),
+
+    #[error(transparent)]
+    SubleafConflict(#[from] SubleafInsertConflict),
 }
 
 /// The range of standard, architecturally-defined CPUID leaves.
@@ -100,25 +560,168 @@ pub fn host_query(leaf: CpuidIdent) -> CpuidValues {
 ///
 /// Panics if the target architecture is not x86-64.
 pub fn host_query_all() -> CpuidMap {
-    let mut map = BTreeMap::new();
+    let mut map = CpuidMap::default();
     let leaf_0 = CpuidIdent::leaf(*STANDARD_LEAVES.start());
     let leaf_0_values = host_query(leaf_0);
-    map.insert(leaf_0, leaf_0_values);
+    map.insert(leaf_0, leaf_0_values).unwrap();
 
     for l in (STANDARD_LEAVES.start() + 1)..=leaf_0_values.eax {
         let leaf = CpuidIdent::leaf(l);
-        map.insert(leaf, host_query(leaf));
+        map.insert(leaf, host_query(leaf)).unwrap();
     }
 
     // This needs to be done by hand because the `__get_cpuid_max` intrinsic
     // only returns the maximum standard leaf.
     let ext_leaf_0 = CpuidIdent::leaf(*EXTENDED_LEAVES.start());
     let ext_leaf_0_values = host_query(ext_leaf_0);
-    map.insert(ext_leaf_0, ext_leaf_0_values);
+    map.insert(ext_leaf_0, ext_leaf_0_values).unwrap();
     for l in (EXTENDED_LEAVES.start() + 1)..=ext_leaf_0_values.eax {
         let leaf = CpuidIdent::leaf(l);
-        map.insert(leaf, host_query(leaf));
+        map.insert(leaf, host_query(leaf)).unwrap();
     }
 
-    CpuidMap(map)
+    map
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn insert_leaf_then_subleaf_fails() {
+        let mut map = CpuidMap::default();
+        assert_eq!(
+            map.insert(CpuidIdent::leaf(0), CpuidValues::default()).unwrap(),
+            None
+        );
+
+        map.insert(CpuidIdent::subleaf(0, 0), CpuidValues::default())
+            .unwrap_err();
+    }
+
+    #[test]
+    fn insert_subleaf_then_leaf_fails() {
+        let mut map = CpuidMap::default();
+        assert_eq!(
+            map.insert(CpuidIdent::subleaf(0, 0), CpuidValues::default())
+                .unwrap(),
+            None
+        );
+
+        map.insert(CpuidIdent::leaf(0), CpuidValues::default()).unwrap_err();
+    }
+
+    #[test]
+    fn insert_leaf_then_remove_then_insert_subleaf() {
+        let mut map = CpuidMap::default();
+        let values = CpuidValues { eax: 1, ebx: 2, ecx: 3, edx: 4 };
+        assert_eq!(map.insert(CpuidIdent::leaf(0), values).unwrap(), None);
+
+        map.insert(CpuidIdent::subleaf(0, 1), values).unwrap_err();
+        assert_eq!(map.remove(CpuidIdent::leaf(0)).unwrap(), values);
+        assert_eq!(
+            map.insert(CpuidIdent::subleaf(0, 1), CpuidValues::default())
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn insert_multiple_subleaves() {
+        let mut map = CpuidMap::default();
+        let values = CpuidValues { eax: 1, ebx: 2, ecx: 3, edx: 4 };
+        for subleaf in 0..10 {
+            assert_eq!(
+                map.insert(CpuidIdent::subleaf(0, subleaf), values).unwrap(),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn leaf_subleaf_removal() {
+        let mut map = CpuidMap::default();
+
+        // Add some leaves (0-2) with no subleaves.
+        for leaf in 0..3 {
+            assert_eq!(
+                map.insert(CpuidIdent::leaf(leaf), CpuidValues::default())
+                    .unwrap(),
+                None
+            );
+        }
+
+        // Add some leaves (3-5) with subleaves.
+        for leaf in 3..6 {
+            for subleaf in 6..9 {
+                assert_eq!(
+                    map.insert(
+                        CpuidIdent::subleaf(leaf, subleaf),
+                        CpuidValues {
+                            eax: leaf,
+                            ebx: subleaf,
+                            ..Default::default()
+                        }
+                    )
+                    .unwrap(),
+                    None
+                );
+            }
+        }
+
+        // One entry for each of leaves 0-2 and three entries each for 3-5.
+        let mut len = map.len();
+        assert_eq!(len, 3 + (3 * 3));
+
+        // Manually remove all of leaf 5's subleaves.
+        for subleaf in 6..9 {
+            assert_eq!(
+                map.remove(CpuidIdent::subleaf(5, subleaf)).unwrap(),
+                CpuidValues { eax: 5, ebx: subleaf, ..Default::default() }
+            );
+
+            len -= 1;
+            assert_eq!(map.len(), len);
+        }
+
+        // Leaf 5 should no longer be in the map in any of its guises.
+        assert_eq!(map.get(CpuidIdent::leaf(5)), None);
+        for subleaf in 6..9 {
+            assert_eq!(map.get(CpuidIdent::subleaf(5, subleaf)), None);
+        }
+
+        // Removing leaves 3 and 4 without specifying their subleaves should
+        // fail.
+        assert_eq!(map.remove(CpuidIdent::leaf(3)), None);
+        assert_eq!(map.remove(CpuidIdent::leaf(4)), None);
+        assert_eq!(map.len(), len);
+
+        // Remove leaf 3 and its subleaves via `remove_leaf`.
+        map.remove_leaf(3);
+        len -= 3;
+        assert_eq!(map.len(), len);
+
+        // Remove leaf 4 via `retain_by_leaf`.
+        map.retain_by_leaf(|leaf| leaf != 4);
+        len -= 3;
+        assert_eq!(map.len(), len);
+
+        // Removing leaf 0, subleaf 0 should fail.
+        assert_eq!(map.remove(CpuidIdent::subleaf(0, 0)), None);
+
+        // Remove leaves 0-2 by their IDs.
+        for leaf in 0..3 {
+            assert!(map.remove(CpuidIdent::leaf(leaf)).is_some());
+            len -= 1;
+            assert_eq!(map.len(), len);
+        }
+
+        assert_eq!(len, 0);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn map_iteration() {
+        todo!()
+    }
 }

--- a/crates/cpuid-utils/src/lib.rs
+++ b/crates/cpuid-utils/src/lib.rs
@@ -358,7 +358,7 @@ impl Iterator for CpuidMapIterator<'_> {
 #[derive(Clone, Debug)]
 pub struct CpuidSet {
     map: CpuidMap,
-    pub vendor: CpuidVendor,
+    vendor: CpuidVendor,
 }
 
 impl Default for CpuidSet {
@@ -401,6 +401,11 @@ impl CpuidSet {
         vendor: CpuidVendor,
     ) -> Result<Self, SubleafInsertConflict> {
         Ok(Self { map, vendor })
+    }
+
+    /// Yields this set's vendor.
+    pub fn vendor(&self) -> CpuidVendor {
+        self.vendor
     }
 
     /// Executes the CPUID instruction on the current machine to determine its

--- a/lib/propolis/src/vcpu.rs
+++ b/lib/propolis/src/vcpu.rs
@@ -172,7 +172,7 @@ impl Vcpu {
                 self.hdl.ioctl(bhyve_api::VM_SET_CPUID, &mut config)?;
             }
         } else {
-            if values.vendor.is_intel() {
+            if values.vendor().is_intel() {
                 config.vvcc_flags |= bhyve_api::VCC_FLAG_INTEL_FALLBACK;
             }
             let mut entries: Vec<bhyve_api::vcpu_cpuid_entry> = values.into();
@@ -757,7 +757,7 @@ pub mod migrate {
     }
     impl From<CpuidSet> for CpuidV1 {
         fn from(value: CpuidSet) -> Self {
-            let vendor = value.vendor.into();
+            let vendor = value.vendor().into();
             let entries: Vec<_> = value
                 .iter()
                 .map(|(k, v)| CpuidEntV1 {

--- a/lib/propolis/src/vcpu.rs
+++ b/lib/propolis/src/vcpu.rs
@@ -43,8 +43,8 @@ pub enum GetCpuidError {
     #[error("failed to build a map of CPUID entries")]
     MapConversion(#[from] CpuidMapConversionError),
 
-    #[error("failed to convert CPUID values to vendor string: {0}")]
-    VendorConversionFailed(&'static str),
+    #[error("unsupported CPUID vendor string: {0}")]
+    UnsupportedVendor(&'static str),
 }
 
 /// A handle to a virtual CPU.
@@ -233,7 +233,7 @@ impl Vcpu {
             let vendor = CpuidVendor::try_from(cpuid_utils::host_query(
                 CpuidIdent::leaf(0),
             ))
-            .map_err(GetCpuidError::VendorConversionFailed)?;
+            .map_err(GetCpuidError::UnsupportedVendor)?;
 
             return Ok(CpuidSet::new(vendor));
         }
@@ -1323,7 +1323,7 @@ pub mod migrate {
                     std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
                         format!(
-                            "error reading CPUID for vCPU {}: {:?}",
+                            "error reading CPUID for vCPU {}: {}",
                             vcpu.id, e
                         ),
                     )

--- a/phd-tests/tests/src/cpuid.rs
+++ b/phd-tests/tests/src/cpuid.rs
@@ -58,10 +58,10 @@ async fn cpuid_boot_test(ctx: &Framework) {
     // host's CPUID leaves, then filter to just a handful of leaves that
     // advertise features to the guest (and that Linux guests will check for
     // during boot).
-    let mut host_cpuid = cpuid_utils::host_query_all().0;
+    let mut host_cpuid = cpuid_utils::host_query_all();
     info!(?host_cpuid, "read host CPUID");
     let leaf_0_values = *host_cpuid
-        .get(&CpuidIdent::leaf(0))
+        .get(CpuidIdent::leaf(0))
         .expect("host CPUID leaf 0 should always be present");
 
     // Linux guests expect to see at least a couple of leaves in the extended
@@ -82,13 +82,12 @@ async fn cpuid_boot_test(ctx: &Framework) {
     // Keep only standard leaves up to 7 and the first two extended leaves.
     // Extended leaves 2 through 4 will be overwritten with a fake brand string
     // (see below).
-    host_cpuid.retain(|leaf, _values| {
-        leaf.leaf <= 0x7
-            || (leaf.leaf >= 0x8000_0000 && leaf.leaf <= 0x8000_0001)
+    host_cpuid.retain_by_leaf(|leaf| {
+        leaf <= 0x7 || (0x8000_0000..=0x8000_0001).contains(&leaf)
     });
 
     // Report that leaf 7 is the last available standard leaf.
-    host_cpuid.get_mut(&CpuidIdent::leaf(0)).unwrap().eax = 7;
+    host_cpuid.get_mut(CpuidIdent::leaf(0)).unwrap().eax = 7;
 
     // Mask off bits that a minimum-viable Oxide platform doesn't support or
     // can't (or won't) expose to guests. See RFD 314 for further discussion of
@@ -97,11 +96,11 @@ async fn cpuid_boot_test(ctx: &Framework) {
     // These are masks (and not assignments) so that, if the host processor
     // doesn't support a feature contained in an `ALL_FLAGS` value, the
     // feature will not be enabled in the guest.
-    let leaf_1 = host_cpuid.get_mut(&CpuidIdent::leaf(1)).unwrap();
+    let leaf_1 = host_cpuid.get_mut(CpuidIdent::leaf(1)).unwrap();
     leaf_1.ecx &=
         (Leaf1Ecx::ALL_FLAGS & !(Leaf1Ecx::OSXSAVE | Leaf1Ecx::MONITOR)).bits();
     leaf_1.edx &= Leaf1Edx::ALL_FLAGS.bits();
-    let leaf_7 = host_cpuid.get_mut(&CpuidIdent::leaf(7)).unwrap();
+    let leaf_7 = host_cpuid.get_mut(CpuidIdent::leaf(7)).unwrap();
     leaf_7.eax = 0;
     leaf_7.ebx &= (Leaf7Sub0Ebx::ALL_FLAGS
         & !(Leaf7Sub0Ebx::PQM
@@ -114,10 +113,9 @@ async fn cpuid_boot_test(ctx: &Framework) {
 
     // Report that leaf 0x8000_0004 is the last extended leaf and clean up
     // feature bits in leaf 0x8000_0001.
-    host_cpuid.get_mut(&CpuidIdent::leaf(0x8000_0000)).unwrap().eax =
+    host_cpuid.get_mut(CpuidIdent::leaf(0x8000_0000)).unwrap().eax =
         0x8000_0004;
-    let ext_leaf_1 =
-        host_cpuid.get_mut(&CpuidIdent::leaf(0x8000_0001)).unwrap();
+    let ext_leaf_1 = host_cpuid.get_mut(CpuidIdent::leaf(0x8000_0001)).unwrap();
     ext_leaf_1.ecx &= (AmdExtLeaf1Ecx::ALT_MOV_CR8
         | AmdExtLeaf1Ecx::ABM
         | AmdExtLeaf1Ecx::SSE4A
@@ -147,9 +145,9 @@ async fn cpuid_boot_test(ctx: &Framework) {
         *dst = u32::from_le_bytes(chunk.try_into().unwrap());
     }
 
-    host_cpuid.insert(CpuidIdent::leaf(0x8000_0002), ext_leaf_2);
-    host_cpuid.insert(CpuidIdent::leaf(0x8000_0003), ext_leaf_3);
-    host_cpuid.insert(CpuidIdent::leaf(0x8000_0004), ext_leaf_4);
+    host_cpuid.insert(CpuidIdent::leaf(0x8000_0002), ext_leaf_2).unwrap();
+    host_cpuid.insert(CpuidIdent::leaf(0x8000_0003), ext_leaf_3).unwrap();
+    host_cpuid.insert(CpuidIdent::leaf(0x8000_0004), ext_leaf_4).unwrap();
 
     // Try to boot a guest with the computed CPUID values. The modified brand
     // string should show up in /proc/cpuinfo.


### PR DESCRIPTION
Move the functionality in `propolis::cpuid::Set` into `cpuid_utils`, then tidy it up a bit by removing its `for_regs` and `into_inner` functions (the former was dead code and the latter is no longer needed).

Rework `CpuidMap` to prevent callers from using both `CpuidIdent { leaf: x, subleaf: None }` and `CpuidIdent { leaf: x, subleaf: Some(y) }` as keys in the same map (does CPUID with eax = x ignore the value passed in ecx or not?).[^1] This requires a fair bit of new code to handle insert/remove and iteration. Add tests for these cases, including a property test to verify a larger number of iteration patterns than we could hope to write by hand.

Finally, add a theory statement and some additional function documentation to the `cpuid_utils` crate.

[^1]: In practice the behavior depends on the order in which the conflicting entries appear in the `vcpu_cpuid_entry` array that Propolis passes to bhyve (the first one to match an incoming CPUID request wins); see bhyve's `cpuid_find_entry`.