### PR TITLE
phd: add smoke test for VCR replacement

### DIFF
--- a/phd-tests/framework/src/lib.rs
+++ b/phd-tests/framework/src/lib.rs
@@ -252,12 +252,27 @@ impl Framework {
         config: &VmConfig<'_>,
         environment: Option<&EnvironmentSpec>,
     ) -> anyhow::Result<TestVm> {
-        TestVm::new(
-            self,
+        self.spawn_vm_with_spec(
             config
                 .vm_spec(self)
                 .await
-                .context("building VM config for test VM")?,
+                .context("building VM spec from VmConfig")?,
+            environment,
+        )
+        .await
+    }
+
+    /// Spawns a new test VM using the supplied `spec`. If `environment` is
+    /// `Some`, the VM is spawned using the supplied environment; otherwise it
+    /// is spawned using the default `environment_builder`.
+    pub async fn spawn_vm_with_spec(
+        &self,
+        spec: VmSpec,
+        environment: Option<&EnvironmentSpec>,
+    ) -> anyhow::Result<TestVm> {
+        TestVm::new(
+            self,
+            spec,
             environment.unwrap_or(&self.environment_builder()),
         )
         .await

--- a/phd-tests/framework/src/test_vm/config.rs
+++ b/phd-tests/framework/src/test_vm/config.rs
@@ -208,7 +208,7 @@ impl<'dr> VmConfig<'dr> {
         self
     }
 
-    pub(crate) async fn vm_spec(
+    pub async fn vm_spec(
         &self,
         framework: &Framework,
     ) -> anyhow::Result<VmSpec> {

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -614,6 +614,12 @@ impl TestVm {
                 .with_context(|| format!("serializing VCR {vcr:?}"))?,
         };
 
+        info!(
+            disk_name = disk.device_name().as_str(),
+            vcr = ?vcr,
+            "issuing Crucible VCR replacement request"
+        );
+
         let response_value = self
             .client
             .instance_issue_crucible_vcr_request()

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use crate::{
+    disk::{crucible::CrucibleDisk, DiskConfig},
     guest_os::{
         self, windows::WindowsVm, CommandSequence, CommandSequenceEntry,
         GuestOs, GuestOsKind,
@@ -601,6 +602,33 @@ impl TestVm {
         &self,
     ) -> Result<InstanceMigrateStatusResponse> {
         Ok(self.client.instance_migrate_status().send().await?.into_inner())
+    }
+
+    pub async fn replace_crucible_vcr(
+        &self,
+        disk: &CrucibleDisk,
+    ) -> anyhow::Result<()> {
+        let vcr = disk.vcr();
+        let body = propolis_client::types::InstanceVcrReplace {
+            vcr_json: serde_json::to_string(&vcr)
+                .with_context(|| format!("serializing VCR {vcr:?}"))?,
+        };
+
+        let response_value = self
+            .client
+            .instance_issue_crucible_vcr_request()
+            .id(disk.device_name().clone().into_backend_name().into_string())
+            .body(body)
+            .send()
+            .await?;
+
+        anyhow::ensure!(
+            response_value.status().is_success(),
+            "VCR replacement request returned an error value: \
+            {response_value:?}"
+        );
+
+        Ok(())
     }
 
     pub async fn get_serial_console_history(

--- a/phd-tests/framework/src/test_vm/spec.rs
+++ b/phd-tests/framework/src/test_vm/spec.rs
@@ -34,13 +34,13 @@ pub struct VmSpec {
 }
 
 impl VmSpec {
-    /// Yields an array of handles to this VM's Crucible disks.
-    pub fn get_crucible_disks(&self) -> Vec<Arc<dyn disk::DiskConfig>> {
+    pub fn get_disk_by_device_name(
+        &self,
+        name: &str,
+    ) -> Option<&Arc<dyn disk::DiskConfig>> {
         self.disk_handles
             .iter()
-            .filter(|d| d.as_crucible().is_some())
-            .cloned()
-            .collect()
+            .find(|disk| disk.device_name().as_str() == name)
     }
 
     /// Update the Crucible backend specs in the instance spec to match the

--- a/phd-tests/framework/src/test_vm/spec.rs
+++ b/phd-tests/framework/src/test_vm/spec.rs
@@ -34,6 +34,15 @@ pub struct VmSpec {
 }
 
 impl VmSpec {
+    /// Yields an array of handles to this VM's Crucible disks.
+    pub fn get_crucible_disks(&self) -> Vec<Arc<dyn disk::DiskConfig>> {
+        self.disk_handles
+            .iter()
+            .filter(|d| d.as_crucible().is_some())
+            .cloned()
+            .collect()
+    }
+
     /// Update the Crucible backend specs in the instance spec to match the
     /// current backend specs given by this specification's disk handles.
     pub(crate) fn refresh_crucible_backends(&mut self) {

--- a/phd-tests/tests/src/crucible/smoke.rs
+++ b/phd-tests/tests/src/crucible/smoke.rs
@@ -4,6 +4,10 @@
 
 use std::time::Duration;
 
+use phd_framework::{
+    disk::{BlockSize, DiskSource},
+    test_vm::{DiskBackend, DiskInterface},
+};
 use phd_testcase::*;
 use propolis_client::types::InstanceState;
 
@@ -81,4 +85,35 @@ async fn shutdown_persistence_test(ctx: &Framework) {
     // The touched file from the previous VM should be present in the new one.
     let lsout = vm.run_shell_command("ls foo.bar 2> /dev/null").await?;
     assert_eq!(lsout, "foo.bar");
+}
+
+#[phd_testcase]
+async fn vcr_replace_test(ctx: &Framework) {
+    let mut config = ctx.vm_config_builder("crucible_vcr_replace_test");
+
+    // Create a blank data disk on which to perform VCR replacement. This is
+    // necessary because Crucible doesn't permit VCR replacements for volumes
+    // whose read-only parents are local files (which is true for artifact-based
+    // Crucible disks).
+    config.data_disk(
+        "vcr-replacement-target",
+        DiskSource::Blank(1024 * 1024 * 1024),
+        DiskInterface::Nvme,
+        DiskBackend::Crucible {
+            min_disk_size_gib: 1,
+            block_size: BlockSize::Bytes512,
+        },
+        5,
+    );
+
+    let spec = config.vm_spec(ctx).await?;
+    let disks = spec.get_crucible_disks();
+    let disk = disks[0].as_crucible().unwrap();
+
+    let mut vm = ctx.spawn_vm_with_spec(spec, None).await?;
+    vm.launch().await?;
+    vm.wait_to_boot().await?;
+
+    disk.set_generation(2);
+    vm.replace_crucible_vcr(disk).await?;
 }

--- a/phd-tests/tests/src/crucible/smoke.rs
+++ b/phd-tests/tests/src/crucible/smoke.rs
@@ -95,8 +95,9 @@ async fn vcr_replace_test(ctx: &Framework) {
     // necessary because Crucible doesn't permit VCR replacements for volumes
     // whose read-only parents are local files (which is true for artifact-based
     // Crucible disks).
+    const DATA_DISK_NAME: &str = "vcr-replacement-target";
     config.data_disk(
-        "vcr-replacement-target",
+        DATA_DISK_NAME,
         DiskSource::Blank(1024 * 1024 * 1024),
         DiskInterface::Nvme,
         DiskBackend::Crucible {
@@ -107,8 +108,9 @@ async fn vcr_replace_test(ctx: &Framework) {
     );
 
     let spec = config.vm_spec(ctx).await?;
-    let disks = spec.get_crucible_disks();
-    let disk = disks[0].as_crucible().unwrap();
+    let disk_hdl =
+        spec.get_disk_by_device_name(DATA_DISK_NAME).cloned().unwrap();
+    let disk = disk_hdl.as_crucible().unwrap();
 
     let mut vm = ctx.spawn_vm_with_spec(spec, None).await?;
     vm.launch().await?;


### PR DESCRIPTION
Add a smoke test for Crucible VCR replacement:

- Add a `CrucibleDisk` function to get a disk's current VCR.
- Add a `TestVm` framework to send a VCR replacement request.
- Fix a couple of bugs in Crucible disk setup:
  - The `id` field in the VCR's `CrucibleOpts` needs to be the same in the old and new VCRs, so use the disk ID for it instead of calling `Uuid::new_v4()` every time the VCR is generated.
  - When using a `Blank` disk source, properly account for the fact that the disk source size is given in bytes, not gibibytes.

Also add a couple of bells and whistles to allow this test to be transformed into a test of VCR replacement during VM startup:

- Make PHD's `VmSpec` type a public type and amend `Framework` to allow tests to create a VM from a spec. This gives tests a way to access a config's Crucible disks before actually launching a VM (and sending an instance spec to Propolis).
- Reorganize the `CrucibleDisk` types to wrap the disk innards in a `Mutex`, allowing them to be mutated through the `Arc` references that tests get. This will eventually be used to allow tests to override the downstairs addresses in a disk's VCRs before launching a VM that uses that disk, which will be used to test fixes for #841. In the meantime, use the mutex to protect the VCR generation number, which no longer needs to be an `AtomicU64`.