### PR TITLE
server: extend API request queue's memory of prior requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4609,6 +4609,7 @@ dependencies = [
  "propolis",
  "propolis_api_types",
  "propolis_types",
+ "proptest",
  "reqwest 0.12.7",
  "rfb",
  "rgb_frame",

--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -73,6 +73,7 @@ ring.workspace = true
 slog = { workspace = true, features = [ "max_level_trace", "release_max_level_debug" ] }
 expectorate.workspace = true
 mockall.workspace = true
+proptest.workspace = true
 
 [features]
 default = []
@@ -83,7 +84,6 @@ omicron-build = ["propolis/omicron-build"]
 
 # Falcon builds require corresponding bits turned on in the dependency libs
 falcon = ["propolis/falcon"]
-
 # Testing necessitates injecting failures which should hopefully be rare or even
 # never occur on real otherwise-unperturbed systems. We conditionally compile
 # code supporting failure injection to avoid the risk of somehow injecting

--- a/bin/propolis-server/src/lib/vm/active.rs
+++ b/bin/propolis-server/src/lib/vm/active.rs
@@ -63,9 +63,9 @@ impl ActiveVm {
 
         self.state_driver_queue
             .queue_external_request(match requested {
-                InstanceStateRequested::Run => ExternalRequest::Start,
-                InstanceStateRequested::Stop => ExternalRequest::Stop,
-                InstanceStateRequested::Reboot => ExternalRequest::Reboot,
+                InstanceStateRequested::Run => ExternalRequest::start(),
+                InstanceStateRequested::Stop => ExternalRequest::stop(),
+                InstanceStateRequested::Reboot => ExternalRequest::reboot(),
             })
             .map_err(Into::into)
     }
@@ -79,10 +79,7 @@ impl ActiveVm {
         websock: dropshot::WebsocketConnection,
     ) -> Result<(), VmError> {
         Ok(self.state_driver_queue.queue_external_request(
-            ExternalRequest::MigrateAsSource {
-                migration_id,
-                websock: websock.into(),
-            },
+            ExternalRequest::migrate_as_source(migration_id, websock),
         )?)
     }
 
@@ -107,11 +104,11 @@ impl ActiveVm {
     ) -> Result<(), VmError> {
         self.state_driver_queue
             .queue_external_request(
-                ExternalRequest::ReconfigureCrucibleVolume {
+                ExternalRequest::reconfigure_crucible_volume(
                     backend_id,
                     new_vcr_json,
                     result_tx,
-                },
+                ),
             )
             .map_err(Into::into)
     }

--- a/bin/propolis-server/src/lib/vm/state_driver.rs
+++ b/bin/propolis-server/src/lib/vm/state_driver.rs
@@ -119,7 +119,10 @@ use super::{
     },
     guest_event::{self, GuestEvent},
     objects::VmObjects,
-    request_queue::{self, ExternalRequest, InstanceAutoStart},
+    request_queue::{
+        self, CompletedRequest, ComponentChangeRequest, ExternalRequest,
+        InstanceAutoStart, StateChangeRequest,
+    },
     state_publisher::{MigrationStateUpdate, StatePublisher},
     InstanceEnsureResponseTx,
 };
@@ -227,15 +230,19 @@ impl InputQueue {
         }
     }
 
