### PR TITLE
server: add state machine docs

### DIFF
--- a/bin/propolis-server/src/lib/vm/ensure.rs
+++ b/bin/propolis-server/src/lib/vm/ensure.rs
@@ -4,26 +4,90 @@
 
 //! Tools for handling instance ensure requests.
 //!
-//! To initialize a new VM, the server must (1) create a set of VM objects from
-//! an instance spec, (2) set up VM services that use those objects, (3) use the
-//! objects and services to drive the VM state machine to the `ActiveVm` state,
-//! and (4) notify the original caller of the "instance ensure" API of the
-//! completion of its request. If VM initialization fails, the actions required
-//! to compensate and drive the state machine to `RundownComplete` depend on how
-//! many steps were completed.
+//! This module handles the first high-level phase of a VM's lifecycle, which
+//! creates all of the VM's components and attendant data structures. These are
+//! handed off to a `StateDriver` that implements the main VM event loop. See
+//! the [`state_driver`] module docs for more details.
 //!
-//! When live migrating into an instance, the live migration task interleaves
-//! initialization steps with the steps of the live migration protocol, and
-//! needs to be able to unwind initialization correctly whenever the migration
-//! protocol fails.
+//! This module uses distinct structs that each represent a distinct phase of VM
+//! initialization. When a server receives a new ensure request, it creates the
+//! first of these structures, then hands it off to the procedure described in
+//! the ensure request to drive the rest of the initialization process, as in
+//! the diagram below:
 //!
-//! The `VmEnsure` types in this module exist to hide the gory details of
-//! initializing and unwinding from higher-level operations like the live
-//! migration task. Each type represents a phase of the initialization process
-//! and has a routine that consumes the current phase and moves to the next
-//! phase. If a higher-level operation fails, it can call a failure handler on
-//! its current phase to unwind the whole operation and drive the VM state
-//! machine to the correct resting state.
+//! ```text
+//!                 +-------------------------+
+//!                 |                         |
+//!                 |  Initial state (no VM)  |
+//!                 |                         |
+//!                 +-----------+-------------+
+//!                             |
+//!                    Receive ensure request
+//!                             |
+//!                             v
+//!                     VmEnsureNotStarted
+//!                             |
+//!                             |
+//!                   +---------v----------+
+//!          Yes      |                    |        No
+//!           +-------+  Live migration?   +---------+
+//!           |       |                    |         |
+//!           |       +--------------------+         |
+//!           |                                      |
+//!     +-----v------+                               |
+//!     |Get params  |                               |
+//!     |from source |                               |
+//!     +-----+------+                               |
+//!           |                                      |
+//!     +-----v------+                     +---------v-----------+
+//!     |Initialize  |                     |Initialize components|
+//!     |components  |                     |    from params      |
+//!     +-----+------+                     +---------+-----------+
+//!           |                                      |
+//!           v                                      v
+//! VmEnsureObjectsCreated                 VmEnsureObjectsCreated
+//!           |                                      |
+//!           |                                      |
+//!     +-----v------+                               |
+//!     |Import state|                               |
+//!     |from source |                               |
+//!     +-----+------+                               |
+//!           |                                      |
+//!           |                                      |
+//!           |        +------------------+          |
+//!           +-------->Launch VM services<----------+
+//!                    +--------+---------+
+//!                             |
+//!                             |
+//!                    +--------v---------+
+//!                    |Move VM to Active |
+//!                    +--------+---------+
+//!                             |
+//!                             |
+//!                             v
+//!                      VmEnsureActive<'_>
+//! ```
+//!
+//! When initializing a VM from scratch, the ensure request contains a spec that
+//! determines what components the VM should create, and they are created into
+//! their default initial states. When migrating in, the VM-ensure structs are
+//! handed off to the migration protocol, which fetches a spec from the
+//! migration source, uses its contents to create the VM's components, and
+//! imports the source VM's device state into those components.
+//!
+//! Once all components exist and are initialized, this module sets up "VM
+//! services" (e.g. the serial console and metrics) that connect this VM to
+//! other Oxide APIs and services. It then updates the server's VM state machine
+//! and yields a completed "active" VM that can be passed into a state driver
+//! run loop.
+//!
+//! Separating the initialization steps in this manner hides the gory details of
+//! initializing a VM (and unwinding initialization) from higher-level
+//! procedures like the migration protocol. Each initialize phase has a failure
+//! handler that allows a higher-level driver to unwind the entire ensure
+//! operation and drive the VM state machine to the correct resting state.
+//!
+//! [`state_driver`]: crate::vm::state_driver
 
 use std::sync::Arc;
 

--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -610,7 +610,7 @@ impl Vm {
 
             let vm_for_driver = self.clone();
             guard.driver = Some(tokio::spawn(async move {
-                state_driver::run_state_driver(
+                state_driver::ensure_vm_and_launch_driver(
                     log_for_driver,
                     vm_for_driver,
                     external_publisher,


### PR DESCRIPTION
Add some doc comments to the propolis-server state machine modules that describe how the state machine works. Also, rename a couple of routines for clarity.

This PR contains no functional changes.