### PR TITLE
server: read host CPUID values if the spec has none

### DIFF
--- a/bin/propolis-server/src/lib/spec/api_spec_v0.rs
+++ b/bin/propolis-server/src/lib/spec/api_spec_v0.rs
@@ -95,7 +95,7 @@ impl From<Spec> for InstanceSpecV0 {
             cpus: board.cpus,
             memory_mb: board.memory_mb,
             chipset: board.chipset,
-            cpuid: cpuid.map(|set| set.into_instance_spec_cpuid()),
+            cpuid: Some(cpuid.into_instance_spec_cpuid()),
         };
         let mut spec = InstanceSpecV0 { board, components: Default::default() };
 

--- a/bin/propolis-server/src/lib/spec/mod.rs
+++ b/bin/propolis-server/src/lib/spec/mod.rs
@@ -63,7 +63,7 @@ pub struct ComponentTypeMismatch;
 #[derive(Clone, Debug, Default)]
 pub(crate) struct Spec {
     pub board: Board,
-    pub cpuid: Option<CpuidSet>,
+    pub cpuid: CpuidSet,
     pub disks: BTreeMap<SpecKey, Disk>,
     pub nics: BTreeMap<SpecKey, Nic>,
     pub boot_settings: Option<BootSettings>,

--- a/crates/cpuid-utils/src/bits.rs
+++ b/crates/cpuid-utils/src/bits.rs
@@ -8,8 +8,20 @@
 //! Definitions here are taken from the AMD Architecture Programmer's Manual,
 //! volume 3, appendix E (Publication 24594, revision 3.36, March 2024).
 
+use propolis_types::CpuidValues;
+
 pub const STANDARD_BASE_LEAF: u32 = 0;
+pub const HYPERVISOR_BASE_LEAF: u32 = 0x4000_0000;
 pub const EXTENDED_BASE_LEAF: u32 = 0x8000_0000;
+
+/// The bhyve default hypervisor identifier ("bhyve bhyve " in ebx/ecx/edx with
+/// no additional hypervisor CPUID leaves reported in eax).
+pub const HYPERVISOR_BHYVE_VALUES: CpuidValues = CpuidValues {
+    eax: HYPERVISOR_BASE_LEAF,
+    ebx: 0x76796862,
+    ecx: 0x68622065,
+    edx: 0x20657679,
+};
 
 bitflags::bitflags! {
     /// Leaf 1 ecx: instruction feature identifiers.

--- a/crates/cpuid-utils/src/host.rs
+++ b/crates/cpuid-utils/src/host.rs
@@ -11,13 +11,13 @@ use crate::{
         AmdExtLeaf1DCacheType, AmdExtLeaf1DEax, Leaf1Ecx, EXTENDED_BASE_LEAF,
         STANDARD_BASE_LEAF,
     },
-    CpuidSet, SubleafInsertConflict,
+    CpuidMapInsertError, CpuidSet,
 };
 
 #[derive(Debug, Error)]
 pub enum GetHostCpuidError {
     #[error("failed to insert into the CPUID map")]
-    CpuidInsertFailed(#[from] SubleafInsertConflict),
+    CpuidInsertFailed(#[from] CpuidMapInsertError),
 
     #[error("CPUID vendor not recognized: {0}")]
     VendorNotRecognized(&'static str),


### PR DESCRIPTION
The `cpuid` field in an instance spec's board is optional. If it is `None`, have propolis-server read bhyve's default CPUID values and insert them into the spec as though the caller had specified them. This has two benefits:

1. propolis-server can set up CPUID values in the hypervisor leaf range without requiring callers to set CPUID values in the standard and extended ranges.
2. When a VM migrates, the default CPUID settings from the source will transfer to the target, even if the target host's bhyve supplies different default CPUID values than the source host's.

Tests: cargo test, PHD, ran `cpuid` in a Debian 11 guest to check that the correct value appears in leaf 0x40000000 (and that other leaves have their expected values).

Fixes #835.