### PR TITLE
api: clean up Instance and InstanceProperties types

### DIFF
--- a/bin/mock-server/src/lib/lib.rs
+++ b/bin/mock-server/src/lib/lib.rs
@@ -232,8 +232,6 @@ async fn instance_get(
     let instance_info = api::Instance {
         properties: instance.properties.clone(),
         state: instance.state,
-        disks: vec![],
-        nics: vec![],
     };
     Ok(HttpResponseOk(api::InstanceGetResponse { instance: instance_info }))
 }

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -376,8 +376,6 @@ async fn instance_get(
             instance: api::Instance {
                 properties: full.properties,
                 state: full.state,
-                disks: vec![],
-                nics: vec![],
             },
         })
     })

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -117,7 +117,7 @@ fn instance_spec_from_request(
     request: &api::InstanceEnsureRequest,
     toml_config: &VmTomlConfig,
 ) -> Result<Spec, SpecBuilderError> {
-    let mut spec_builder = SpecBuilder::new(&request.properties);
+    let mut spec_builder = SpecBuilder::new(request.vcpus, request.memory);
 
     spec_builder.add_devices_from_config(toml_config)?;
 

--- a/bin/propolis-server/src/lib/spec/builder.rs
+++ b/bin/propolis-server/src/lib/spec/builder.rs
@@ -15,7 +15,7 @@ use propolis_api_types::{
         },
         PciPath,
     },
-    DiskRequest, InstanceProperties, NetworkInterfaceRequest,
+    DiskRequest, NetworkInterfaceRequest,
 };
 use thiserror::Error;
 
