### PR TITLE
add JSON output format to cpuid-gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4466,6 +4466,7 @@ dependencies = [
  "clap",
  "libc",
  "propolis",
+ "propolis_api_types",
  "serde",
  "serde_json",
 ]

--- a/bin/propolis-cli/src/main.rs
+++ b/bin/propolis-cli/src/main.rs
@@ -167,19 +167,19 @@ enum Command {
 #[derive(Args, Clone, Debug)]
 struct VmConfig {
     /// A path to a file containing a JSON-formatted instance spec
-    #[clap(short = 's', long, action)]
+    #[clap(short = 's', long, action, group = "spec_group")]
     spec: Option<PathBuf>,
 
     /// Number of vCPUs allocated to instance
-    #[clap(short = 'c', default_value = "4", action, conflicts_with = "spec")]
+    #[clap(short = 'c', default_value = "4", action, requires = "config_toml")]
     vcpus: u8,
 
     /// Memory allocated to instance (MiB)
-    #[clap(short, default_value = "1024", action, conflicts_with = "spec")]
+    #[clap(short, default_value = "1024", action, requires = "config_toml")]
     memory: u64,
 
     /// A path to a file containing a config TOML
-    #[clap(short = 't', long, action, conflicts_with = "spec")]
+    #[clap(short = 't', long, action, group = "config_group", requires_all = ["vcpus", "memory"])]
     config_toml: Option<PathBuf>,
 
     /// File with a JSON array of DiskRequest structs

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -10,6 +10,7 @@
 //! processing.
 
 use std::convert::TryFrom;
+use std::error::Error;
 use std::net::IpAddr;
 use std::net::Ipv6Addr;
 use std::net::SocketAddr;
@@ -220,10 +221,15 @@ async fn instance_ensure(
     };
 
     let vm_init = match init {
-        InstanceInitializationMethod::Spec { spec } => spec
-            .try_into()
-            .map(VmInitializationMethod::Spec)
-            .map_err(|e| e.to_string()),
+        InstanceInitializationMethod::Spec { spec } => {
+            spec.try_into().map(VmInitializationMethod::Spec).map_err(|e| {
+                if let Some(s) = e.source() {
+                    format!("{e}: {s}")
+                } else {
+                    e.to_string()
+                }
+            })
+        }
         InstanceInitializationMethod::MigrationTarget {
             migration_id,
             src_addr,

--- a/bin/propolis-utils/Cargo.toml
+++ b/bin/propolis-utils/Cargo.toml
@@ -19,6 +19,7 @@ anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 propolis = { workspace = true, default-features = false }
+propolis_api_types.workspace = true
 bhyve_api = { workspace = true }
 libc = { workspace = true }
 serde_json.workspace = true

--- a/bin/propolis-utils/src/bin/cpuid-gen.rs
+++ b/bin/propolis-utils/src/bin/cpuid-gen.rs
@@ -296,6 +296,10 @@ fn print_json(results: &BTreeMap<CpuidKey, Cpuid>) {
         }
     };
 
+    // propolis-server will reject CPUID entry lists that contain a no-subleaf
+    // and a subleaf-bearing entry for the same leaf. Filter these out by
+    // dropping Leaf entries whose immediate successor is a SubLeaf with the
+    // same leaf number.
     let entries = results
         .iter()
         .zip(results.keys().skip(1))

--- a/bin/propolis-utils/src/bin/cpuid-gen.rs
+++ b/bin/propolis-utils/src/bin/cpuid-gen.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use bhyve_api::{VmmCtlFd, VmmFd};
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
 fn create_vm() -> anyhow::Result<VmmFd> {
     let name = format!("cpuid-gen-{}", std::process::id());
@@ -271,7 +271,7 @@ fn print_json(results: &BTreeMap<CpuidKey, Cpuid>) {
         use propolis_api_types::instance_spec::{CpuidValues, CpuidVendor};
         match results.get(&CpuidKey::Leaf(0)) {
             None => {
-                eprintln!("no result for leaf 0, selecting default vendor");
+                eprintln!("no result for leaf 0, setting vendor to AMD");
                 CpuidVendor::Amd
             }
             Some(values) => {
@@ -285,8 +285,8 @@ fn print_json(results: &BTreeMap<CpuidKey, Cpuid>) {
                 match CpuidVendor::try_from(values) {
                     Err(_) => {
                         eprintln!(
-                            "vendor in leaf 0 values ({values:?}) \
-                        not recognized, selecting default vendor"
+                            "vendor in leaf 0 values ({values:?}) not \
+                            recognized, setting vendor to AMD"
                         );
                         CpuidVendor::Amd
                     }
@@ -326,7 +326,7 @@ fn print_json(results: &BTreeMap<CpuidKey, Cpuid>) {
     println!("{}", serde_json::to_string_pretty(&cpuid).unwrap());
 }
 
-#[derive(Default, Clone, Copy, Debug)]
+#[derive(Default, Clone, Copy, Debug, ValueEnum)]
 enum OutputFormat {
     /// Print a human-readable plain-text representation.
     #[default]
@@ -362,8 +362,8 @@ struct Opts {
     #[clap(short)]
     zero_elide: bool,
 
-    /// Emit output in the specified format ("text", "toml", or "json")
-    #[clap(short, long, value_parser, default_value = "text")]
+    /// Emit output in the specified format
+    #[clap(short, long, value_enum, default_value = "text")]
     format: OutputFormat,
 
     /// Query CPU directly, rather that via bhyve masking

--- a/bin/propolis-utils/src/bin/cpuid-gen.rs
+++ b/bin/propolis-utils/src/bin/cpuid-gen.rs
@@ -296,15 +296,6 @@ fn print_json(results: &BTreeMap<CpuidKey, Cpuid>) {
         }
     };
 
-    // Returns `true` if `key` has subleaf data and its leaf index is `leaf`.
-    fn key_matches_leaf_and_has_subleaves(key: &CpuidKey, leaf: u32) -> bool {
-        let CpuidKey::SubLeaf(l, _) = key else {
-            return false;
-        };
-
-        leaf == *l
-    }
-
     let cpuid = Cpuid {
         entries: results
             .iter()
@@ -316,7 +307,7 @@ fn print_json(results: &BTreeMap<CpuidKey, Cpuid>) {
                 let (leaf, subleaf) = match key {
                     CpuidKey::Leaf(leaf) => {
                         if results.keys().any(|k| {
-                            key_matches_leaf_and_has_subleaves(k, *leaf)
+                            matches!(k, CpuidKey::SubLeaf(l, _) if *l == *leaf)
                         }) {
                             return None;
                         }
@@ -378,7 +369,7 @@ struct Opts {
     #[clap(short)]
     zero_elide: bool,
 
-    /// Emit output in the specified format
+    /// Emit output in the specified format ("text", "toml", or "json")
     #[clap(short, long, value_parser, default_value = "text")]
     format: OutputFormat,
 


### PR DESCRIPTION
Add a JSON output format to `cpuid-gen`, which prints output suitable for inserting into an instance spec that can be fed to `propolis-cli`.

This is useful for ad hoc testing of hypervisor enlightenments. Enlightenments are exposed through special CPUID leaves in the hypervisor leaf range (0x4000_0000 to 0x4000_FFFF). To expose enlightenments, Propolis thus needs to pass the correct CPUID values to bhyve. However, if Propolis starts setting CPUID values for the hypervisor leaves, it will also need to set them for the standard and extended leaves. This implies that, to enable enlightenments, Propolis's instance-ensure API (or propolis-standalone's VM setup logic) will need a complete set of standard/extended CPUID values to apply. For `propolis-server`, the easiest way to do this is to use `propolis-cli new --spec`. The goal of this change is to make it easy to get a CPUID JSON blob to paste into this command's input spec.

While dorking around with this change, I discovered that the `propolis-cli new --spec` switch was not properly marked as exclusive with the `--config-toml` switch. Fix that up as well.

Finally, if `propolis-server` fails to convert an API spec to its internal instance spec type, and the resulting error has a source, print both the error and the source. This allows the display of messages like "leaf 7 is specified both with and without a subleaf" when appropriate.

Tested by booting some ad hoc propolis-server VMs using propolis-cli and the new output from cpuid-gen.