-    /// Notifies the external request queue that the instance's state has
-    /// changed so that it can change the dispositions for new state change
-    /// requests.
-    fn notify_instance_state_change(
-        &self,
-        state: request_queue::InstanceStateChange,
-    ) {
+    /// Notifies the external request queue that the state driver has completed
+    /// a request from that queue.
+    fn notify_request_completed(&self, state: CompletedRequest) {
         let mut guard = self.inner.lock().unwrap();
-        guard.external_requests.notify_instance_state_change(state);
+        guard.external_requests.notify_request_completed(state);
+    }
+
+    /// Notifies the external request queue that the instance has stopped. This
+    /// is used to stop the queue when the instance stops without a request from
+    /// the API (e.g. because the guest requested a chipset-driven shutdown).
+    fn notify_stopped(&self) {
+        let mut guard = self.inner.lock().unwrap();
+        guard.external_requests.notify_stopped();
     }
 
     /// Submits an external state change request to the queue.
@@ -522,14 +529,23 @@ impl StateDriver {
 
         let start_result =
             self.objects.lock_exclusive().await.start(start_reason).await;
+
+        self.input_queue.notify_request_completed(CompletedRequest::Start {
+            succeeded: start_result.is_ok(),
+        });
+
         match &start_result {
             Ok(()) => {
-                self.publish_steady_state(InstanceState::Running);
+                self.external_state.update(ExternalStateUpdate::Instance(
+                    InstanceState::Running,
+                ));
             }
             Err(e) => {
                 error!(&self.log, "failed to start devices";
                                  "error" => ?e);
-                self.publish_steady_state(InstanceState::Failed);
+                self.external_state.update(ExternalStateUpdate::Instance(
+                    InstanceState::Failed,
+                ));
             }
         }
 
@@ -544,6 +560,11 @@ impl StateDriver {
             GuestEvent::VcpuSuspendHalt(_when) => {
                 info!(self.log, "Halting due to VM suspend event",);
                 self.do_halt().await;
+                self.external_state.update(ExternalStateUpdate::Instance(
+                    InstanceState::Stopped,
+                ));
+
+                self.input_queue.notify_stopped();
                 HandleEventOutcome::Exit {
                     final_state: InstanceState::Destroyed,
                 }
@@ -564,6 +585,11 @@ impl StateDriver {
             GuestEvent::ChipsetHalt => {
                 info!(self.log, "Halting due to chipset-driven halt");
                 self.do_halt().await;
+                self.external_state.update(ExternalStateUpdate::Instance(
+                    InstanceState::Stopped,
+                ));
+
+                self.input_queue.notify_stopped();
                 HandleEventOutcome::Exit {
                     final_state: InstanceState::Destroyed,
                 }
@@ -581,7 +607,7 @@ impl StateDriver {
         request: ExternalRequest,
     ) -> HandleEventOutcome {
         match request {
-            ExternalRequest::Start => {
+            ExternalRequest::State(StateChangeRequest::Start) => {
                 match self.start_vm(VmStartReason::ExplicitRequest).await {
                     Ok(_) => HandleEventOutcome::Continue,
                     Err(_) => HandleEventOutcome::Exit {
@@ -589,31 +615,50 @@ impl StateDriver {
                     },
                 }
             }
-            ExternalRequest::MigrateAsSource { migration_id, websock } => {
-                self.migrate_as_source(migration_id, websock.into_inner())
-                    .await;
-
-                // The callee either queues its own stop request (on a
-                // successful migration out) or resumes the VM (on a failed
-                // migration out). Either way, the main loop can just proceed to
-                // process the queue as normal.
-                HandleEventOutcome::Continue
+            ExternalRequest::State(StateChangeRequest::MigrateAsSource {
+                migration_id,
+                websock,
+            }) => {
+                if self
+                    .migrate_as_source(migration_id, websock.into_inner())
+                    .await
+                    .is_ok()
+                {
+                    self.do_halt().await;
+                    HandleEventOutcome::Exit {
+                        final_state: InstanceState::Destroyed,
+                    }
+                } else {
+                    HandleEventOutcome::Continue
+                }
             }
-            ExternalRequest::Reboot => {
+            ExternalRequest::State(StateChangeRequest::Reboot) => {
                 self.do_reboot().await;
+                self.input_queue
+                    .notify_request_completed(CompletedRequest::Reboot);
+
                 HandleEventOutcome::Continue
             }
-            ExternalRequest::Stop => {
+            ExternalRequest::State(StateChangeRequest::Stop) => {
                 self.do_halt().await;
+                self.external_state.update(ExternalStateUpdate::Instance(
+                    InstanceState::Stopped,
+                ));
+
+                self.input_queue
+                    .notify_request_completed(CompletedRequest::Stop);
+
                 HandleEventOutcome::Exit {
                     final_state: InstanceState::Destroyed,
                 }
             }
-            ExternalRequest::ReconfigureCrucibleVolume {
-                backend_id,
-                new_vcr_json,
-                result_tx,
-            } => {
+            ExternalRequest::Component(
+                ComponentChangeRequest::ReconfigureCrucibleVolume {
+                    backend_id,
+                    new_vcr_json,
+                    result_tx,
+                },
+            ) => {
                 let _ = result_tx.send(
                     self.reconfigure_crucible_volume(&backend_id, new_vcr_json)
                         .await,
@@ -633,9 +678,6 @@ impl StateDriver {
 
         // Notify other consumers that the instance successfully rebooted and is
         // now back to Running.
-        self.input_queue.notify_instance_state_change(
-            request_queue::InstanceStateChange::Rebooted,
-        );
         self.external_state
             .update(ExternalStateUpdate::Instance(InstanceState::Running));
     }
@@ -658,34 +700,13 @@ impl StateDriver {
 
             guard.halt().await;
         }
-
-        self.publish_steady_state(InstanceState::Stopped);
-    }
-
-    fn publish_steady_state(&mut self, state: InstanceState) {
-        let change = match state {
-            InstanceState::Running => {
-                request_queue::InstanceStateChange::StartedRunning
-            }
-            InstanceState::Stopped => {
-                request_queue::InstanceStateChange::Stopped
-            }
-            InstanceState::Failed => request_queue::InstanceStateChange::Failed,
-            _ => panic!(
-                "Called publish_steady_state on non-terminal state {:?}",
-                state
-            ),
-        };
-
-        self.input_queue.notify_instance_state_change(change);
-        self.external_state.update(ExternalStateUpdate::Instance(state));
     }
 
     async fn migrate_as_source(
         &mut self,
         migration_id: Uuid,
         websock: dropshot::WebsocketConnection,
-    ) {
+    ) -> Result<(), ()> {
         let conn = tokio_tungstenite::WebSocketStream::from_raw_socket(
             websock.into_inner(),
             tokio_tungstenite::tungstenite::protocol::Role::Server,
@@ -712,7 +733,7 @@ impl StateDriver {
                     },
                 ));
 
-                return;
+                return Err(());
             }
         };
 
@@ -740,15 +761,25 @@ impl StateDriver {
                 // On a successful migration out, the protocol promises to leave
                 // the VM objects in a paused state, so don't pause them again.
                 self.paused = true;
-                self.input_queue
-                    .queue_external_request(ExternalRequest::Stop)
-                    .expect("can always queue a request to stop");
+                self.input_queue.notify_request_completed(
+                    CompletedRequest::MigrationOut { succeeded: true },
+                );
+
+                Ok(())
             }
             Err(e) => {
                 info!(self.log, "migration out failed, resuming";
                       "error" => ?e);
 
-                self.publish_steady_state(InstanceState::Running);
+                self.input_queue.notify_request_completed(
+                    CompletedRequest::MigrationOut { succeeded: false },
+                );
+
+                self.external_state.update(ExternalStateUpdate::Instance(
+                    InstanceState::Running,
+                ));
+
+                Err(())
             }
         }
     }

--- a/bin/propolis-server/src/proptest-regressions/vm/request_queue.txt
+++ b/bin/propolis-server/src/proptest-regressions/vm/request_queue.txt
@@ -1,0 +1,11 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 467749978aea2988f7790844904751ed5f0797f700949e702db74ae430a659e0 # shrinks to reqs = [Migrate, Stop]
+cc 03ba07e9b5a99141bddd9b878bff86845a6da9eb1aa015b3afc7b3ebfed7a6d1 # shrinks to reqs = [Start, Stop, Migrate]
+cc 67a067444d475068e86b43528884319ff178d6d9038a3d9223c32789f871baa3 # shrinks to reqs = [Start, Migrate]
+cc b3df4b82bdb87e3533f4bd47f0a3ee8be21893c0afc15b472281b2a79006aadf # shrinks to reqs = [Migrate]
+cc 3430b43ba860946e5feb7b3b0246623708efb1465dd4fe7a604ddf479d4dc3ae # shrinks to reqs = [Start { will_succeed: true }, Migrate { will_succeed: false }, Reboot]

--- a/bin/propolis-server/src/proptest-regressions/vm/request_queue.txt
+++ b/bin/propolis-server/src/proptest-regressions/vm/request_queue.txt
@@ -9,3 +9,4 @@ cc 03ba07e9b5a99141bddd9b878bff86845a6da9eb1aa015b3afc7b3ebfed7a6d1 # shrinks to
 cc 67a067444d475068e86b43528884319ff178d6d9038a3d9223c32789f871baa3 # shrinks to reqs = [Start, Migrate]
 cc b3df4b82bdb87e3533f4bd47f0a3ee8be21893c0afc15b472281b2a79006aadf # shrinks to reqs = [Migrate]
 cc 3430b43ba860946e5feb7b3b0246623708efb1465dd4fe7a604ddf479d4dc3ae # shrinks to reqs = [Start { will_succeed: true }, Migrate { will_succeed: false }, Reboot]
+cc 2e8b284223a88421aaed16749309839818c16efda4bc4d8d930a35cbdce018cd # shrinks to ops = [Enqueue(ReconfigureCrucible), Enqueue(Start { will_succeed: true }), Dequeue]


### PR DESCRIPTION
Today the server's API request queue decides whether to accept or reject incoming requests by storing a fixed disposition for each kind of request and adjusting those dispositions as new requests are queued or as a VM's state changes. This is not always enough information to maintain the proper dispositions. Consider the following example:

1. A VM begins to start. Reboot requests are denied in this state (since a VM that hasn't booted yet can't be rebooted).
2. A caller queues a request to stop the VM after it starts. All subsequent reboot requests should now be denied because the VM will halt before they can be serviced.
3. The VM successfully starts. The correct reboot disposition is still "deny," because there's a pending stop request, but there's no way to discern this from the prior reboot disposition (it was also "deny" before the stop request was queued!).

To address this sort of problem, and to pave the way for better handling of Crucible VCR replacements during instance start, refactor the queue as follows:

- Remember what kinds of outstanding requests have not been processed and dispose of requests based on this state and the queue's notion of the instance's overall state.
- Break external API requests into "state change" and "component change" requests. This will allow them to be dequeued independently when the state driver wants to handle component changes without changing the order of state change requests.
- Tweak the language the state driver uses to communicate with the queue: instead of saying "the VM is now in state X," the driver says "I handled (or failed to handle) a request of type Y."

Tests: cargo test, PHD.

Fixes #879.