### PR TITLE
lib: migrate overlay manager state explicitly

### DIFF
--- a/lib/propolis/src/enlightenment/hyperv/overlay.rs
+++ b/lib/propolis/src/enlightenment/hyperv/overlay.rs
@@ -570,8 +570,10 @@ impl ManagerInner {
             .collect::<Result<BTreeMap<Pfn, OverlaySet>, OverlayError>>()?;
 
         // Now that the tracking tables have been reconstructed, create a set of
-        // overlay page descriptors to return to the caller. The caller will
-        // audit these to make sure they align with other enlightenment state.
+        // overlay page descriptors to return to the caller.
+        //
+        // The caller can check the kinds and PFNs of these pages to make sure
+        // that they line up with the enlightenment's imported MSR values.
         let pages: Vec<OverlayPage> = self
             .overlays
             .iter()

--- a/lib/propolis/src/enlightenment/hyperv/overlay.rs
+++ b/lib/propolis/src/enlightenment/hyperv/overlay.rs
@@ -207,11 +207,13 @@ pub(super) struct OverlayPage {
     pfn: Pfn,
 }
 
+// Manually implemented to avoid including the `Weak<OverlayManager>`.
 impl std::fmt::Debug for OverlayPage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self { kind, pfn, manager: _ } = self;
         f.debug_struct("OverlayPage")
-            .field("kind", &self.kind)
-            .field("pfn", &self.pfn)
+            .field("kind", &kind)
+            .field("pfn", &pfn)
             .finish()
     }
 }
@@ -746,10 +748,11 @@ pub mod migrate {
 
     impl std::fmt::Debug for OverlaySetV1 {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let Self { active, pending, original_contents: _ } = self;
             f.debug_struct("OverlaySetV1")
                 .field("original_contents", &"<page redacted>")
-                .field("active", &self.active)
-                .field("pending", &self.pending.keys().collect::<Vec<_>>())
+                .field("active", &active)
+                .field("pending", &pending.keys())
                 .finish()
         }
     }

--- a/lib/propolis/src/vmm/mem.rs
+++ b/lib/propolis/src/vmm/mem.rs
@@ -1082,6 +1082,12 @@ impl std::fmt::Display for Pfn {
     }
 }
 
+impl std::fmt::LowerHex for Pfn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        core::fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
 impl From<Pfn> for u64 {
     fn from(value: Pfn) -> Self {
         value.0


### PR DESCRIPTION
(N.B. Stacked on #851.)

Explicitly migrate the state of a Hyper-V stack's `OverlayManager` instead of having the stack reapply its own overlays. The manager's `OverlaySet`s are exported and imported more or less as-is, though with some transformations between types for serialization purposes (e.g. `Box<u8; PAGE_SIZE>` is serialized as `Vec<u8>`) or for compatibility reasons (`enum MigratedOverlayKind` is distinct from `enum OverlayKind` so that the latter can change without rendering the manager unable to recognize overlay kinds from old Propolis versions).

Importing manager state produces a set of `OverlayPage` registrations that the higher-level Hyper-V import logic can audit for correctness (there should be exactly as many entries as MSRs with active overlays, and they should be associated with the correct PFNs).

Tests: cargo test and PHD; examined the migration logs from an ad hoc migration and verified that the expected overlay state was migrated.

Fixes #850.