### PR TITLE
phd: wait for source to resume before asking to migrate again

### DIFF
--- a/phd-tests/tests/src/migrate.rs
+++ b/phd-tests/tests/src/migrate.rs
@@ -181,6 +181,15 @@ mod running_process {
             .state;
         assert_eq!(target_migration_state, MigrationState::Error);
 
+        // Wait for the source to report that it has resumed before requesting
+        // another migration.
+        source
+            .wait_for_state(
+                InstanceState::Running,
+                std::time::Duration::from_secs(5),
+            )
+            .await?;
+
         // try again. this time, it should work!
         target2
             .migrate_from(&source, Uuid::new_v4(), MigrationTimeout::default())
@@ -233,6 +242,15 @@ mod running_process {
             .expect("target should have a migration-in status")
             .state;
         assert_eq!(target_migration_state, MigrationState::Error);
+
+        // Wait for the source to report that it has resumed before requesting
+        // another migration.
+        source
+            .wait_for_state(
+                InstanceState::Running,
+                std::time::Duration::from_secs(5),
+            )
+            .await?;
 
         // try again. this time, it should work!
         target2


### PR DESCRIPTION
The `import_failure` and `export_failure` PHD migration tests request a migration that they expect to fail, wait for that failure, and then request a second migration that they expect to succeed. The catch is that after the first migration, the tests only wait for the *target* to report failure before proceeding; they also need to wait for the source to report that it has resumed and that new migration requests will be accepted.

To solve this, have these test cases wait for the source to return to the Running state before requesting their second migration.

Tests: ran the old tests with a small Propolis change that makes migration sources wait several seconds between discovering that migration has failed and returning to Running; verified that the tests fail consistently without this fix and pass consistently with it. Also ran the `import_failure` test in a loop on a test machine; it usually fails within 5-10 minutes without the fix but passes consistently with it.

Fixes #811.