### PR TITLE
build: upgrade tokio to 1.40.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,9 +2559,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libdlpi-sys"
@@ -6268,9 +6268,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
This version includes some useful new features like `tokio::io::simplex`.

Both this version and 1.43.0 pass PHD tests, but this change opts for 1.40.0 because the Omicron repo has been on that version for several weeks and has (evidently) not had any problems with it.

Tests: cargo test, PHD.