### PR TITLE
mock-server: add single-step API

### DIFF
--- a/bin/mock-server/src/lib/api_types.rs
+++ b/bin/mock-server/src/lib/api_types.rs
@@ -51,3 +51,16 @@ pub struct InstanceSerialHistoryParams {
     /// `max_bytes`.
     pub max_bytes: Option<u64>,
 }
+
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, JsonSchema, Serialize, Deserialize,
+)]
+pub enum MockMode {
+    /// The mock server should run freely, advancing the state every time the
+    /// instance_state_monitor endpoint is requested while new state
+    /// transitions are queued.
+    Run,
+    /// The mock server should only advance the current state when the
+    /// /mock/step endpoint is requested.
+    SingleStep,
+}


### PR DESCRIPTION
For certain test scenarios, the `propolis-mock-server` ought to have a mechanism
for manual control of the mocked instance's progress through the state machine.
In particular, this is necessary for testing changes like
oxidecomputer/omicron#7548, which adds a timeout tracked by the sled-agent when
an instance is stopped. If Propolis is stuck and cannot progress, the sled-agent
will forcefully terminate it after that timeout...but testing this requires a
way to make the mock Propolis pretend to be stuck.

This commit adds the following new endpoints to the mock server which are not
part of the real `propolis-server` API:

- `PUT /mock/mode`: sets a mock mode, either `Run` (the normal behavior), or
  `SingleStep`, where state transitions only ocur when asked for by the test.
- `GET /mock/mode`: returns whether or not we are single-steppy
- `PUT /mock/step`: advances to the next queued generation

Testing: I've written [a test in Omicron][1] that uses this, and I can make
the mock propolis get wedged in the correct place. So that's nice.

Closes #858 

[1]: https://github.com/oxidecomputer/omicron/compare/eliza/single-steppy?expand=1