### PR TITLE
add marker trait to help check safety of guest memory reads

### DIFF
--- a/lib/propolis/src/hw/nvme/bits.rs
+++ b/lib/propolis/src/hw/nvme/bits.rs
@@ -5,11 +5,12 @@
 #![allow(dead_code)]
 
 use bitstruct::bitstruct;
+use zerocopy::{FromBytes, FromZeroes};
 
 /// A Submission Queue Entry as represented in memory.
 ///
 /// See NVMe 1.0e Section 4.2 Submission Queue Entry - Command Format
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone, FromBytes, FromZeroes)]
 #[repr(C, packed(1))]
 pub struct SubmissionQueueEntry {
     /// Command Dword 0 (CDW0)
@@ -85,9 +86,6 @@ pub struct SubmissionQueueEntry {
     /// A command specific value.
     pub cdw15: u32,
 }
-
-/// Safety: all fields of SubmissionQueueEntry are valid for all bit patterns.
-unsafe impl crate::vmm::AlwaysInhabited for SubmissionQueueEntry {}
 
 impl SubmissionQueueEntry {
     /// Returns the Identifier (CID) of this Submission Queue Entry.

--- a/lib/propolis/src/hw/nvme/bits.rs
+++ b/lib/propolis/src/hw/nvme/bits.rs
@@ -86,6 +86,9 @@ pub struct SubmissionQueueEntry {
     pub cdw15: u32,
 }
 
+/// Safety: all fields of SubmissionQueueEntry are valid for all bit patterns.
+unsafe impl crate::vmm::AlwaysInhabited for SubmissionQueueEntry {}
+
 impl SubmissionQueueEntry {
     /// Returns the Identifier (CID) of this Submission Queue Entry.
     ///

--- a/lib/propolis/src/hw/qemu/fwcfg.rs
+++ b/lib/propolis/src/hw/qemu/fwcfg.rs
@@ -815,7 +815,7 @@ mod bits {
     use zerocopy::byteorder::big_endian::{
         U16 as BE16, U32 as BE32, U64 as BE64,
     };
-    use zerocopy::AsBytes;
+    use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
     pub const FW_CFG_IOP_SELECTOR: u16 = 0x0510;
     pub const FW_CFG_IOP_DATA: u16 = 0x0511;
@@ -867,18 +867,13 @@ mod bits {
         }
     }
 
-    #[derive(AsBytes, Default, Copy, Clone, Debug)]
+    #[derive(AsBytes, Default, Copy, Clone, Debug, FromBytes, FromZeroes)]
     #[repr(C)]
     pub struct FwCfgDmaAccess {
         pub ctrl: BE32,
         pub len: BE32,
         pub addr: BE64,
     }
-
-    /// Safety: all fields of FwCfgDmaAccess are valid for all bit patterns.
-    ///
-    /// They're just big-endian instead of little-endian.
-    unsafe impl crate::vmm::AlwaysInhabited for FwCfgDmaAccess {}
 }
 
 #[cfg(test)]

--- a/lib/propolis/src/hw/qemu/fwcfg.rs
+++ b/lib/propolis/src/hw/qemu/fwcfg.rs
@@ -874,6 +874,11 @@ mod bits {
         pub len: BE32,
         pub addr: BE64,
     }
+
+    /// Safety: all fields of FwCfgDmaAccess are valid for all bit patterns.
+    ///
+    /// They're just big-endian instead of little-endian.
+    unsafe impl crate::vmm::AlwaysInhabited for FwCfgDmaAccess {}
 }
 
 #[cfg(test)]

--- a/lib/propolis/src/hw/virtio/queue.rs
+++ b/lib/propolis/src/hw/virtio/queue.rs
@@ -25,6 +25,8 @@ struct VqdDesc {
     flags: u16,
     next: u16,
 }
+/// Safety: all fields of VqdDesc are valid for all bit patterns
+unsafe impl crate::vmm::AlwaysInhabited for VqdDesc {}
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 struct VqdUsed {

--- a/lib/propolis/src/hw/virtio/queue.rs
+++ b/lib/propolis/src/hw/virtio/queue.rs
@@ -17,16 +17,16 @@ use crate::common::*;
 use crate::migrate::MigrateStateError;
 use crate::vmm::MemCtx;
 
+use zerocopy::{FromBytes, FromZeroes};
+
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, FromBytes, FromZeroes)]
 struct VqdDesc {
     addr: u64,
     len: u32,
     flags: u16,
     next: u16,
 }
-/// Safety: all fields of VqdDesc are valid for all bit patterns
-unsafe impl crate::vmm::AlwaysInhabited for VqdDesc {}
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 struct VqdUsed {


### PR DESCRIPTION
we noted that a pointer into guest memory must point to a properly-initialized T when read into Propolis, but there was no way to actually check that was a case. for example, it may be tempting to write an enum describing states of a guest device like:
```
enum MyCoolDevicePower {
  Off = 0,
  On = 1,
}
```
and read/write to guest memory using the convenient read/write helpers. but a devious guest could put a `2` at that address, where reading that into Propolis would be UB.

`zerocopy::FromBytes` happens to have the same requirements about its implementors as we need, that they're always valid to view from bytes, so use it to check that we can safely read a type out of guest memory. in our case we'll always copy those bytes to our own buffer, but `zerocopy::FromBytes` also comes with a great proc macro so we can [`#[derive(FromBytes)]`](https://docs.rs/zerocopy/latest/zerocopy/derive.FromBytes.html) on structs to be copied out.