### PR TITLE
propolis-server should not crash when failing to start a VM

### DIFF
--- a/bin/propolis-server/src/lib/vm/ensure.rs
+++ b/bin/propolis-server/src/lib/vm/ensure.rs
@@ -321,7 +321,6 @@ impl<'a> VmEnsureNotStarted<'a> {
                     kernel_vm_paused: false,
                 })
             }
-
             Err(e) => Err(self.fail(e).await),
         }
     }


### PR DESCRIPTION
tripped over this while trying to figure out how it was that `propolis-server` is now failing to create VMs with a toml that was working fine just an hour ago. what was a crash with stdout having an  `INFO ... migration: InstanceMigrateStatusResponse { migration_in: None, migration_out: None}` (silently truncated early due to panic) now very helpfully does _not_ kill `propolis-server` and instead has an `ERRO ... failed to add low memory region: Not enough space`.

Fixes #838 
