### PR TITLE
mock: attempt realistic state transitions

### DIFF
--- a/bin/mock-server/src/lib/lib.rs
+++ b/bin/mock-server/src/lib/lib.rs
@@ -162,8 +162,23 @@ impl InstanceContext {
             for &state in states {
                 self.generation += 1;
                 self.state = state;
-                queue.insert(self.generation, api::InstanceStateMonitorResponse { gen: self.generation, migration: api::InstanceMigrateStatusResponse { migration_in: None, migration_out: None }, state });
-                slog::info!(log, "queued instance state transition"; "state" => ?state, "gen" => ?self.generation);
+                queue.insert(
+                    self.generation,
+                    api::InstanceStateMonitorResponse {
+                        gen: self.generation,
+                        migration: api::InstanceMigrateStatusResponse {
+                            migration_in: None,
+                            migration_out: None,
+                        },
+                        state,
+                    },
+                );
+                slog::info!(
+                    log,
+                    "queued instance state transition";
+                    "state" => ?state,
+                    "gen" => ?self.generation,
+                );
             }
         })
     }


### PR DESCRIPTION
Presently, when the mock `propolis-server` receives a put-state request
for `Stopped`, it sets `self.state` to `Stopped` and shuts down the mock
serial console, here:
https://github.com/oxidecomputer/propolis/blob/c849babafa7013c206336c795110a5ecc20c5a0c/bin/mock-server/src/lib/lib.rs#L107-L111

However, it never actually sets the `state_watcher` state, which is
what's used by the `instance_state_monitor` endpoint, to `Stopping`,
the way we do for other state transitions:
https://github.com/oxidecomputer/propolis/blob/c849babafa7013c206336c795110a5ecc20c5a0c/bin/mock-server/src/lib/lib.rs#L92-L106

If we want to actually use the mock server to test sled-agent behavior
around instance stop, we need to make it behave realistically here.

In real life, stopping an instance will cause it to go through multiple
state transitions: first to `Stopping` and then to `Stopped`. This also
Currently, the mock doesn't have a way to cause multiple state transitions
to be observed by the `instance_state_monitor` client. Therefore, I've
changed the implementation to support this, using a map of states by
generation number. Now, when the state monitor requests the next state
transition from a given generation, we will return the state at
`gen + 1` in that map if one exists, or wait until more states are
added to the map. Transitions that cause the instance to go through
multiple states will now add all of those states to the queue of states
to simulate.

The state used by `instance_get` and for determining what state
transitions are updated is now represented by a variable tracking the
current state generation. This is updated only once we expose a new
state to the `instance_state_monitor` client, so the understanding of
the instance's state used to determine what requested transitions
are valid is kept in sync with what we've claimed to be from the state
monitor's perspective.

Testing: I've pointed the `omicron` repo's `propolis-mock-server` dep
at commit 28d81cbd4af1e81d0caa49d73b6ad296323d07ac and run
`cargo nextest run -p omicron-sled-agent`.[^1] All the tests still pass.

Fixes #857

[^1]: I believe only the sled-agent test suite uses
      `propolis-mock-server`?