### PR TITLE
Update crucible for real this time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9#c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9"
+source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -843,7 +843,6 @@ dependencies = [
  "dropshot",
  "futures",
  "futures-core",
- "http 0.2.12",
  "internal-dns",
  "itertools 0.13.0",
  "libc",
@@ -852,7 +851,6 @@ dependencies = [
  "omicron-uuid-kinds",
  "oximeter",
  "oximeter-producer",
- "progenitor-client 0.9.1",
  "rand",
  "rand_chacha",
  "rayon",
@@ -878,7 +876,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9#c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9"
+source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -891,7 +889,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9#c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9"
+source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
 dependencies = [
  "anyhow",
  "atty",
@@ -921,7 +919,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9#c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9"
+source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6557,13 +6555,11 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
 dependencies = [
- "cfg-if",
  "rand",
- "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,8 +85,8 @@ oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 sled-agent-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 
 # Crucible
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "ace54d9cb5957fda79422e8237d7c54c33af928e" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "ace54d9cb5957fda79422e8237d7c54c33af928e" }
 
 # External dependencies
 anyhow = "1.0"


### PR DESCRIPTION
Changes to crucible:
Allow read only activation with less than three downstairs (#1608) 
Tweaks to automatic flush (#1613)
Update Rust crate twox-hash to v2 (#1547)
Remove `LastFlushAck` (#1603)
Correctly print 'connecting' state (#1612)
Make live-repair part of invariants checks (#1610) 
Simplify mend region selection (#1606)
Generic read test for crutest (#1609)
Always remove skipped jobs from dependencies (#1604) 
Add libsqlite3-dev install step to Github Actions CI (#1607) 
Move Nexus notification to standalone task (#1584) 
DTrace cleanup. (#1602)
Reset completed work Downstairs on a `Barrier` operation (#1601) 
Upstairs state machine refactoring (3/3) (#1577)