### PR TITLE
lib: use correct MAXCPU value in CPUID specializer

### DIFF
--- a/lib/propolis/src/cpuid.rs
+++ b/lib/propolis/src/cpuid.rs
@@ -70,7 +70,7 @@ impl Specializer {
 
     /// Specify vCPU ID to specialize for
     pub fn with_vcpuid(self, vcpuid: i32) -> Self {
-        assert!((vcpuid as usize) < bhyve_api::VM_MAXCPU);
+        assert!((vcpuid as usize) < crate::vcpu::MAXCPU);
         Self { vcpuid: Some(vcpuid), ..self }
     }
 


### PR DESCRIPTION
Make the CPUID specializer use the vCPU limit specified by the current build configuration instead of using the fixed limit from the `bhyve_api` crate.

Tested as follows:

- obtain a system running the stlouis branch
- build `propolis-server` with the `omicron-build` feature enabled
- create a small reservoir (required to launch VMs in this configuration)
- attempt to create a VM with 64 vCPUs

Without this change, Propolis panics; with it the VM is successfully created. (Note that on a mainline Helios install, i.e. one not built from the stlouis branch, Propolis won't panic, but the VM will still fail to start, because the call to configure CPUID for the 33rd CPU will fail.) The resulting VM appears to operate normally, and `nproc` reports that all 64 vCPUs are visible to the guest.

Fixes #875.