@@ -78,10 +78,10 @@ pub(crate) struct SpecBuilder {
 }
 
 impl SpecBuilder {
-    pub fn new(properties: &InstanceProperties) -> Self {
+    pub fn new(cpus: u8, memory_mb: u64) -> Self {
         let board = Board {
-            cpus: properties.vcpus,
-            memory_mb: properties.memory,
+            cpus,
+            memory_mb,
             chipset: Chipset::I440Fx(I440Fx { enable_pcie: false }),
         };
 
@@ -455,7 +455,7 @@ mod test {
             backends::{BlobStorageBackend, VirtioNetworkBackend},
             devices::{VirtioDisk, VirtioNic},
         },
-        InstanceMetadata, Slot, VolumeConstructionRequest,
+        Slot, VolumeConstructionRequest,
     };
     use uuid::Uuid;
 
@@ -463,28 +463,8 @@ mod test {
 
     use super::*;
 
-    fn test_metadata() -> InstanceMetadata {
-        InstanceMetadata {
-            silo_id: uuid::uuid!("556a67f8-8b14-4659-bd9f-d8f85ecd36bf"),
-            project_id: uuid::uuid!("75f60038-daeb-4a1d-916a-5fa5b7237299"),
-            sled_id: uuid::uuid!("43a789ac-a0dd-4e1e-ac33-acdada142faa"),
-            sled_serial: "some-gimlet".into(),
-            sled_revision: 1,
-            sled_model: "abcd".into(),
-        }
-    }
-
     fn test_builder() -> SpecBuilder {
-        SpecBuilder::new(&InstanceProperties {
-            id: Default::default(),
-            name: Default::default(),
-            description: Default::default(),
-            metadata: test_metadata(),
-            image_id: Default::default(),
-            bootrom_id: Default::default(),
-            memory: 512,
-            vcpus: 4,
-        })
+        SpecBuilder::new(4, 512)
     }
 
     #[test]

--- a/bin/propolis-server/src/lib/stats/network_interface.rs
+++ b/bin/propolis-server/src/lib/stats/network_interface.rs
@@ -151,7 +151,7 @@ impl InstanceNetworkInterfaces {
     /// metrics from.
     #[cfg(all(not(test), target_os = "illumos"))]
     pub(crate) fn new(
-        properties: &propolis_api_types::InstanceProperties,
+        virtual_machine: &super::VirtualMachine,
         interface_ids: &NetworkInterfaceIds,
     ) -> Self {
         Self {
@@ -160,9 +160,9 @@ impl InstanceNetworkInterfaces {
                 // multiple targets in the `to_samples` method and override
                 // this.
                 interface_id: uuid::Uuid::nil(),
-                instance_id: properties.id,
-                project_id: properties.metadata.project_id,
-                silo_id: properties.metadata.silo_id,
+                instance_id: virtual_machine.target.instance_id,
+                project_id: virtual_machine.target.project_id,
+                silo_id: virtual_machine.target.silo_id,
             },
             interface_ids: interface_ids.to_vec(),
         }

--- a/bin/propolis-server/src/lib/stats/virtual_machine.rs
+++ b/bin/propolis-server/src/lib/stats/virtual_machine.rs
@@ -61,8 +61,11 @@ pub struct VirtualMachine {
     vm_name: String,
 }
 
-impl From<&propolis_api_types::InstanceProperties> for VirtualMachine {
-    fn from(properties: &propolis_api_types::InstanceProperties) -> Self {
+impl VirtualMachine {
+    pub fn new(
+        n_vcpus: u8,
+        properties: &propolis_api_types::InstanceProperties,
+    ) -> Self {
         Self {
             target: VirtualMachineTarget {
                 silo_id: properties.metadata.silo_id,
@@ -73,7 +76,7 @@ impl From<&propolis_api_types::InstanceProperties> for VirtualMachine {
                 sled_revision: properties.metadata.sled_revision,
                 sled_serial: properties.metadata.sled_serial.clone().into(),
             },
-            n_vcpus: properties.vcpus.into(),
+            n_vcpus: u32::from(n_vcpus),
             vm_name: properties.vm_name(),
         }
     }

--- a/bin/propolis-server/src/lib/vm/services.rs
+++ b/bin/propolis-server/src/lib/vm/services.rs
@@ -14,6 +14,7 @@ use slog::{error, info, Logger};
 use crate::{
     serial::SerialTaskControlMessage,
     server::MetricsEndpointConfig,
+    spec::Spec,
     stats::{ServerStats, VirtualMachine},
     vnc::VncServer,
 };
@@ -56,16 +57,23 @@ impl VmServices {
         vm_properties: &InstanceProperties,
         ensure_options: &super::EnsureOptions,
     ) -> Self {
+        let vm_objects = vm_objects.lock_shared().await;
         let oximeter_state = if let Some(cfg) = &ensure_options.metrics_config {
             let registry = ensure_options.oximeter_registry.as_ref().expect(
                 "should have a producer registry if metrics are configured",
             );
-            register_oximeter_producer(log, cfg, registry, vm_properties).await
+            register_oximeter_producer(
+                log,
+                cfg,
+                registry,
+                vm_objects.instance_spec(),
+                vm_properties,
+            )
+            .await
         } else {
             OximeterState::default()
         };
 
-        let vm_objects = vm_objects.lock_shared().await;
         let vnc_server = ensure_options.vnc_server.clone();
         if let Some(ramfb) = vm_objects.framebuffer() {
             vnc_server.attach(vm_objects.ps2ctrl().clone(), ramfb.clone());
@@ -110,10 +118,11 @@ async fn register_oximeter_producer(
     log: &slog::Logger,
     cfg: &MetricsEndpointConfig,
     registry: &ProducerRegistry,
+    spec: &Spec,
     vm_properties: &InstanceProperties,
 ) -> OximeterState {
     let mut oximeter_state = OximeterState::default();
-    let virtual_machine = VirtualMachine::from(vm_properties);
+    let virtual_machine = VirtualMachine::new(spec.board.cpus, vm_properties);
 
     // Create the server itself.
     //

--- a/crates/propolis-api-types/src/lib.rs
+++ b/crates/propolis-api-types/src/lib.rs
@@ -237,8 +237,6 @@ impl InstanceProperties {
 pub struct Instance {
     pub properties: InstanceProperties,
     pub state: InstanceState,
-    pub disks: Vec<DiskAttachment>,
-    pub nics: Vec<NetworkInterface>,
 }
 
 /// Request a specific range of an Instance's serial console output history.
@@ -338,27 +336,6 @@ pub struct Disk {
     pub interface: DiskType,
 }
 
-// TODO: Struggling to make this struct derive "JsonSchema"
-/*
-bitflags! {
-    #[derive(Deserialize, Serialize)]
-    pub struct DiskFlags: u32 {
-        const READ = 0b0000_0001;
-        const WRITE = 0b0000_0010;
-        const READ_WRITE = Self::READ.bits | Self::WRITE.bits;
-    }
-}
-*/
-
-// TODO: Remove this; it's a hack to workaround the above bug.
-#[allow(dead_code)]
-pub const DISK_FLAG_READ: u32 = 0b0000_0001;
-#[allow(dead_code)]
-pub const DISK_FLAG_WRITE: u32 = 0b0000_0010;
-#[allow(dead_code)]
-pub const DISK_FLAG_READ_WRITE: u32 = DISK_FLAG_READ | DISK_FLAG_WRITE;
-type DiskFlags = u32;
-
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct DiskRequest {
     pub name: String,
@@ -371,27 +348,6 @@ pub struct DiskRequest {
         crucible_client_types::VolumeConstructionRequest,
 }
 
-#[derive(Clone, Deserialize, Serialize, JsonSchema)]
-pub struct DiskAttachmentInfo {
-    pub flags: DiskFlags,
-    pub slot: u16,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub enum DiskAttachmentState {
-    Attached(Uuid),
-    Detached,
-    Destroyed,
-    Faulted,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct DiskAttachment {
-    pub generation_id: u64,
-    pub disk_id: Uuid,
-    pub state: DiskAttachmentState,
-}
-
 /// A stable index which is translated by Propolis
 /// into a PCI BDF, visible to the guest.
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, JsonSchema)]
@@ -402,19 +358,6 @@ pub struct NetworkInterfaceRequest {
     pub interface_id: Uuid,
     pub name: String,
     pub slot: Slot,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub struct NetworkInterface {
-    pub name: String,
-    pub attachment: NetworkInterfaceAttachmentState,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-pub enum NetworkInterfaceAttachmentState {
-    Attached(Slot),
-    Detached,
-    Faulted,
 }
 
 #[derive(Deserialize, JsonSchema)]

--- a/crates/propolis-api-types/src/lib.rs
+++ b/crates/propolis-api-types/src/lib.rs
@@ -52,6 +52,12 @@ pub struct InstanceMetadata {
 pub struct InstanceEnsureRequest {
     pub properties: InstanceProperties,
 
+    /// Number of vCPUs to be allocated to the Instance.
+    pub vcpus: u8,
+
+    /// Size of memory allocated to the Instance, in MiB.
+    pub memory: u64,
+
     #[serde(default)]
     pub nics: Vec<NetworkInterfaceRequest>,
 
@@ -218,14 +224,6 @@ pub struct InstanceProperties {
     pub description: String,
     /// Metadata used to track statistics for this Instance.
     pub metadata: InstanceMetadata,
-    /// ID of the image used to initialize this Instance.
-    pub image_id: Uuid,
-    /// ID of the bootrom used to initialize this Instance.
-    pub bootrom_id: Uuid,
-    /// Size of memory allocated to the Instance, in MiB.
-    pub memory: u64,
-    /// Number of vCPUs to be allocated to the Instance.
-    pub vcpus: u8,
 }
 
 impl InstanceProperties {

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -1228,6 +1228,12 @@
               "$ref": "#/components/schemas/DiskRequest"
             }
           },
+          "memory": {
+            "description": "Size of memory allocated to the Instance, in MiB.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
           "migrate": {
             "nullable": true,
             "allOf": [
@@ -1245,10 +1251,18 @@
           },
           "properties": {
             "$ref": "#/components/schemas/InstanceProperties"
+          },
+          "vcpus": {
+            "description": "Number of vCPUs to be allocated to the Instance.",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
           }
         },
         "required": [
-          "properties"
+          "memory",
+          "properties",
+          "vcpus"
         ]
       },
       "InstanceEnsureResponse": {
@@ -1394,11 +1408,6 @@
       "InstanceProperties": {
         "type": "object",
         "properties": {
-          "bootrom_id": {
-            "description": "ID of the bootrom used to initialize this Instance.",
-            "type": "string",
-            "format": "uuid"
-          },
           "description": {
             "description": "Free-form text description of an Instance.",
             "type": "string"
@@ -1407,17 +1416,6 @@
             "description": "Unique identifier for this Instance.",
             "type": "string",
             "format": "uuid"
-          },
-          "image_id": {
-            "description": "ID of the image used to initialize this Instance.",
-            "type": "string",
-            "format": "uuid"
-          },
-          "memory": {
-            "description": "Size of memory allocated to the Instance, in MiB.",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
           },
           "metadata": {
             "description": "Metadata used to track statistics for this Instance.",
@@ -1430,23 +1428,13 @@
           "name": {
             "description": "Human-readable name of the Instance.",
             "type": "string"
-          },
-          "vcpus": {
-            "description": "Number of vCPUs to be allocated to the Instance.",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
           }
         },
         "required": [
-          "bootrom_id",
           "description",
           "id",
-          "image_id",
-          "memory",
           "metadata",
-          "name",
-          "vcpus"
+          "name"
         ]
       },
       "InstanceSerialConsoleHistoryResponse": {

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -1036,53 +1036,6 @@
         ],
         "additionalProperties": false
       },
-      "DiskAttachment": {
-        "type": "object",
-        "properties": {
-          "disk_id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "generation_id": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "state": {
-            "$ref": "#/components/schemas/DiskAttachmentState"
-          }
-        },
-        "required": [
-          "disk_id",
-          "generation_id",
-          "state"
-        ]
-      },
-      "DiskAttachmentState": {
-        "oneOf": [
-          {
-            "type": "string",
-            "enum": [
-              "Detached",
-              "Destroyed",
-              "Faulted"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "Attached": {
-                "type": "string",
-                "format": "uuid"
-              }
-            },
-            "required": [
-              "Attached"
-            ],
-            "additionalProperties": false
-          }
-        ]
-      },
       "DiskRequest": {
         "type": "object",
         "properties": {
@@ -1179,18 +1132,6 @@
       "Instance": {
         "type": "object",
         "properties": {
-          "disks": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DiskAttachment"
-            }
-          },
-          "nics": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/NetworkInterface"
-            }
-          },
           "properties": {
             "$ref": "#/components/schemas/InstanceProperties"
           },
@@ -1199,8 +1140,6 @@
           }
         },
         "required": [
-          "disks",
-          "nics",
           "properties",
           "state"
         ]
@@ -1609,44 +1548,6 @@
           "Server",
           "Finish",
           "Error"
-        ]
-      },
-      "NetworkInterface": {
-        "type": "object",
-        "properties": {
-          "attachment": {
-            "$ref": "#/components/schemas/NetworkInterfaceAttachmentState"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "attachment",
-          "name"
-        ]
-      },
-      "NetworkInterfaceAttachmentState": {
-        "oneOf": [
-          {
-            "type": "string",
-            "enum": [
-              "Detached",
-              "Faulted"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "Attached": {
-                "$ref": "#/components/schemas/Slot"
-              }
-            },
-            "required": [
-              "Attached"
-            ],
-            "additionalProperties": false
-          }
         ]
       },
       "NetworkInterfaceRequest": {

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -311,10 +311,6 @@ impl TestVm {
             name: format!("phd-vm-{}", self.id),
             metadata: self.spec.metadata.clone(),
             description: "Pheidippides-managed VM".to_string(),
-            image_id: Uuid::default(),
-            bootrom_id: Uuid::default(),
-            memory: memory_mib,
-            vcpus,
         };
 
         // The non-spec ensure interface requires a set of `DiskRequest`
@@ -356,6 +352,8 @@ impl TestVm {
                 InstanceEnsureApi::Ensure => {
                     let ensure_req = InstanceEnsureRequest {
                         cloud_init_bytes: None,
+                        vcpus,
+                        memory: memory_mib,
                         disks: disk_reqs.clone().unwrap(),
                         migrate: migrate.clone(),
                         nics: vec![],


### PR DESCRIPTION
Clean up unused fields and structures in the server API:

- Remove the unused `image_id` and `bootrom_id` fields from `InstanceProperties`.
- Remove the `disks` and `nics` fields from the `Instance` struct returned by an instance GET and all their supporting types. These are also not used today. Callers who are interested in finding out about an instance's disks and NICs can query the instance spec GET endpoint instead.
- Remove the CPU count and memory size fields from `InstanceProperties` and put them in `InstanceEnsureRequest` instead. This eliminates an extra copy of these data in the server (they were available in both the properties and the instance spec; now they're just available in the spec).

N.B. This is a client API breaking change; requiescat, migrate-from-base tests. The live migration protocol is unaffected.

Tests: cargo test; PHD; deployed this change to an Omicron dev cluster and booted some instances there; launched and migrated a VM between local servers using propolis-cli.

Fixes #723.