### PR TITLE
Update crucible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
+source = "git+https://github.com/oxidecomputer/crucible?rev=86a2ce1f9f13912a5fe652472de765ec5fc22e76#86a2ce1f9f13912a5fe652472de765ec5fc22e76"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -876,7 +876,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
+source = "git+https://github.com/oxidecomputer/crucible?rev=86a2ce1f9f13912a5fe652472de765ec5fc22e76#86a2ce1f9f13912a5fe652472de765ec5fc22e76"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
+source = "git+https://github.com/oxidecomputer/crucible?rev=86a2ce1f9f13912a5fe652472de765ec5fc22e76#86a2ce1f9f13912a5fe652472de765ec5fc22e76"
 dependencies = [
  "anyhow",
  "atty",
@@ -919,7 +919,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
+source = "git+https://github.com/oxidecomputer/crucible?rev=86a2ce1f9f13912a5fe652472de765ec5fc22e76#86a2ce1f9f13912a5fe652472de765ec5fc22e76"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,8 +85,8 @@ oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 sled-agent-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 
 # Crucible
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "ace54d9cb5957fda79422e8237d7c54c33af928e" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "ace54d9cb5957fda79422e8237d7c54c33af928e" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "86a2ce1f9f13912a5fe652472de765ec5fc22e76" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "86a2ce1f9f13912a5fe652472de765ec5fc22e76" }
 
 # External dependencies
 anyhow = "1.0"


### PR DESCRIPTION
Crucible updates include:
Add early rejection of IOs if too many Downstairs are inactive (#1565) 
Fix missing write stats in Oximeter. (#1617)
Shrink replay buffer (#1616)
Update tokio to 1.40 (#1611)