### PR TITLE
update nvme-trace.d to match current probe definitions

### DIFF
--- a/scripts/nvme-trace.d
+++ b/scripts/nvme-trace.d
@@ -16,8 +16,8 @@ dtrace:::BEGIN
 struct io_info {
     string op;
     uint64_t ts;
-    uint64_t slba;
-    uint16_t nlb;
+    uint64_t offset_bytes;
+    uint64_t size_bytes;
 };
 
 struct io_info io[uint64_t];
@@ -25,24 +25,28 @@ struct io_info io[uint64_t];
 propolis$target:::nvme_read_enqueue,
 propolis$target:::nvme_write_enqueue
 {
-    this->cid = args[0];
+    this->cid = args[2];
     this->op = (probename == "nvme_read_enqueue") ? "read" : "write";
     io[this->cid].op = this->op;
     io[this->cid].ts = timestamp;
-    io[this->cid].slba = args[1];
-    io[this->cid].nlb = args[2];
+    io[this->cid].offset_bytes = args[3];
+    io[this->cid].size_bytes = args[4];
 }
 
 propolis$target:::nvme_read_complete,
 propolis$target:::nvme_write_complete
 /io[args[0]].ts != 0/
 {
-    this->cid = args[0];
+    this->cid = args[1];
     this->elapsed = timestamp - io[this->cid].ts;
     this->elapsed_us = this->elapsed / 1000;
     @time[strjoin(io[this->cid].op, " (us)")] = quantize(this->elapsed_us);
-    printf("%s(cid=%u) %d blocks from LBA 0x%x in %uus\n",
-           io[this->cid].op, this->cid, io[this->cid].nlb, io[this->cid].slba, this->elapsed_us);
+    printf("%s(cid=%u) %d bytes from offset 0x%x in %uus\n",
+           io[this->cid].op,
+           this->cid,
+           io[this->cid].size_bytes,
+           io[this->cid].offset_bytes,
+           this->elapsed_us);
 }
 
 dtrace:::END


### PR DESCRIPTION
Tested by running this script ad hoc and making sure the output values looked reasonable.

Fixes #820.