### PR TITLE
propolis-cli: check for duplicate spec keys when parsing toml

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -1020,7 +1020,7 @@ impl MachineInitializer<'_> {
             .map(|ident| {
                 match ident.eax & 0xf00 {
                     // If family ID is 0xf, extended family is added to it
-                    0xf00 => (ident.eax >> 20 & 0xff) + 0xf,
+                    0xf00 => ((ident.eax >> 20) & 0xff) + 0xf,
                     // ... otherwise base family ID is used
                     base => base >> 8,
                 }
@@ -1048,7 +1048,7 @@ impl MachineInitializer<'_> {
         };
 
         let proc_id = cpuid_ident
-            .map(|id| u64::from(id.eax) | u64::from(id.edx) << 32)
+            .map(|id| u64::from(id.eax) | (u64::from(id.edx) << 32))
             .unwrap_or(0);
 
         let proc_version = cpuid_procname

--- a/bin/propolis-server/src/lib/stats/mod.rs
+++ b/bin/propolis-server/src/lib/stats/mod.rs
@@ -134,12 +134,12 @@ impl Producer for ServerStats {
 ///
 /// - `id`: The ID of the instance for whom this server is being started.
 /// - `config`: The metrics config options, including our address (on which we
-///    serve metrics for oximeter to collect), and the registration address (a
-///    Nexus instance through which we request registration as an oximeter
-///    producer).
+///   serve metrics for oximeter to collect), and the registration address (a
+///   Nexus instance through which we request registration as an oximeter
+///   producer).
 /// - `log`: A logger to use when logging from this routine.
 /// - `registry`: The oximeter [`ProducerRegistry`] that the spawned server will
-///    use to return metric data to oximeter on request.
+///   use to return metric data to oximeter on request.
 ///
 /// The returned server will attempt to register with Nexus in a background
 /// task, and will periodically renew that registration. The returned server is

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -873,7 +873,7 @@ fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
         .unwrap_or_else(|| cpuid_utils::host::query(CpuidIdent::leaf(1)));
     let family = match cpuid_ident.eax & 0xf00 {
         // If family ID is 0xf, extended family is added to it
-        0xf00 => (cpuid_ident.eax >> 20 & 0xff) + 0xf,
+        0xf00 => ((cpuid_ident.eax >> 20) & 0xff) + 0xf,
         // ... otherwise base family ID is used
         base => base >> 8,
     };
@@ -892,7 +892,8 @@ fn generate_smbios(params: SmbiosParams) -> anyhow::Result<smbios::TableBytes> {
         //unknown
         _ => 0x2,
     };
-    let proc_id = u64::from(cpuid_ident.eax) | u64::from(cpuid_ident.edx) << 32;
+    let proc_id =
+        u64::from(cpuid_ident.eax) | (u64::from(cpuid_ident.edx) << 32);
     let procname_entries = params.cpuid_procname.or_else(|| {
         if cpuid_utils::host::query(CpuidIdent::leaf(0x8000_0000)).eax
             >= 0x8000_0004

--- a/crates/rfb/src/proto.rs
+++ b/crates/rfb/src/proto.rs
@@ -637,7 +637,7 @@ mod raw {
 
     #[allow(dead_code)]
     #[derive(Copy, Clone, FromBytes, FromZeroes, AsBytes)]
-    #[repr(packed)]
+    #[repr(C, packed)]
     pub(crate) struct PixelFormat {
         pub bits_per_pixel: u8,
         pub depth: u8,
@@ -653,7 +653,7 @@ mod raw {
     }
 
     #[derive(Copy, Clone, FromBytes, FromZeroes)]
-    #[repr(packed)]
+    #[repr(C, packed)]
     pub(crate) struct FramebufferUpdateRequest {
         pub incremental: u8,
         pub position: Position,
@@ -661,7 +661,7 @@ mod raw {
     }
 
     #[derive(Copy, Clone, FromBytes, FromZeroes)]
-    #[repr(packed)]
+    #[repr(C, packed)]
     pub(crate) struct KeyEvent {
         pub down_flag: u8,
         pub _padding: [u8; 2],
@@ -669,14 +669,14 @@ mod raw {
     }
 
     #[derive(Copy, Clone, FromBytes, FromZeroes)]
-    #[repr(packed)]
+    #[repr(C, packed)]
     pub(crate) struct PointerEvent {
         pub button_mask: u8,
         pub position: Position,
     }
 
     #[derive(Copy, Clone, FromBytes, FromZeroes)]
-    #[repr(packed)]
+    #[repr(C, packed)]
     pub(crate) struct Position {
         pub x: U16,
         pub y: U16,
@@ -688,7 +688,7 @@ mod raw {
     }
 
     #[derive(Copy, Clone, FromBytes, FromZeroes)]
-    #[repr(packed)]
+    #[repr(C, packed)]
     pub(crate) struct Resolution {
         width: U16,
         height: U16,
@@ -700,7 +700,7 @@ mod raw {
     }
 
     #[derive(Copy, Clone, AsBytes)]
-    #[repr(packed)]
+    #[repr(C, packed)]
     #[allow(dead_code)]
     pub(crate) struct FramebufferUpdateHeader {
         msg_type: u8,

--- a/lib/propolis/src/cpuid.rs
+++ b/lib/propolis/src/cpuid.rs
@@ -165,7 +165,7 @@ impl Specializer {
                 None => break,
                 Some(vals) => {
                     // bits 7:5 hold the cache level
-                    let visible_count = match (vals.eax & 0b11100000 >> 5) {
+                    let visible_count = match ((vals.eax & 0b11100000) >> 5) {
                         0b001 | 0b010 => {
                             // L1/L2 shared by SMT siblings
                             if self.has_smt {

--- a/lib/propolis/src/hw/nvme/cmds.rs
+++ b/lib/propolis/src/hw/nvme/cmds.rs
@@ -614,7 +614,7 @@ impl TryFrom<u32> for FeatNumberQueues {
 impl From<FeatNumberQueues> for u32 {
     fn from(value: FeatNumberQueues) -> Self {
         // Convert to 0's based DW0
-        u32::from(value.ncq.saturating_sub(1)) << 16
+        (u32::from(value.ncq.saturating_sub(1)) << 16)
             | u32::from(value.nsq.saturating_sub(1))
     }
 }
@@ -632,7 +632,7 @@ impl From<u32> for FeatInterruptVectorConfig {
 }
 impl From<FeatInterruptVectorConfig> for u32 {
     fn from(value: FeatInterruptVectorConfig) -> Self {
-        u32::from(value.iv) | u32::from(value.cd) << 16
+        u32::from(value.iv) | (u32::from(value.cd) << 16)
     }
 }
 
@@ -664,14 +664,14 @@ impl NvmCmd {
         let cmd = match raw.opcode() {
             bits::NVM_OPC_FLUSH => NvmCmd::Flush,
             bits::NVM_OPC_WRITE => NvmCmd::Write(WriteCmd {
-                slba: u64::from(raw.cdw11) << 32 | u64::from(raw.cdw10),
+                slba: (u64::from(raw.cdw11) << 32) | u64::from(raw.cdw10),
                 // Convert from 0's based value
                 nlb: raw.cdw12 as u16 + 1,
                 prp1: raw.prp1,
                 prp2: raw.prp2,
             }),
             bits::NVM_OPC_READ => NvmCmd::Read(ReadCmd {
-                slba: u64::from(raw.cdw11) << 32 | u64::from(raw.cdw10),
+                slba: (u64::from(raw.cdw11) << 32) | u64::from(raw.cdw10),
                 // Convert from 0's based value
                 nlb: raw.cdw12 as u16 + 1,
                 prp1: raw.prp1,
@@ -1014,8 +1014,8 @@ impl Completion {
 
     /// Helper method to combine [StatusCodeType] and status code
     const fn status_field(sct: StatusCodeType, sc: u8) -> u16 {
-        (sc as u16) << 1 | ((sct as u8) as u16) << 9
-        // (more as u16) << 14 | (dnr as u16) << 15
+        ((sc as u16) << 1) | (((sct as u8) as u16) << 9)
+        // ((more as u16) << 14) | ((dnr as u16) << 15)
     }
 }
 

--- a/lib/propolis/src/hw/pci/test.rs
+++ b/lib/propolis/src/hw/pci/test.rs
@@ -83,7 +83,7 @@ fn pcie_decoder_multiple_bdfs() {
     });
 
     let mut ro =
-        ReadOp::from_buf(4_usize << 15 | 3_usize << 12 | 0x123, &mut buf);
+        ReadOp::from_buf((4_usize << 15) | (3_usize << 12) | 0x123, &mut buf);
     pcie.service(RWOp::Read(&mut ro), |bdf, rwo| {
         assert_eq!(*bdf, Bdf::new(0, 4, 3).unwrap());
         assert_eq!(rwo.offset(), 0x123);
@@ -91,7 +91,7 @@ fn pcie_decoder_multiple_bdfs() {
     });
 
     let mut ro = ReadOp::from_buf(
-        133_usize << 20 | 7_usize << 15 | 1_usize << 12 | 0x337,
+        (133_usize << 20) | (7_usize << 15) | (1_usize << 12) | 0x337,
         &mut buf,
     );
     pcie.service(RWOp::Read(&mut ro), |bdf, rwo| {

--- a/lib/propolis/src/hw/qemu/fwcfg.rs
+++ b/lib/propolis/src/hw/qemu/fwcfg.rs
@@ -258,7 +258,7 @@ struct State {
 }
 impl State {
     fn dma_addr(&self) -> u64 {
-        u64::from(self.dma_addr_high) << 32 | u64::from(self.dma_addr_low)
+        (u64::from(self.dma_addr_high) << 32) | u64::from(self.dma_addr_low)
     }
     fn reset(&mut self) {
         self.selected = None;
@@ -987,7 +987,7 @@ mod test {
             &mem,
             req_addr,
             DmaReq {
-                ctrl: u32::from(LegacyId::Signature as u16) << 16 | 0x000a,
+                ctrl: (u32::from(LegacyId::Signature as u16) << 16) | 0x000a,
                 len: 4,
                 addr: dma_addr,
             },
@@ -1010,7 +1010,7 @@ mod test {
         write_dma_req(
             &mem,
             req_addr,
-            DmaReq { ctrl: 0xfffe << 16 | 0x000a, len: 4, addr: dma_addr },
+            DmaReq { ctrl: (0xfffe << 16) | 0x000a, len: 4, addr: dma_addr },
         );
 
         // Put garbage at dma destination to confirm it gets overwritten

--- a/lib/propolis/src/vmm/mem.rs
+++ b/lib/propolis/src/vmm/mem.rs
@@ -1061,7 +1061,7 @@ impl<T: Copy + FromBytes> Iterator for GuestData<MemMany<'_, T>> {
     fn next(&mut self) -> Option<Self::Item> {
         let res = self.get(self.pos);
         self.pos += 1;
-        res.map(GuestData::from)
+        res
     }
 }
 

--- a/xtask/src/task_phd.rs
+++ b/xtask/src/task_phd.rs
@@ -301,9 +301,8 @@ impl Cmd {
             }
         };
 
-        let artifact_dir = artifact_args
-            .artifact_directory
-            .unwrap_or_else(|| {
+        let artifact_dir =
+            artifact_args.artifact_directory.unwrap_or_else(|| {
                 // if there's no explicitly overridden `artifact_dir` path, use
                 // `target/phd/artifacts`.
                 phd_dir.join("artifacts")
@@ -331,9 +330,8 @@ impl Cmd {
 
         mkdir(&tmp_dir, "temp directory")?;
 
-        let artifacts_toml = artifact_args
-            .artifact_toml_path
-            .unwrap_or_else(|| {
+        let artifacts_toml =
+            artifact_args.artifact_toml_path.unwrap_or_else(|| {
                 // if there's no explicitly overridden `artifacts.toml` path,
                 // determine the default one from the workspace path.
                 relativize(&meta.workspace_root)

--- a/xtask/src/task_phd.rs
+++ b/xtask/src/task_phd.rs
@@ -303,7 +303,6 @@ impl Cmd {
 
         let artifact_dir = artifact_args
             .artifact_directory
-            .map(Utf8PathBuf::from)
             .unwrap_or_else(|| {
                 // if there's no explicitly overridden `artifact_dir` path, use
                 // `target/phd/artifacts`.
@@ -334,7 +333,6 @@ impl Cmd {
 
         let artifacts_toml = artifact_args
             .artifact_toml_path
-            .map(Utf8PathBuf::from)
             .unwrap_or_else(|| {
                 // if there's no explicitly overridden `artifacts.toml` path,
                 // determine the default one from the workspace path.


### PR DESCRIPTION
otherwise if a TOML defines a block device and disk device the same name, say, calling both "boot", one will clobber the other and the CLI tool will send a malformed request to propolis-server.

now you get a more helpful error:
```
Error: spec key Name("boot") defined multiple times
```

this is set to merge into the 1.85 clippy branch for review/readability reasons, i expect to merge the clippy changes first of course.

i was very confused trying to use `propolis-cli+propolis-server` and getting a `400` about the disk that very much exists in my toml not existing by the time `propolis-server` heard about it.. :grin: 