### PR TITLE
add a test about boot option descriptions

### DIFF
--- a/phd-tests/tests/src/boot_order.rs
+++ b/phd-tests/tests/src/boot_order.rs
@@ -525,6 +525,9 @@ async fn nvme_boot_option_description(ctx: &Framework) {
     cfg.boot_order(vec!["boot-disk", "nvme-test-disk"]);
 
     let mut vm = ctx.spawn_vm(&cfg, None).await?;
+    if !vm.guest_os_kind().is_linux() {
+        phd_skip!("boot option description test depends on efivarfs");
+    }
     vm.launch().await?;
     vm.wait_to_boot().await?;
 


### PR DESCRIPTION
ensuring we don't inflict [Omicron#5112](https://github.com/oxidecomputer/omicron/issues/5112) on instances due to our own changes: boot option descriptions are load-bearing, so if we've changed them make sure we think through the consequences. i'm pleasantly surprised that `EfiLoadOption` just.. worked here. yay.

the procedure that gets us names we see for guest disks today is a bit subtle, but i've tried to document it fully to pair with the expectation in this test.

there are also specific conditions where failing this assertion is fine - say, if we've done https://github.com/oxidecomputer/propolis/issues/787, or changed how we're processing UEFI boot variables. just, as things are right now, we're surprisingly dependent on dancing with OVMF in exactly the same way every time a guest boots.