### PR TITLE
clippy fixes for 1.82

### DIFF
--- a/phd-tests/framework/src/test_vm/spec.rs
+++ b/phd-tests/framework/src/test_vm/spec.rs
@@ -48,13 +48,12 @@ impl VmSpec {
             let backend_spec = disk.backend_spec();
             let backend_name =
                 disk.device_name().clone().into_backend_name().into_string();
-            match self.instance_spec.components.get(&backend_name) {
-                Some(ComponentV0::CrucibleStorageBackend(_)) => {
-                    self.instance_spec
-                        .components
-                        .insert(backend_name, backend_spec);
-                }
-                Some(_) | None => {}
+            if let Some(ComponentV0::CrucibleStorageBackend(_)) =
+                self.instance_spec.components.get(&backend_name)
+            {
+                self.instance_spec
+                    .components
+                    .insert(backend_name, backend_spec);
             }
         }
     }


### PR DESCRIPTION
Tests: verified with `cargo check` that PHD still builds with 1.80 and 1.81.