### PR TITLE
lib: tidy up overlay page migration & reduce memory usage

### DIFF
--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -460,7 +460,9 @@ impl Instance {
                     }
                 }
                 State::Quiesce => {
-                    // stop device emulation and vCPUs
+                    // Stop device emulation and vCPUs. Note that the device
+                    // lifecycle trait requires vCPUs to be paused before any
+                    // devices pause.
                     for vcpu_task in guard.vcpu_tasks.iter_mut() {
                         let _ = vcpu_task.hold();
                     }

--- a/lib/propolis/src/enlightenment/hyperv/mod.rs
+++ b/lib/propolis/src/enlightenment/hyperv/mod.rs
@@ -366,11 +366,29 @@ mod migrate {
 
     use crate::migrate::{Schema, SchemaId};
 
+    #[derive(Serialize, Deserialize)]
+    #[serde(tag = "type", content = "value")]
+    pub(super) enum OverlaidGuestPage {
+        Zero,
+        Page(Vec<u8>),
+    }
+
+    impl std::fmt::Debug for OverlaidGuestPage {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Zero => write!(f, "Zero"),
+                Self::Page(_) => {
+                    f.debug_tuple("Page").field(&"<page redacted>").finish()
+                }
+            }
+        }
+    }
+
     #[derive(Debug, Serialize, Deserialize)]
     pub struct HyperVEnlightenmentV1 {
         pub(super) msr_guest_os_id: u64,
         pub(super) msr_hypercall: u64,
-        pub(super) overlay_originals: BTreeMap<u64, Vec<u8>>,
+        pub(super) overlay_originals: BTreeMap<u64, OverlaidGuestPage>,
     }
 
     impl Schema<'_> for HyperVEnlightenmentV1 {

--- a/lib/propolis/src/enlightenment/hyperv/overlay.rs
+++ b/lib/propolis/src/enlightenment/hyperv/overlay.rs
@@ -322,20 +322,10 @@ impl Drop for OverlayPage {
     }
 }
 
+#[derive(Debug)]
 enum OverlaidGuestPage {
     ZeroPage,
     Page(OverlayContents),
-}
-
-impl std::fmt::Debug for OverlaidGuestPage {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ZeroPage => write!(f, "ZeroPage"),
-            Self::Page(_) => {
-                f.debug_tuple("Page").field(&"<page redacted>").finish()
-            }
-        }
-    }
 }
 
 impl TryFrom<MigratedOverlaidGuestPage> for OverlaidGuestPage {


### PR DESCRIPTION
Tweak a few bits of Hyper-V overlay migration:

- Don't store page kinds separately from page contents. Instead, a page's kind *determines* its contents. Most overlays have static contents or contents that depend on only a couple of parameters (e.g. the TSC scale/offset for the TSC reference page), so this saves a fair bit of memory for most kinds of pending overlay pages.

- Change the overlay ordering discipline to depend entirely on the ordering of `OverlayKind`s. (Previously the first overlay assigned to a PFN would become active and then would remain active until it was removed, but pending overlays were promoted in order by kind.) This obviates the need to export/import a PFN's current active overlay during migration (or to remember the order in which overlays were applied), since a set of overlays at a single PFN will always have the same active overlay (...provided the ordering remains stable across Propolis versions; there's a comment about this caveat in the new code.)

- Continue to manually transfer the original contents of guest pages that are covered by an overlay (since these still need to be restored), but wrap them in an enum with a variant that specifies that the overlaid page contained all zeroes. Because VM memory is initially zeroed, and many guests will establish overlay pages early in boot over pages they haven't otherwise touched, this can significantly reduce the amount of serialized page data that the manager needs to send over a migration.

See https://github.com/oxidecomputer/propolis/pull/853#discussion_r1960595633 for a bit more context.