### PR TITLE
lib: implement reference TSC enlightenment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3910,6 +3910,7 @@ dependencies = [
  "phd-testcase",
  "propolis-client",
  "reqwest 0.12.7",
+ "tokio",
  "tracing",
  "uuid",
 ]

--- a/bin/propolis-cli/src/main.rs
+++ b/bin/propolis-cli/src/main.rs
@@ -19,7 +19,7 @@ use newtype_uuid::{GenericUuid, TypedUuid, TypedUuidKind, TypedUuidTag};
 use propolis_client::support::nvme_serial_from_str;
 use propolis_client::types::{
     BlobStorageBackend, Board, Chipset, ComponentV0, CrucibleStorageBackend,
-    GuestHypervisorInterface, I440Fx, InstanceEnsureRequest,
+    GuestHypervisorInterface, HyperVFeatureFlag, I440Fx, InstanceEnsureRequest,
     InstanceInitializationMethod, InstanceMetadata, InstanceSpecGetResponse,
     InstanceSpecV0, NvmeDisk, QemuPvpanic, ReplacementComponent, SerialPort,
     SerialPortNumber, VirtioDisk,
@@ -298,7 +298,9 @@ impl VmConfig {
                 cpus: self.vcpus,
                 memory_mb: self.memory,
                 guest_hv_interface: if self.hyperv {
-                    Some(GuestHypervisorInterface::HyperV { features: vec![] })
+                    Some(GuestHypervisorInterface::HyperV {
+                        features: vec![HyperVFeatureFlag::ReferenceTsc],
+                    })
                 } else {
                     None
                 },

--- a/crates/propolis-api-types/src/instance_spec/components/board.rs
+++ b/crates/propolis-api-types/src/instance_spec/components/board.rs
@@ -115,7 +115,9 @@ pub struct CpuidEntry {
     PartialEq,
 )]
 #[serde(deny_unknown_fields)]
-pub enum HyperVFeatureFlag {}
+pub enum HyperVFeatureFlag {
+    ReferenceTsc,
+}
 
 /// A hypervisor interface to expose to the guest.
 #[derive(Clone, Deserialize, Serialize, Debug, JsonSchema, Default)]

--- a/lib/propolis/src/enlightenment/bhyve.rs
+++ b/lib/propolis/src/enlightenment/bhyve.rs
@@ -7,6 +7,8 @@
 //! This interface supplies no special enlightenments; it merely identifies
 //! itself as a bhyve hypervisor in CPUID leaf 0x4000_0000.
 
+use std::sync::Arc;
+
 use cpuid_utils::{
     bits::HYPERVISOR_BASE_LEAF, CpuidIdent, CpuidSet, CpuidValues,
 };
@@ -16,6 +18,7 @@ use crate::{
     common::{Lifecycle, VcpuId},
     enlightenment::{AddCpuidError, Enlightenment},
     msr::{MsrId, RdmsrOutcome, WrmsrOutcome},
+    vmm::VmmHdl,
 };
 
 /// An implementation of the bhyve guest-hypervisor interface. This interface
@@ -59,5 +62,5 @@ impl Enlightenment for BhyveGuestInterface {
         WrmsrOutcome::NotHandled
     }
 
-    fn attach(&self, _parent: &MemAccessor) {}
+    fn attach(&self, _parent: &MemAccessor, _vmm_hdl: Arc<VmmHdl>) {}
 }

--- a/lib/propolis/src/enlightenment/hyperv/bits.rs
+++ b/lib/propolis/src/enlightenment/hyperv/bits.rs
@@ -108,7 +108,7 @@ pub(super) const HYPERV_LEAF_5_VALUES: CpuidValues =
 pub(super) const HV_X64_MSR_GUEST_OS_ID: u32 = 0x4000_0000;
 
 /// Specifies the guest physical address at which the guest would like to place
-/// the hypercall page. See TLFS section 3.13 and the [`MsrHypercalLValue`]
+/// the hypercall page. See TLFS section 3.13 and the [`MsrHypercallValue`]
 /// struct.
 ///
 /// Read-write; requires the [`HyperVLeaf3Eax::HYPERCALL`] privilege.
