### PR TITLE
server: improve behavior of starting VMs that are waiting for Crucible activation

### DIFF
--- a/bin/propolis-cli/src/main.rs
+++ b/bin/propolis-cli/src/main.rs
@@ -155,8 +155,8 @@ enum Command {
     /// Call the VolumeConstructionRequest replace endpoint
     Vcr {
         /// Uuid for the disk
-        #[clap(short = 'u', action)]
-        uuid: Uuid,
+        #[clap(short = 'd', action)]
+        disk_id: String,
 
         /// File with a JSON InstanceVcrReplace struct
         #[clap(long, action)]
@@ -510,7 +510,7 @@ async fn new_instance(
 
 async fn replace_vcr(
     client: &Client,
-    id: Uuid,
+    id: String,
     vcr_replace: InstanceVcrReplace,
 ) -> anyhow::Result<()> {
     // Try to call the endpoint
@@ -941,9 +941,9 @@ async fn main() -> anyhow::Result<()> {
         }
         Command::Monitor => monitor(addr).await?,
         Command::InjectNmi => inject_nmi(&client).await?,
-        Command::Vcr { uuid, vcr_replace } => {
+        Command::Vcr { disk_id, vcr_replace } => {
             let replace: InstanceVcrReplace = parse_json_file(&vcr_replace)?;
-            replace_vcr(&client, uuid, replace).await?
+            replace_vcr(&client, disk_id, replace).await?
         }
     }
 

--- a/bin/propolis-server/src/lib/vm/objects.rs
+++ b/bin/propolis-server/src/lib/vm/objects.rs
@@ -23,9 +23,7 @@ use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::{serial::Serial, spec::Spec, vcpu_tasks::VcpuTaskController};
 
-use super::{
-    state_driver::VmStartReason, BlockBackendMap, CrucibleBackendMap, DeviceMap,
-};
+use super::{BlockBackendMap, CrucibleBackendMap, DeviceMap};
 
 /// A collection of components that make up a Propolis VM instance.
 pub(crate) struct VmObjects {
@@ -189,6 +187,14 @@ impl VmObjectsLocked {
         &self.ps2ctrl
     }
 
+    pub(crate) fn device_map(&self) -> &DeviceMap {
+        &self.devices
+    }
+
+    pub(crate) fn block_backend_map(&self) -> &BlockBackendMap {
+        &self.block_backends
+    }
+
     /// Iterates over all of the lifecycle trait objects in this VM and calls
     /// `func` on each one.
     pub(crate) fn for_each_device(
@@ -244,33 +250,6 @@ impl VmObjectsLocked {
         self.machine.reinitialize().unwrap();
     }
 
-    /// Starts a VM's devices and allows all of its vCPU tasks to run.
-    ///
-    /// This function may be called either after initializing a new VM from
-    /// scratch or after an inbound live migration. In the latter case, this
-    /// routine assumes that the caller initialized and activated the VM's vCPUs
-    /// prior to importing state from the migration source.
-    pub(super) async fn start(
-        &mut self,
-        reason: VmStartReason,
-    ) -> anyhow::Result<()> {
-        match reason {
-            VmStartReason::ExplicitRequest => {
-                self.reset_vcpus();
-            }
-            VmStartReason::MigratedIn => {
-                self.resume_kernel_vm();
-            }
-        }
-
-        let result = self.start_devices().await;
-        if result.is_ok() {
-            self.vcpu_tasks.resume_all();
-        }
-
-        result
-    }
-
     /// Pauses this VM's devices and its kernel VMM.
     pub(crate) async fn pause(&mut self) {
         // Order matters here: the Propolis lifecycle trait's pause function
@@ -288,6 +267,16 @@ impl VmObjectsLocked {
         // that all devices resume before any vCPUs do.
         self.resume_kernel_vm();
         self.resume_devices();
+        self.resume_vcpus();
+    }
+
+    /// Resumes this VM's vCPU tasks.
+    ///
+    /// This is intended for use in VM startup sequences where the state driver
+    /// needs fine-grained control over the order in which devices and vCPUs
+    /// start. When pausing and resuming a VM that's already been started, use
+    /// [`Self::pause`] and [`Self::resume`] instead.
+    pub(crate) fn resume_vcpus(&mut self) {
         self.vcpu_tasks.resume_all();
     }
 
@@ -321,31 +310,7 @@ impl VmObjectsLocked {
         // Resume devices so they're ready to do more work, then resume
         // vCPUs.
         self.resume_devices();
-        self.vcpu_tasks.resume_all();
-    }
-
-    /// Starts all of a VM's devices and allows its block backends to process
-    /// requests from their devices.
-    async fn start_devices(&self) -> anyhow::Result<()> {
-        self.for_each_device_fallible(|name, dev| {
-            info!(self.log, "sending startup complete to {}", name);
-            let res = dev.start();
-            if let Err(e) = &res {
-                error!(self.log, "startup failed for {}: {:?}", name, e);
-            }
-            res
-        })?;
-
-        for (name, backend) in self.block_backends.iter() {
-            info!(self.log, "starting block backend {}", name);
-            let res = backend.start().await;
-            if let Err(e) = &res {
-                error!(self.log, "startup failed for {}: {:?}", name, e);
-                return res;
-            }
-        }
-
-        Ok(())
+        self.resume_vcpus();
     }
 
     /// Pauses all of a VM's devices.

--- a/bin/propolis-server/src/lib/vm/request_queue.rs
+++ b/bin/propolis-server/src/lib/vm/request_queue.rs
@@ -88,10 +88,6 @@ impl std::fmt::Debug for StateChangeRequest {
 pub enum ComponentChangeRequest {
     /// Attempts to update the volume construction request for the supplied
     /// Crucible volume.
-    ///
-    /// TODO: Due to https://github.com/oxidecomputer/crucible/issues/871, this
-    /// is only allowed once the VM is started and the volume has activated, but
-    /// it should be allowed even before the VM has started.
     ReconfigureCrucibleVolume {
         /// The ID of the Crucible backend in the VM's Crucible backend map.
         backend_id: SpecKey,
@@ -356,7 +352,6 @@ impl ExternalRequestQueue {
                     "request" => ?request,
                     "reason" => %reason
                 );
-
                 return Err(reason);
             }
         }
@@ -795,7 +790,6 @@ mod test {
     fn mutation_disallowed_after_stopped() {
         let mut queue =
             ExternalRequestQueue::new(test_logger(), InstanceAutoStart::Yes);
-
         queue.notify_request_completed(CompletedRequest::Start {
             succeeded: true,
         });

--- a/phd-tests/framework/src/lib.rs
+++ b/phd-tests/framework/src/lib.rs
@@ -290,15 +290,8 @@ impl Framework {
         vm: &TestVm,
         environment: Option<&EnvironmentSpec>,
     ) -> anyhow::Result<TestVm> {
-        let mut vm_spec =
-            VmSpec { vm_name: vm_name.to_owned(), ..vm.vm_spec() };
-
-        // Reconcile any differences between the generation numbers in the VM
-        // objects' instance spec and the associated Crucible disk handles.
-        // This may be needed because a test can call `set_generation` on a disk
-        // handle to change its active generation number mid-test, and this
-        // won't automatically be reflected in the VM's instance spec.
-        vm_spec.refresh_crucible_backends();
+        let mut vm_spec = vm.vm_spec().clone();
+        vm_spec.set_vm_name(vm_name.to_owned());
 
         // Create new metadata for an instance based on this predecessor. It
         // should have the same project and silo IDs, but the sled identifiers

--- a/phd-tests/framework/src/test_vm/config.rs
+++ b/phd-tests/framework/src/test_vm/config.rs
@@ -387,14 +387,14 @@ impl<'dr> VmConfig<'dr> {
             sled_serial: sled_id.to_string(),
         };
 
-        Ok(VmSpec {
-            vm_name: vm_name.clone(),
-            instance_spec: spec,
+        Ok(VmSpec::new(
+            vm_name.clone(),
+            spec,
             disk_handles,
             guest_os_kind,
             bootrom_path,
             metadata,
-        })
+        ))
     }
 }
 

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -292,7 +292,7 @@ impl TestVm {
 
         let init = match migrate {
             None => InstanceInitializationMethod::Spec {
-                spec: self.spec.instance_spec.clone(),
+                spec: self.spec.instance_spec(),
             },
             Some(info) => InstanceInitializationMethod::MigrationTarget {
                 migration_id: info.migration_id,
@@ -489,7 +489,7 @@ impl TestVm {
         let timeout_duration = match Into::<MigrationTimeout>::into(timeout) {
             MigrationTimeout::Explicit(val) => val,
             MigrationTimeout::InferFromMemorySize => {
-                let mem_mib = self.spec.instance_spec.board.memory_mb;
+                let mem_mib = self.spec.instance_spec().board.memory_mb;
                 std::time::Duration::from_secs(
                     (MIGRATION_SECS_PER_GUEST_GIB * mem_mib) / 1024,
                 )
@@ -573,7 +573,7 @@ impl TestVm {
 
     fn generate_replacement_components(&self) -> ReplacementComponents {
         let mut map = ReplacementComponents::new();
-        for (id, comp) in &self.spec.instance_spec.components {
+        for (id, comp) in &self.spec.instance_spec().components {
             match comp {
                 ComponentV0::MigrationFailureInjector(inj) => {
                     map.insert(

--- a/phd-tests/framework/src/test_vm/spec.rs
+++ b/phd-tests/framework/src/test_vm/spec.rs
@@ -18,7 +18,7 @@ pub struct VmSpec {
     pub vm_name: String,
 
     /// The instance spec to pass to the VM when starting the guest.
-    pub instance_spec: InstanceSpecV0,
+    base_instance_spec: InstanceSpecV0,
 
     /// A set of handles to disk files that the VM's disk backends refer to.
     pub disk_handles: Vec<Arc<dyn disk::DiskConfig>>,
@@ -43,9 +43,37 @@ impl VmSpec {
             .find(|disk| disk.device_name().as_str() == name)
     }
 
+    pub(crate) fn new(
+        vm_name: String,
+        instance_spec: InstanceSpecV0,
+        disk_handles: Vec<Arc<dyn disk::DiskConfig>>,
+        guest_os_kind: GuestOsKind,
+        bootrom_path: Utf8PathBuf,
+        metadata: InstanceMetadata,
+    ) -> Self {
+        Self {
+            vm_name,
+            base_instance_spec: instance_spec,
+            disk_handles,
+            guest_os_kind,
+            bootrom_path,
+            metadata,
+        }
+    }
+
+    pub(crate) fn set_vm_name(&mut self, name: String) {
+        self.vm_name = name
+    }
+
+    pub(crate) fn instance_spec(&self) -> InstanceSpecV0 {
+        let mut spec = self.base_instance_spec.clone();
+        self.set_crucible_backends(&mut spec);
+        spec
+    }
+
     /// Update the Crucible backend specs in the instance spec to match the
     /// current backend specs given by this specification's disk handles.
-    pub(crate) fn refresh_crucible_backends(&mut self) {
+    fn set_crucible_backends(&self, spec: &mut InstanceSpecV0) {
         for disk in &self.disk_handles {
             let disk = if let Some(disk) = disk.as_crucible() {
                 disk
@@ -57,11 +85,9 @@ impl VmSpec {
             let backend_name =
                 disk.device_name().clone().into_backend_name().into_string();
             if let Some(ComponentV0::CrucibleStorageBackend(_)) =
-                self.instance_spec.components.get(&backend_name)
+                spec.components.get(&backend_name)
             {
-                self.instance_spec
-                    .components
-                    .insert(backend_name, backend_spec);
+                spec.components.insert(backend_name, backend_spec);
             }
         }
     }

--- a/phd-tests/tests/src/crucible/smoke.rs
+++ b/phd-tests/tests/src/crucible/smoke.rs
@@ -88,8 +88,13 @@ async fn shutdown_persistence_test(ctx: &Framework) {
 }
 
 #[phd_testcase]
-async fn vcr_replace_test(ctx: &Framework) {
-    let mut config = ctx.vm_config_builder("crucible_vcr_replace_test");
+async fn vcr_replace_during_start_test(ctx: &Framework) {
+    if !ctx.crucible_enabled() {
+        phd_skip!("Crucible backends not enabled (no downstairs path)");
+    }
+
+    let mut config =
+        ctx.vm_config_builder("crucible_vcr_replace_during_start_test");
 
     // Create a blank data disk on which to perform VCR replacement. This is
     // necessary because Crucible doesn't permit VCR replacements for volumes
@@ -107,15 +112,38 @@ async fn vcr_replace_test(ctx: &Framework) {
         5,
     );
 
+    // Configure the disk so that when the VM starts, it will have an invalid
+    // downstairs address.
     let spec = config.vm_spec(ctx).await?;
     let disk_hdl =
         spec.get_disk_by_device_name(DATA_DISK_NAME).cloned().unwrap();
     let disk = disk_hdl.as_crucible().unwrap();
+    disk.enable_vcr_black_hole();
 
+    // Try to start the VM, but don't wait for it to boot; it should get stuck
+    // while activating using an invalid downstairs address.
     let mut vm = ctx.spawn_vm_with_spec(spec, None).await?;
     vm.launch().await?;
+
+    // The VM is expected not to reach the Running state. Unfortunately, there's
+    // no great way to test that this is never going to happen; as a best-effort
+    // alternative, wait for a short while and assert that the VM doesn't reach
+    // Running in the timeout interval.
+    vm.wait_for_state(InstanceState::Running, Duration::from_secs(5))
+        .await
+        .unwrap_err();
+
+    // Fix the disk's downstairs address and send a replacement request. This
+    // should be processed and should allow the VM to boot.
+    disk.disable_vcr_black_hole();
+    disk.set_generation(2);
+    vm.replace_crucible_vcr(disk).await?;
     vm.wait_to_boot().await?;
 
-    disk.set_generation(2);
+    assert_eq!(vm.get().await?.instance.state, InstanceState::Running);
+
+    // VCR replacements should continue to be accepted now that the instance is
+    // running.
+    disk.set_generation(3);
     vm.replace_crucible_vcr(disk).await?;
 }

--- a/phd-tests/tests/src/server_state_machine.rs
+++ b/phd-tests/tests/src/server_state_machine.rs
@@ -6,6 +6,10 @@
 
 use std::time::Duration;
 
+use phd_framework::{
+    disk::{BlockSize, DiskSource},
+    test_vm::{DiskBackend, DiskInterface},
+};
 use phd_testcase::*;
 use propolis_client::types::InstanceState;
 
@@ -88,4 +92,50 @@ async fn instance_reset_requires_running_test(ctx: &Framework) {
     assert!(vm.reset().await.is_err());
     vm.launch().await?;
     vm.wait_for_state(InstanceState::Running, Duration::from_secs(60)).await?;
+}
+
+#[phd_testcase]
+async fn stop_while_blocked_on_start_test(ctx: &Framework) {
+    // This test uses a Crucible disk backend to cause VM startup to block.
+    if !ctx.crucible_enabled() {
+        phd_skip!("test requires Crucible support");
+    }
+
+    let mut config = ctx.vm_config_builder("stop_while_blocked_on_start_test");
+
+    // Create a VM that blocks while starting by attaching a Crucible data disk
+    // to it and enabling the black hole address in its volume construction
+    // request. The invalid address will keep Crucible from activating and so
+    // will block the VM from fully starting.
+    const DATA_DISK_NAME: &str = "vcr-replacement-target";
+    config.data_disk(
+        DATA_DISK_NAME,
+        DiskSource::Blank(1024 * 1024 * 1024),
+        DiskInterface::Nvme,
+        DiskBackend::Crucible {
+            min_disk_size_gib: 1,
+            block_size: BlockSize::Bytes512,
+        },
+        5,
+    );
+
+    let spec = config.vm_spec(ctx).await?;
+    let disk_hdl =
+        spec.get_disk_by_device_name(DATA_DISK_NAME).cloned().unwrap();
+    let disk = disk_hdl.as_crucible().unwrap();
+    disk.enable_vcr_black_hole();
+
+    // Launch the VM and wait for it to advertise that its components are
+    // starting.
+    let mut vm = ctx.spawn_vm_with_spec(spec, None).await?;
+    vm.launch().await?;
+    vm.wait_for_state(InstanceState::Starting, Duration::from_secs(15))
+        .await
+        .unwrap();
+
+    // Send a stop request. This should enqueue successfully, and the VM should
+    // shut down even though activation is blocked.
+    vm.stop().await?;
+    vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))
+        .await?;
 }


### PR DESCRIPTION
Modify the state driver's VM startup procedure to allow the driver to process Crucible volume configuration changes while block backends are being activated. This fixes a livelock that occurs when starting a VM with a Crucible VCR that points to an unavailable downstairs: the unavailable downstairs prevents Crucible activation from proceeding; Nexus sends a corrected VCR that, if applied, would allow the upstairs to activate; but the state driver never applies the new VCR because it's blocked trying to activate using the broken VCR.

Since the state driver can now dequeue VM state change requests during startup, also teach it to abort startup if a stop request is received while block backends are starting. This is very slightly spicy, because it can cancel a block backend startup future in a way that was not possible before, but (a) the only affected backend is the Crucible backend, and (b) there should be no requests in flight anyway because, if this case is reached, the VM's vCPUs have not started.

Add PHD coverage of the new behaviors:

- Modify the PHD VCR replacement smoke test to check that start requests with a bad set of Crucible targets can be unblocked by replacing a bad target with a good target.
- Add a server state machine test that checks that a VM that is blocked waiting for Crucible activation can be explicitly stopped.

To assist with this, add a feature to PHD Crucible disks that allows a test to specify that a disk's generated VCRs should contain an invalid downstairs IP address. Starting a VM with a disk configured this way will cause activation to block until the disk's VCR is replaced with a corrected VCR.

Tests: cargo test, PHD w/Alpine and Debian 11 guests.

Fixes #841.