@@ -121,3 +121,20 @@ pub(super) const HV_X64_MSR_HYPERCALL: u32 = 0x4000_0001;
 ///
 /// Read-only; requires the [`HyperVLeaf3Eax::VP_INDEX`] privilege.
 pub(super) const HV_X64_MSR_VP_INDEX: u32 = 0x4000_0002;
+
+/// Guests may read this register to obtain the time since this VM was created,
+/// in 100-nanosecond units.
+///
+/// Read-only; requires the [`HyperVLeaf3Eax::PARTITION_REFERENCE_COUNTER`]
+/// privilege.
+pub(super) const HV_X64_MSR_TIME_REF_COUNT: u32 = 0x4000_0020;
+
+/// Specifies the guest physical address at which the guest would like to place
+/// the reference TSC page. See TLFS section 12.7 and the
+/// [`MsrReferenceTscValue`] struct.
+///
+/// Read-write; requires the [`HyperVLeaf3Eax::PARTITION_REFERENCE_TSC`]
+/// privilege.
+///
+/// [`MsrReferenceTscValue`]: super::tsc::MsrReferenceTscValue
+pub(super) const HV_X64_MSR_REFERENCE_TSC: u32 = 0x4000_0021;

--- a/lib/propolis/src/enlightenment/hyperv/mod.rs
+++ b/lib/propolis/src/enlightenment/hyperv/mod.rs
@@ -315,11 +315,7 @@ impl HyperV {
                 let page = ReferenceTscPage::new(time_data.guest_freq);
                 inner
                     .overlay_manager
-                    .add_overlay(
-                        new.gpfn(),
-                        OverlayKind::ReferenceTsc,
-                        OverlayContents(page.into()),
-                    )
+                    .add_overlay(new.gpfn(), OverlayKind::ReferenceTsc(page))
                     .ok()
             }
         } else {

--- a/lib/propolis/src/enlightenment/hyperv/mod.rs
+++ b/lib/propolis/src/enlightenment/hyperv/mod.rs
@@ -506,8 +506,17 @@ impl Lifecycle for HyperV {
     }
 
     fn reset(&self) {
-        let inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock().unwrap();
+
+        // The overlay manager shouldn't have any active overlays, because
+        // `pause` drops them all, and state drivers are required to call
+        // `pause` before `reset`.
         assert!(inner.overlay_manager.is_empty());
+
+        *inner = Inner {
+            overlay_manager: inner.overlay_manager.clone(),
+            ..Default::default()
+        };
     }
 
     fn halt(&self) {

--- a/lib/propolis/src/enlightenment/hyperv/mod.rs
+++ b/lib/propolis/src/enlightenment/hyperv/mod.rs
@@ -228,10 +228,9 @@ impl HyperV {
         // which the VM was started, so it suffices to subtract the latter from
         // the former and divide by 100 to get 100-nanosecond units.
         //
-        // If this VM is migrated or otherwise saved/restored, the migration
-        // protocol is expected to set `boot_hrtime` for the restored VM to
-        // account for any hrtime differences between hosts and any time where
-        // the VM was paused.
+        // This module assumes that if its user migrates this VM, the migration
+        // procedure will adjust `boot_hrtime` on the target to account for any
+        // hrtime differences between the source and target VM hosts.
         let ns_since_boot: u64 = time_data
             .hrtime
             .checked_sub(time_data.boot_hrtime)

--- a/lib/propolis/src/enlightenment/hyperv/mod.rs
+++ b/lib/propolis/src/enlightenment/hyperv/mod.rs
@@ -256,10 +256,10 @@ impl HyperV {
         // The reference TSC MSR can always be written even if the guest OS ID
         // MSR is 0. TLFS section 12.7.1 specifies that if the selected GPA is
         // invalid, "the reference TSC page will not be accessible to the
-        // guest," but the MSR write itself does not #GP. This means that if the
-        // overlay is enabled, it suffices to try to create an overlay (or move
-        // the existing one) to the requested location and, if this succeeds,
-        // store the resulting overlay page.
+        // guest," but the MSR write itself does not #GP. It therefore suffices
+        // here just to check if the guest requested an overlay and, if it did,
+        // attempt to establish one there, either by moving the previous overlay
+        // (if there is one) or by creating a new one.
         let mut inner = self.inner.lock().unwrap();
         let old_overlay = inner.overlays.tsc.take();
         inner.overlays.tsc = if new.enabled() {

--- a/lib/propolis/src/enlightenment/hyperv/overlay.rs
+++ b/lib/propolis/src/enlightenment/hyperv/overlay.rs
@@ -84,6 +84,8 @@ use crate::{accessors::MemAccessor, common::PAGE_SIZE, vmm::Pfn};
 
 use self::pfn::MappedPfn;
 
+use super::tsc::ReferenceTscPage;
+
 /// An error that can be returned from an overlay page operation.
 #[derive(Debug, Error)]
 pub(super) enum OverlayError {
@@ -143,13 +145,14 @@ impl TryFrom<Vec<u8>> for OverlayContents {
 
 /// A kind of overlay page, annotated with any other information that may be
 /// needed to generate the page's contents.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug)]
 pub(super) enum OverlayKind {
     /// A hypercall page whose instruction sequence immediately returns a "not
     /// supported" error status to its caller.
     HypercallReturnNotSupported,
 
-    /// A dummy page used for testing.
+    ReferenceTsc(ReferenceTscPage),
+
     #[cfg(test)]
     Test {
         /// An index that disambiguates different test page kinds.
@@ -175,6 +178,7 @@ impl OverlayKind {
     fn priority(&self) -> u32 {
         let high: u16 = match self {
             Self::HypercallReturnNotSupported => 0,
+            Self::ReferenceTsc(_) => 1,
 
             #[cfg(test)]
             Self::Test { .. } => u16::MAX,
@@ -195,6 +199,7 @@ impl OverlayKind {
             Self::HypercallReturnNotSupported => OverlayContents(Box::new(
                 super::hypercall::hypercall_page_contents(),
             )),
+            Self::ReferenceTsc(page) => OverlayContents(page.into()),
             #[cfg(test)]
             Self::Test { index: _, fill } => {
                 OverlayContents(Box::new([*fill; PAGE_SIZE]))
@@ -202,6 +207,14 @@ impl OverlayKind {
         }
     }
 }
+
+impl PartialEq for OverlayKind {
+    fn eq(&self, other: &Self) -> bool {
+        self.priority() == other.priority()
+    }
+}
+
+impl Eq for OverlayKind {}
 
 impl Ord for OverlayKind {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {

--- a/lib/propolis/src/enlightenment/hyperv/overlay.rs
+++ b/lib/propolis/src/enlightenment/hyperv/overlay.rs
@@ -80,11 +80,12 @@ use std::{
 
 use thiserror::Error;
 
-use crate::{accessors::MemAccessor, common::PAGE_SIZE, vmm::Pfn};
+use crate::{
+    accessors::MemAccessor, common::PAGE_SIZE,
+    enlightenment::hyperv::tsc::ReferenceTscPage, vmm::Pfn,
+};
 
 use self::pfn::MappedPfn;
-
-use super::tsc::ReferenceTscPage;
 
 /// An error that can be returned from an overlay page operation.
 #[derive(Debug, Error)]

--- a/lib/propolis/src/enlightenment/hyperv/tsc.rs
+++ b/lib/propolis/src/enlightenment/hyperv/tsc.rs
@@ -1,0 +1,238 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Support for the Hyper-V reference time enlightenment. See TLFS section 12.7.
+//!
+//! # Theory
+//!
+//! The x86 timestamp counter (TSC) gives system software a high-resolution
+//! performance counter that increments roughly once per processor clock cycle.
+//! The TSC is just a counter and does not return elapsed time in SI units;
+//! instead, readers convert TSC values to elapsed time by dividing the number
+//! of TSC ticks by the TSC frequency to get a number of seconds, which they can
+//! then convert to a reference frequency:
+//!
+//! ```text
+//! elapsed reference units
+//!     = elapsed seconds * (reference units / 1 sec)
+//!     = TSC ticks * (1 / (TSC ticks / 1 sec)) * reference frequency
+//!     = TSC ticks * (1 / TSC frequency) * reference frequency
+//!     = TSC ticks * (reference frequency / TSC frequency)
+//! ```
+//!
+//! (This calculation assumes that the TSC does in fact tick at a constant
+//! frequency. This is often the case on modern processors, but it is not
+//! guaranteed, and system software is expected to check CPUID to see if the CPU
+//! advertises such an "invariant" TSC before doing this kind of calculation.)
+//!
+//! KVM and Linux use nanoseconds as the reference time unit and so have a
+//! reference frequency of 1e9 ticks/sec. Windows and Hyper-V use 100ns units
+//! and a frequency of 1e7 ticks/sec. Because these frequencies are expressed in
+//! cycles per second, using simple integer divisions to convert ticks to
+//! seconds or to scale frequencies will lose all sub-second precision, which
+//! precision is of course the point of having a high-resolution timekeeping
+//! facility. To avoid this problem without having to use floating-point
+//! arithmetic, timekeeping enlightenments usually turn to fixed-point scaling
+//! fractions.
+//!
+//! The general idea is to take an N-bit frequency value and represent it as a
+//! 2N-bit value with an implicit radix point between bits N and N-1, such that
+//! the high N bits of the value are its integer part and the low N bits are its
+//! fractional part. That is, the idea is to re-express the frequency multiplier
+//! term in the conversion above as follows:
+//!
+//! ```text
+//! frequency multiplier
+//!     = reference frequency / TSC frequency
+//!     = ((reference frequency) * 2^N) / TSC frequency) * (1 / 2^N)
+//! ```
+//!
+//! In the present case, N = 64, and the `reference frequency * 2^N` term is a
+//! fixed-point number with 64 integer bits and 64 fractional bits. Notice that
+//! now, dividing by the TSC frequency will not truncate to 0; instead, the
+//! 64 highest-order bits of the fractional portion of the quotient will be
+//! preserved in the low 64 bits of the result of this 128-bit integer division.
+//!
+//! Since this scaling factor is represented as an integer, a TSC reader can
+//! simply multiply and shift to get an elapsed tick count:
+//!
+//! ```text
+//! elapsed reference units
+//!     = TSC ticks * (reference frequency / TSC frequency)
+//!     = (TSC ticks * scaling factor) / 2^64
+//!     = (TSC ticks * scaling factor) >> 64
+//! ```
+//!
+//! There is one small catch: the scaling factor is nominally a 128-bit integer,
+//! but the x86-64 `IMUL` instruction's maximum operand size is 64 bits. There
+//! are several ways around this; Hyper-V's is to observe that if the host TSC
+//! frequency is greater than or equal to 10 MHz, then scaling factor will be
+//! less than 1, which means its integer portion is 0, which means that the `TSC
+//! ticks * scaling factor` factor can be trivially rewritten as the 128-bit
+//! product of a 64-bit TSC value and the low 64 bits (the fractional bits) of
+//! the scaling factor.
+//!
+//! # Practice
+//!
+//! Hyper-V provides an overlay page that contains a 64-bit scaling factor and
+//! an offset that a guest can use to convert a guest TSC reading to the time
+//! since guest boot in 100-nanosecond units. Section 12.7.3 of the TLFS
+//! specifies the following computation:
+//!
+//! ```text
+//! reference_time: u128 = ((tsc * scale) >> 64) + offset
+//! ```
+//!
+//! The host computes the `scale` factor by shifting the reference frequency
+//! (1e7) left by 64 places and dividing by the guest's effective TSC frequency
+//! to get a scaling fraction, as described above. The `offset` depends on the
+//! difference between the host and guest TSC values; this implementation
+//! assumes that bhyve will set up the guest such that this offset can always be
+//! 0 (i.e., the guest will obtain an appropriately-offset TSC value directly
+//! from RDTSC without having to correct it further).
+//!
+//! Although unlikely on the machines Propolis generally targets, it is
+//! theoretically possible for the host TSC frequency to be so low that the
+//! scaling factor cannot be expressed as a 0.64 fixed-point fraction. In this
+//! case the hypervisor writes a special value to the TSC page's `sequence`
+//! field to denote that the rest of the page's contents are invalid. See
+//! [`ReferenceTscPage`] for more details.
+//!
+//! # Live migration
+//!
+//! When a VM migrates from one host to another, it will usually find that the
+//! hosts' TSC values are not in sync, either because they were started at
+//! different times or they have different TSC frequencies (or both).
+//!
+//! Propolis accounts for these differences using hardware TSC scaling and
+//! offset features. These are similar to the scale and offset fields on the
+//! reference page: the hypervisor programs a fixed-point scaling multiplier and
+//! offset into the VM's control structures before entering the guest, and the
+//! processor applies these factors when the guest executes RDTSC.
+//!
+//! This module assumes that if its VM is migrated, the overarching migration
+//! protocol will ensure that the guest's observed TSC frequency and offset will
+//! remain unchanged, such that the reference TSC page's contents can remain
+//! unchanged when a VM migrates. (The propolis-server migration protocol
+//! ensures this by requiring migration targets to support hardware-based TSC
+//! scaling and offsetting.)
+
+use crate::{
+    common::{GuestAddr, PAGE_MASK, PAGE_SHIFT, PAGE_SIZE},
+    vmm::Pfn,
+};
+
+use zerocopy::AsBytes;
+
+const ENABLED_BIT: u64 = 0;
+const ENABLED_MASK: u64 = 1 << ENABLED_BIT;
+
+/// Represents a value written to the [`HV_X64_MSR_REFERENCE_TSC`] register.
+///
+/// [`HV_X64_MSR_REFERENCE_TSC`]: super::bits::HV_X64_MSR_REFERENCE_TSC
+#[derive(Clone, Copy, Default)]
+pub(super) struct MsrReferenceTscValue(pub(super) u64);
+
+impl std::fmt::Debug for MsrReferenceTscValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MsrReferenceTscValue")
+            .field("raw", &self.0)
+            .field("raw", &format!("{:#x}", self.0))
+            .field("gpa", &format!("{:#x}", self.gpa().0))
+            .field("enabled", &self.enabled())
+            .finish()
+    }
+}
+
+impl MsrReferenceTscValue {
+    /// Yields the PFN at which the guest would like to place the reference TSC
+    /// page.
+    pub fn gpfn(&self) -> Pfn {
+        Pfn::new(self.0 >> PAGE_SHIFT).unwrap()
+    }
+
+    /// Yields the guest physical address at which the guest would like to place
+    /// the reference TSC page.
+    pub fn gpa(&self) -> GuestAddr {
+        GuestAddr(self.0 & PAGE_MASK as u64)
+    }
+
+    /// Returns `true` if the reference TSC overlay is enabled.
+    pub fn enabled(&self) -> bool {
+        (self.0 & ENABLED_MASK) != 0
+    }
+}
+
+/// The contents of a reference TSC page, defined in TLFS section 12.7.2.
+#[derive(Clone, Copy, Debug, Default, AsBytes)]
+#[repr(packed, C)]
+pub(super) struct ReferenceTscPage {
+    /// Incremented whenever the `scale` or `offset` fields of this page are
+    /// modified. Guests are meant to read the sequence value, read the scale
+    /// and offset fields, and re-read the sequence value, consuming the scale
+    /// and offset only if the sequence did not change.
+    ///
+    /// If this value is 0, guests are not to use the scale and offset factors
+    /// on this page and are to fall back to another time source.
+    ///
+    /// This module assumes that if a VM migrates, the overarching migration
+    /// protocol will work with bhyve to ensure that the guest TSC offset and
+    /// observed frequency remain unchanged.
+    sequence: u32,
+
+    /// Reserved for alignment.
+    reserved: u32,
+
+    /// The 0.64 fixed-point scaling factor to use to convert guest TSC ticks
+    /// into 100-nanosecond time units. This is computed as `((10_000_000u128 <<
+    /// 64) / guest_tsc_frequency`. If this value cannot be represented as a
+    /// 0.64 fixed-point fraction, the reference TSC page is disabled.
+    scale: u64,
+
+    /// The offset, in 100 ns units, that the guest should add to its scaled TSC
+    /// readings to obtain the number of 100 ns units that have elapsed since
+    /// the guest booted.
+    ///
+    /// This implementation assumes that bhyve ensures that the guest TSC is
+    /// always correctly offset from the host TSC, so it always sets this value
+    /// to 0.
+    offset: i64,
+}
+
+impl ReferenceTscPage {
+    /// Creates reference TSC data with a scaling factor computed from the
+    /// supplied guest TSC frequency.
+    pub(super) fn new(guest_freq: u64) -> Self {
+        let (scale, sequence) =
+            if let Some(scale) = guest_freq_to_scale(guest_freq) {
+                (scale, 1)
+            } else {
+                (0, 0)
+            };
+
+        Self { sequence, scale, ..Default::default() }
+    }
+}
+
+impl From<&ReferenceTscPage> for Box<[u8; PAGE_SIZE]> {
+    fn from(value: &ReferenceTscPage) -> Self {
+        let mut page = Box::new([0u8; PAGE_SIZE]);
+        page[0..std::mem::size_of::<ReferenceTscPage>()]
+            .copy_from_slice(value.as_bytes());
+
+        page
+    }
+}
+
+/// Converts the supplied guest TSC frequency into a 0.64 fixed-point scaling
+/// factor. Returns `None` if the correct factor cannot be so expressed.
+fn guest_freq_to_scale(guest_freq: u64) -> Option<u64> {
+    const HUNDRED_NS_PER_SEC: u128 = 10_000_000;
+    let scale: u128 = (HUNDRED_NS_PER_SEC << 64) / guest_freq as u128;
+    if (scale >> 64) != 0 {
+        None
+    } else {
+        Some(scale as u64)
+    }
+}

--- a/lib/propolis/src/enlightenment/hyperv/tsc.rs
+++ b/lib/propolis/src/enlightenment/hyperv/tsc.rs
@@ -151,7 +151,6 @@ pub(super) struct MsrReferenceTscValue(pub(super) u64);
 impl std::fmt::Debug for MsrReferenceTscValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MsrReferenceTscValue")
-            .field("raw", &self.0)
             .field("raw", &format!("{:#x}", self.0))
             .field("gpa", &format!("{:#x}", self.gpa().0))
             .field("enabled", &self.enabled())

--- a/lib/propolis/src/enlightenment/mod.rs
+++ b/lib/propolis/src/enlightenment/mod.rs
@@ -82,7 +82,8 @@ pub trait Enlightenment: Lifecycle + Send + Sync {
     /// Attaches this enlightenment stack to a VM.
     ///
     /// Users of an enlightenment stack must guarantee that this function is
-    /// called exactly once per instance of that stack.
+    /// called exactly once per instance of that stack and must do this before
+    /// starting any vCPUs or other VM components that may use the stack.
     ///
     /// # Arguments
     ///

--- a/lib/propolis/src/enlightenment/mod.rs
+++ b/lib/propolis/src/enlightenment/mod.rs
@@ -64,6 +64,7 @@ use crate::{
     accessors::MemAccessor,
     common::{Lifecycle, VcpuId},
     msr::{MsrId, RdmsrOutcome, WrmsrOutcome},
+    vmm::VmmHdl,
 };
 
 pub mod bhyve;
@@ -89,7 +90,8 @@ pub trait Enlightenment: Lifecycle + Send + Sync {
     ///   Stacks that wish to access guest memory should call
     ///   [`MemAccessor::new_orphan`] when they're created and then should call
     ///   [`MemAccessor::adopt`] from this function.
-    fn attach(&self, mem_acc: &MemAccessor);
+    /// - `vmm_hdl`: A handle to the bhyve VMM for the VM that owns this stack.
+    fn attach(&self, mem_acc: &MemAccessor, vmm_hdl: Arc<VmmHdl>);
 
     /// Adds this hypervisor interface's CPUID entries to `cpuid`.
     ///

--- a/lib/propolis/src/migrate.rs
+++ b/lib/propolis/src/migrate.rs
@@ -14,6 +14,13 @@ pub enum MigrateStateError {
     #[error("device not migratable")]
     NonMigratable,
 
+    /// The device isn't in a state where its state can be exported. Because
+    /// fully-initialized devices should be able to pause and export their state
+    /// at any time, this generally means that the device was asked to export
+    /// its state before it was fully initialized.
+    #[error("device's state is not ready to be exported")]
+    NotReadyForExport,
+
     /// I/O Error encounted while performing import/export
     #[error("IO Error")]
     Io(#[from] std::io::Error),

--- a/lib/propolis/src/vmm/machine.rs
+++ b/lib/propolis/src/vmm/machine.rs
@@ -271,7 +271,7 @@ impl Builder {
             .take()
             .unwrap_or(Arc::new(BhyveGuestInterface));
 
-        guest_hv_interface.attach(&acc_mem);
+        guest_hv_interface.attach(&acc_mem, hdl.clone());
         let vcpus = (0..self.max_cpu)
             .map(|id| {
                 Vcpu::new(

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -1089,7 +1089,10 @@
       },
       "HyperVFeatureFlag": {
         "description": "Flags that enable \"simple\" Hyper-V enlightenments that require no feature-specific configuration.",
-        "type": "string"
+        "type": "string",
+        "enum": [
+          "ReferenceTsc"
+        ]
       },
       "I440Fx": {
         "description": "An Intel 440FX-compatible chipset.",

--- a/phd-tests/tests/Cargo.toml
+++ b/phd-tests/tests/Cargo.toml
@@ -17,5 +17,6 @@ http.workspace = true
 propolis-client.workspace = true
 phd-testcase.workspace = true
 reqwest.workspace = true
+tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true
 uuid.workspace = true

--- a/phd-tests/tests/src/hyperv.rs
+++ b/phd-tests/tests/src/hyperv.rs
@@ -238,7 +238,7 @@ async fn hyperv_reference_tsc_elapsed_time_test(ctx: &Framework) {
         // scaling factors: shifting the scaling factor by the wrong number of
         // bits, for example, is liable to produce a much larger error than
         // this.
-        const TOLERANCE: f64 = 0.25;
+        const TOLERANCE: f64 = 0.025;
 
         // Take six readings to get five comparisons of consecutive readings.
         const NUM_READINGS: usize = 6;

--- a/phd-tests/tests/src/hyperv.rs
+++ b/phd-tests/tests/src/hyperv.rs
@@ -2,10 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use phd_framework::{artifacts, lifecycle::Action, TestVm};
+use std::time::{Duration, Instant};
+
+use phd_framework::{
+    artifacts, lifecycle::Action, test_vm::MigrationTimeout, TestVm,
+};
 use phd_testcase::*;
 use propolis_client::types::HyperVFeatureFlag;
-use tracing::warn;
+use tracing::{info, warn};
+use uuid::Uuid;
 
 /// Attempts to see if the guest has detected Hyper-V support. This is
 /// best-effort, since not all PHD guest images contain in-box tools that
@@ -86,7 +91,7 @@ async fn hyperv_lifecycle_test(ctx: &Framework) {
 }
 
 #[phd_testcase]
-async fn hyperv_reference_tsc_test(ctx: &Framework) {
+async fn hyperv_reference_tsc_clocksource_test(ctx: &Framework) {
     let mut cfg = ctx.vm_config_builder("hyperv_reference_tsc_test");
     cfg.guest_hv_interface(
         propolis_client::types::GuestHypervisorInterface::HyperV {
@@ -146,4 +151,124 @@ async fn hyperv_reference_tsc_test(ctx: &Framework) {
         },
     )
     .await?;
+}
+
+#[phd_testcase]
+async fn hyperv_reference_tsc_elapsed_time_test(ctx: &Framework) {
+    if ctx.default_guest_os_kind().await?.is_windows() {
+        phd_skip!("test requires a guest with /proc/timer_list in procfs");
+    }
+
+    let mut cfg = ctx.vm_config_builder("hyperv_reference_tsc_elapsed_test");
+    cfg.guest_hv_interface(
+        propolis_client::types::GuestHypervisorInterface::HyperV {
+            features: vec![HyperVFeatureFlag::ReferenceTsc],
+        },
+    );
+    let mut vm = ctx.spawn_vm(&cfg, None).await?;
+    vm.launch().await?;
+    vm.wait_to_boot().await?;
+
+    #[derive(Debug)]
+    struct Reading {
+        taken_at: Instant,
+        guest_ns: u64,
+    }
+
+    impl Reading {
+        async fn take_from(vm: &TestVm) -> anyhow::Result<Self> {
+            let cmd =
+                "cat /proc/timer_list | grep \"now at\" | awk '{ print $3 }'";
+            let guest_ns = vm.run_shell_command(cmd).await?.parse::<u64>()?;
+
+            // It's important to minimize the time between the host and guest
+            // readings to avoid introducing skew when comparing sets of
+            // readings. Capturing the host timestamp after the guest time
+            // excludes the time needed to send bytes to the guest serial potr
+            // and wait for them to be echoed from this delta.
+            let taken_at = Instant::now();
+            Ok(Self { taken_at, guest_ns })
+        }
+
+        /// Compares `self` with an earlier reading, `other`, and returns the
+        /// difference between the measured elapsed time on the host and the
+        /// measured elapsed time on the guest, expressed as a percentage of the
+        /// measured elapsed time on the host.
+        fn compare_with_earlier(&self, other: &Reading) -> f64 {
+            let host_delta_ns =
+                i64::try_from((self.taken_at - other.taken_at).as_nanos())
+                    .expect("host delta is small enough to fit in an i64");
+
+            let guest_delta_ns = i64::try_from(self.guest_ns - other.guest_ns)
+                .expect("guest delta is small enough to fit in an i64");
+
+            let diff = (host_delta_ns - guest_delta_ns).unsigned_abs();
+            let diff_pct = (diff as f64) / (host_delta_ns as f64);
+
+            info!(
+                before = ?other,
+                after = ?self,
+                host_delta_ns,
+                guest_delta_ns,
+                diff,
+                diff_pct,
+                "compared time readings"
+            );
+
+            diff_pct
+        }
+    }
+
+    // The logic below takes pairs of time readings on the host and guest and
+    // compares them to check that the amount of elapsed time perceived by the
+    // guest is roughly equivalent to the "real" elapsed time on the host. The
+    // host and guest measurements can't be taken atomically, so some difference
+    // between these readings is expected (especially because the guest shell
+    // command needs to print its result to the serial port, and the harness has
+    // to read it).
+    //
+    // Accept a measurement error of up to 1% of the elapsed time between host
+    // readings. This is an extremely generous tolerance. It is chosen primarily
+    // to avoid flakiness while still checking for gross errors in the
+    // construction of the TSC page (e.g. mis-shifting the TSC scaling factor
+    // so that it's off by a factor of 2).
+    const TOLERANCE: f64 = 0.01;
+
+    let mut readings = vec![];
+    for _ in 0..5 {
+        readings.push(Reading::take_from(&vm).await?);
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    for window in readings.as_slice().windows(2) {
+        let first = &window[0];
+        let second = &window[1];
+        let diff_pct = second.compare_with_earlier(first);
+        assert!(
+            diff_pct < TOLERANCE,
+            "time readings {first:?} and {second:?} differ by more than a
+            factor of {TOLERANCE}"
+        );
+    }
+
+    // For good measure, also take readings over a live migration; this also
+    // helps to verify the time-adjustment portions of the migration protocol.
+    let mut target = ctx
+        .spawn_successor_vm("hyperv_reference_tsc_elapsed_target", &vm, None)
+        .await?;
+
+    let before_migration = Reading::take_from(&vm).await?;
+    target
+        .migrate_from(&vm, Uuid::new_v4(), MigrationTimeout::default())
+        .await?;
+
+    let after_migration = Reading::take_from(&target).await?;
+    let diff_pct = after_migration.compare_with_earlier(&before_migration);
+    assert!(
+        diff_pct < TOLERANCE,
+        "time readings {:?} and {:?} differ by more than a
+        factor of {TOLERANCE}",
+        before_migration,
+        after_migration
+    );
 }


### PR DESCRIPTION
Add a Hyper-V reference time enlightenment to the Hyper-V stack. See the new `tsc` module's doc comment for details about how the enlightenment operates.

Add PHD tests that try to verify both that the enlightenment is present (by querying the current clocksource) and that it keeps time roughly correctly (by comparing host and guest time readings). The latter test also takes readings over a migration to help get some coverage of the time data phase of live migration (though the migration is not currently cross-machine, so this is a little less interesting than it might otherwise be).

Tests: cargo test; PHD w/Alpine, Debian 11, WS2022 guests.

Fixes #328.