### PR TITLE
propolis-server: collect and report VSS minus VM mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "api_identity"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
@@ -644,7 +644,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 [[package]]
 name = "clickhouse-admin-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "anyhow",
  "atomicwrites",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2404,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "id-map"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "daft",
  "derive-where",
@@ -2451,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "illumos-utils"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2614,11 +2614,11 @@ dependencies = [
 [[package]]
 name = "internal-dns-resolver"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "futures",
  "hickory-resolver",
- "internal-dns-types 0.1.0 (git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d)",
+ "internal-dns-types 0.1.0 (git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a)",
  "omicron-common",
  "omicron-workspace-hack",
  "qorb 0.3.1",
@@ -2644,7 +2644,7 @@ dependencies = [
 [[package]]
 name = "internal-dns-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3199,7 +3199,7 @@ dependencies = [
 [[package]]
 name = "nexus-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "chrono",
  "futures",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "nexus-sled-agent-shared"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "daft",
  "illumos-utils",
@@ -3244,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "nexus-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -3264,7 +3264,7 @@ dependencies = [
  "humantime",
  "id-map",
  "illumos-utils",
- "internal-dns-types 0.1.0 (git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d)",
+ "internal-dns-types 0.1.0 (git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a)",
  "ipnetwork",
  "newtype-uuid",
  "newtype_derive",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "omicron-common"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "omicron-passwords"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "argon2",
  "omicron-workspace-hack",
@@ -3611,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "omicron-uuid-kinds"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "daft",
  "newtype-uuid",
@@ -3817,7 +3817,7 @@ dependencies = [
 [[package]]
 name = "oximeter"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3836,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "oximeter-instruments"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "oximeter-macro-impl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
@@ -3865,12 +3865,12 @@ dependencies = [
 [[package]]
 name = "oximeter-producer"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "chrono",
  "dropshot",
- "internal-dns-resolver 0.1.0 (git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d)",
- "internal-dns-types 0.1.0 (git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d)",
+ "internal-dns-resolver 0.1.0 (git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a)",
+ "internal-dns-types 0.1.0 (git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a)",
  "nexus-client",
  "omicron-common",
  "omicron-workspace-hack",
@@ -3887,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "oximeter-schema"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3908,7 +3908,7 @@ dependencies = [
 [[package]]
 name = "oximeter-timeseries-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "omicron-workspace-hack",
  "oximeter-schema",
@@ -3921,7 +3921,7 @@ dependencies = [
 [[package]]
 name = "oximeter-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "bytes",
  "chrono",
@@ -3941,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "oxlog"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "anyhow",
  "camino",
@@ -3968,7 +3968,7 @@ dependencies = [
 [[package]]
 name = "oxql-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5961,7 +5961,7 @@ dependencies = [
 [[package]]
 name = "sled-hardware-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "illumos-utils",
  "omicron-common",
@@ -7151,7 +7151,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "update-engine"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=da5f7706119b3f39dc5dfb2fde823c2294476b5a#da5f7706119b3f39dc5dfb2fde823c2294476b5a"
 dependencies = [
  "anyhow",
  "cancel-safe-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 dependencies = [
  "backtrace",
 ]
@@ -157,6 +157,7 @@ dependencies = [
 [[package]]
 name = "api_identity"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
@@ -325,9 +326,9 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e5c85d84b0a51803caffb335a1063612edb02f6d#e5c85d84b0a51803caffb335a1063612edb02f6d"
+source = "git+https://github.com/oxidecomputer/propolis?rev=060a204d91e401a368c700a09d24510b7cd2b0e4#060a204d91e401a368c700a09d24510b7cd2b0e4"
 dependencies = [
- "bhyve_api_sys 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=e5c85d84b0a51803caffb335a1063612edb02f6d)",
+ "bhyve_api_sys 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=060a204d91e401a368c700a09d24510b7cd2b0e4)",
  "libc",
  "strum 0.26.3",
 ]
@@ -343,7 +344,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e5c85d84b0a51803caffb335a1063612edb02f6d#e5c85d84b0a51803caffb335a1063612edb02f6d"
+source = "git+https://github.com/oxidecomputer/propolis?rev=060a204d91e401a368c700a09d24510b7cd2b0e4#060a204d91e401a368c700a09d24510b7cd2b0e4"
 dependencies = [
  "libc",
  "strum 0.26.3",
@@ -387,9 +388,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
 ]
@@ -643,6 +644,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 [[package]]
 name = "clickhouse-admin-types"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "anyhow",
  "atomicwrites",
@@ -771,7 +773,7 @@ name = "cpuid_utils"
 version = "0.0.0"
 dependencies = [
  "bhyve_api 0.0.0",
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "propolis_api_types",
  "propolis_types",
  "proptest",
@@ -854,7 +856,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
- "reqwest 0.12.7",
+ "reqwest 0.12.15",
  "ringbuffer",
  "schemars",
  "semver 1.0.26",
@@ -939,7 +941,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da3cf198a0e000bb89efc3a1c77d7ba09340a600#da3cf198a0e000bb89efc3a1c77d7ba09340a600"
+source = "git+https://github.com/oxidecomputer/crucible?rev=45801597f410685015ac2704d044919a41e3ff75#45801597f410685015ac2704d044919a41e3ff75"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -1006,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "daft"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca607475e0cd38d41f8d1a5bd8985e7cdc1a205a69942211a475b02e48e406e0"
+checksum = "e09ff0315ed35eef47b90604921246c9eac0ace59aec99d46f7031eeea8cc0ec"
 dependencies = [
  "daft-derive",
  "newtype-uuid",
@@ -1019,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "daft-derive"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78e2436bc785be168ec3641025f713acc89b541ab41c318d7a1cfb4a4c2c50e"
+checksum = "1c3ea205baff86c8c0fc59f725aa55acfe159aaad7b1a99d84bcd203e4103245"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1743,14 +1745,16 @@ dependencies = [
 [[package]]
 name = "gateway-client"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "daft",
  "gateway-messages",
  "omicron-workspace-hack",
  "progenitor",
  "rand 0.8.5",
- "reqwest 0.12.7",
+ "reqwest 0.12.15",
  "schemars",
  "serde",
  "serde_json",
@@ -1761,9 +1765,9 @@ dependencies = [
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=9bbac475dcaac88286c07a20b6bd3e94fc81d7f0#9bbac475dcaac88286c07a20b6bd3e94fc81d7f0"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=f9566e68e0a0ccb7c3eeea081ae1cea279c11b2a#f9566e68e0a0ccb7c3eeea081ae1cea279c11b2a"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "hubpack",
  "serde",
  "serde-big-array",
@@ -1829,7 +1833,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -2400,6 +2404,7 @@ dependencies = [
 [[package]]
 name = "id-map"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "daft",
  "derive-where",
@@ -2438,20 +2443,25 @@ dependencies = [
 [[package]]
 name = "illumos-sys-hdrs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
+source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
+dependencies = [
+ "bitflags 2.9.0",
+]
 
 [[package]]
 name = "illumos-utils"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "anyhow",
  "async-trait",
- "bhyve_api 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=e5c85d84b0a51803caffb335a1063612edb02f6d)",
+ "bhyve_api 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=060a204d91e401a368c700a09d24510b7cd2b0e4)",
  "byteorder",
  "camino",
  "camino-tempfile",
  "cfg-if",
  "crucible-smf",
+ "debug-ignore",
  "dropshot",
  "futures",
  "http 1.2.0",
@@ -2536,7 +2546,7 @@ name = "ingot"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/ingot.git?rev=bff93247fe75ff889121e39d494cc3805fc01906#bff93247fe75ff889121e39d494cc3805fc01906"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "ingot-macros",
  "ingot-types",
  "macaddr",
@@ -2588,21 +2598,6 @@ dependencies = [
 [[package]]
 name = "internal-dns-resolver"
 version = "0.1.0"
-dependencies = [
- "futures",
- "hickory-resolver",
- "internal-dns-types 0.1.0",
- "omicron-common",
- "omicron-workspace-hack",
- "qorb",
- "reqwest 0.12.7",
- "slog",
- "thiserror 1.0.64",
-]
-
-[[package]]
-name = "internal-dns-resolver"
-version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "futures",
@@ -2610,8 +2605,24 @@ dependencies = [
  "internal-dns-types 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "omicron-common",
  "omicron-workspace-hack",
- "qorb",
- "reqwest 0.12.7",
+ "qorb 0.2.1",
+ "reqwest 0.12.15",
+ "slog",
+ "thiserror 1.0.64",
+]
+
+[[package]]
+name = "internal-dns-resolver"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
+dependencies = [
+ "futures",
+ "hickory-resolver",
+ "internal-dns-types 0.1.0 (git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d)",
+ "omicron-common",
+ "omicron-workspace-hack",
+ "qorb 0.3.1",
+ "reqwest 0.12.15",
  "slog",
  "thiserror 1.0.64",
 ]
@@ -2619,6 +2630,7 @@ dependencies = [
 [[package]]
 name = "internal-dns-types"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2632,7 +2644,7 @@ dependencies = [
 [[package]]
 name = "internal-dns-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2710,9 +2722,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2742,6 +2754,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jiff"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a064218214dc6a10fbae5ec5fa888d80c45d611aba169222fc272072bf7aef6"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2752,17 +2805,18 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "kstat-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
+source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -2862,7 +2916,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "libc",
 ]
 
@@ -3010,13 +3064,13 @@ dependencies = [
 [[package]]
 name = "mg-admin-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/maghemite?rev=5a0d6edd0ecc7f26225a5bf3849d8508956682d0#5a0d6edd0ecc7f26225a5bf3849d8508956682d0"
+source = "git+https://github.com/oxidecomputer/maghemite?rev=872aae7d76493f2a4f59711b24dde55523536b40#872aae7d76493f2a4f59711b24dde55523536b40"
 dependencies = [
  "anyhow",
  "chrono",
  "percent-encoding",
  "progenitor",
- "reqwest 0.12.7",
+ "reqwest 0.12.15",
  "schemars",
  "serde",
  "serde_json",
@@ -3145,6 +3199,7 @@ dependencies = [
 [[package]]
 name = "nexus-client"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "chrono",
  "futures",
@@ -3157,7 +3212,7 @@ dependencies = [
  "oxnet",
  "progenitor",
  "regress",
- "reqwest 0.12.7",
+ "reqwest 0.12.15",
  "schemars",
  "serde",
  "serde_json",
@@ -3168,6 +3223,7 @@ dependencies = [
 [[package]]
 name = "nexus-sled-agent-shared"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "daft",
  "illumos-utils",
@@ -3181,12 +3237,14 @@ dependencies = [
  "sled-hardware-types",
  "strum 0.26.3",
  "thiserror 1.0.64",
+ "tufaceous-artifact",
  "uuid",
 ]
 
 [[package]]
 name = "nexus-types"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -3206,7 +3264,7 @@ dependencies = [
  "humantime",
  "id-map",
  "illumos-utils",
- "internal-dns-types 0.1.0",
+ "internal-dns-types 0.1.0 (git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d)",
  "ipnetwork",
  "newtype-uuid",
  "newtype_derive",
@@ -3219,6 +3277,7 @@ dependencies = [
  "oxnet",
  "oxql-types",
  "parse-display",
+ "regex",
  "schemars",
  "semver 1.0.26",
  "serde",
@@ -3231,6 +3290,7 @@ dependencies = [
  "thiserror 1.0.64",
  "tufaceous-artifact",
  "update-engine",
+ "url",
  "uuid",
 ]
 
@@ -3252,7 +3312,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -3264,7 +3324,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -3494,6 +3554,7 @@ dependencies = [
 [[package]]
 name = "omicron-common"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -3514,9 +3575,10 @@ dependencies = [
  "oxnet",
  "parse-display",
  "progenitor-client",
+ "protocol",
  "rand 0.8.5",
  "regress",
- "reqwest 0.12.7",
+ "reqwest 0.12.15",
  "schemars",
  "semver 1.0.26",
  "serde",
@@ -3535,6 +3597,7 @@ dependencies = [
 [[package]]
 name = "omicron-passwords"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "argon2",
  "omicron-workspace-hack",
@@ -3548,6 +3611,7 @@ dependencies = [
 [[package]]
 name = "omicron-uuid-kinds"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "daft",
  "newtype-uuid",
@@ -3616,7 +3680,7 @@ version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -3657,9 +3721,9 @@ dependencies = [
 [[package]]
 name = "opte"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
+source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "dyn-clone",
  "illumos-sys-hdrs",
@@ -3676,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "opte-api"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
+source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
 dependencies = [
  "illumos-sys-hdrs",
  "ingot",
@@ -3689,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "opte-ioctl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
+source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
 dependencies = [
  "libc",
  "libnet",
@@ -3737,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "oxide-vpc"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
+source = "git+https://github.com/oxidecomputer/opte?rev=88adb1a5df689b3e2daddab9325ee94047f6ffad#88adb1a5df689b3e2daddab9325ee94047f6ffad"
 dependencies = [
  "cfg-if",
  "illumos-sys-hdrs",
@@ -3753,6 +3817,7 @@ dependencies = [
 [[package]]
 name = "oximeter"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3771,6 +3836,7 @@ dependencies = [
 [[package]]
 name = "oximeter-instruments"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -3788,6 +3854,7 @@ dependencies = [
 [[package]]
 name = "oximeter-macro-impl"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
@@ -3798,11 +3865,12 @@ dependencies = [
 [[package]]
 name = "oximeter-producer"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "chrono",
  "dropshot",
- "internal-dns-resolver 0.1.0",
- "internal-dns-types 0.1.0",
+ "internal-dns-resolver 0.1.0 (git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d)",
+ "internal-dns-types 0.1.0 (git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d)",
  "nexus-client",
  "omicron-common",
  "omicron-workspace-hack",
@@ -3819,6 +3887,7 @@ dependencies = [
 [[package]]
 name = "oximeter-schema"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3839,6 +3908,7 @@ dependencies = [
 [[package]]
 name = "oximeter-timeseries-macro"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "omicron-workspace-hack",
  "oximeter-schema",
@@ -3851,6 +3921,7 @@ dependencies = [
 [[package]]
 name = "oximeter-types"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "bytes",
  "chrono",
@@ -3870,11 +3941,13 @@ dependencies = [
 [[package]]
 name = "oxlog"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "anyhow",
  "camino",
  "chrono",
  "clap",
+ "jiff",
  "omicron-workspace-hack",
  "sigpipe",
  "uuid",
@@ -3895,6 +3968,7 @@ dependencies = [
 [[package]]
 name = "oxql-types"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4091,7 +4165,7 @@ dependencies = [
  "oximeter",
  "propolis-client",
  "rand 0.8.5",
- "reqwest 0.12.7",
+ "reqwest 0.12.15",
  "ring 0.17.14",
  "serde",
  "serde_derive",
@@ -4169,7 +4243,7 @@ dependencies = [
  "oximeter-producer",
  "phd-testcase",
  "propolis-client",
- "reqwest 0.12.7",
+ "reqwest 0.12.15",
  "slog",
  "slog-term",
  "strum 0.26.3",
@@ -4304,9 +4378,18 @@ source = "git+https://github.com/oxidecomputer/poptrie?branch=multipath#ca52bef3
 
 [[package]]
 name = "portable-atomic"
-version = "1.6.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "postcard"
@@ -4416,9 +4499,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -4443,7 +4526,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "percent-encoding",
- "reqwest 0.12.7",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4496,7 +4579,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bhyve_api 0.0.0",
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "bitstruct",
  "byteorder",
  "cpuid_utils",
@@ -4549,7 +4632,7 @@ dependencies = [
  "newtype-uuid",
  "propolis-client",
  "propolis-config-toml",
- "reqwest 0.12.7",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "slog",
@@ -4572,7 +4655,7 @@ dependencies = [
  "progenitor-client",
  "propolis_api_types",
  "rand 0.8.5",
- "reqwest 0.12.7",
+ "reqwest 0.12.15",
  "schemars",
  "serde",
  "serde_json",
@@ -4610,7 +4693,7 @@ dependencies = [
  "progenitor",
  "propolis_types",
  "rand 0.8.5",
- "reqwest 0.12.7",
+ "reqwest 0.12.15",
  "schemars",
  "semver 1.0.26",
  "serde",
@@ -4674,7 +4757,7 @@ dependencies = [
  "propolis_api_types",
  "propolis_types",
  "proptest",
- "reqwest 0.12.7",
+ "reqwest 0.12.15",
  "rfb",
  "rgb_frame",
  "ring 0.17.14",
@@ -4779,7 +4862,7 @@ checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -4789,6 +4872,17 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "protocol"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/lldp#82fbc8c9747eb9f74dde0f92ae77ec67f65652c4"
+dependencies = [
+ "anyhow",
+ "schemars",
+ "serde",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -4806,6 +4900,27 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "thiserror 1.0.64",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "usdt 0.5.0",
+]
+
+[[package]]
+name = "qorb"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7161fa1fa51fab06e6458e5f58c0548d10e0ed6c80436be364ced0b775bb65a9"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "debug-ignore",
+ "derive-where",
+ "futures",
+ "hickory-resolver",
+ "rand 0.9.0",
+ "serde",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4991,7 +5106,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -5104,9 +5219,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5143,6 +5258,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls 0.26.0",
  "tokio-util",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5169,7 +5285,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "ascii",
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "clap",
  "dropshot",
  "futures",
@@ -5235,7 +5351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "serde",
  "serde_derive",
 ]
@@ -5276,7 +5392,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "errno 0.3.9",
  "libc",
  "linux-raw-sys",
@@ -5442,6 +5558,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
+ "url",
  "uuid",
 ]
 
@@ -5499,7 +5616,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5844,6 +5961,7 @@ dependencies = [
 [[package]]
 name = "sled-hardware-types"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "illumos-utils",
  "omicron-common",
@@ -6008,9 +6126,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -6270,7 +6388,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "system-configuration-sys 0.6.0",
 ]
@@ -6727,10 +6845,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-service"
-version = "0.3.2"
+name = "tower"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -6844,10 +6983,10 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "tufaceous-artifact"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#69e2896b5905aba61445e519aaa40f02d59638b2"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#04681f26ba09e144e5467dd6bd22c4887692a670"
 dependencies = [
  "daft",
- "parse-display",
+ "hex",
  "proptest",
  "schemars",
  "semver 1.0.26",
@@ -7012,6 +7151,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "update-engine"
 version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//omicron.git?rev=3950a44ba51c1696b19392d20fd2cbb9457a000d#3950a44ba51c1696b19392d20fd2cbb9457a000d"
 dependencies = [
  "anyhow",
  "cancel-safe-futures",
@@ -7047,6 +7187,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -7327,23 +7468,24 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -7364,9 +7506,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7374,9 +7516,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7387,9 +7529,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"
@@ -7563,32 +7708,31 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -7642,11 +7786,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -7662,6 +7822,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7672,6 +7838,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7686,10 +7858,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7704,6 +7888,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7714,6 +7904,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7728,6 +7924,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7738,6 +7940,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -7773,7 +7981,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -7983,11 +8191,11 @@ dependencies = [
 
 [[package]]
 name = "zone"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62a428a79ea2224ce8ab05d6d8a21bdd7b4b68a8dbc1230511677a56e72ef22"
+checksum = "5d9ff514599b819915af2745e8adf6304030b28c072b2b1eb895e5739381bd0c"
 dependencies = [
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "thiserror 1.0.64",
  "tokio",
  "zone_cfg_derive",
@@ -8005,3 +8213,8 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[patch.unused]]
+name = "tufaceous-artifact"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer//tufaceous.git?rev=04681f26ba09e144e5467dd6bd22c4887692a670#04681f26ba09e144e5467dd6bd22c4887692a670"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,6 @@ dependencies = [
 [[package]]
 name = "api_identity"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
@@ -326,9 +325,9 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6b5f2af796a3ea57405721407ab70520a93ec73f#6b5f2af796a3ea57405721407ab70520a93ec73f"
+source = "git+https://github.com/oxidecomputer/propolis?rev=e5c85d84b0a51803caffb335a1063612edb02f6d#e5c85d84b0a51803caffb335a1063612edb02f6d"
 dependencies = [
- "bhyve_api_sys 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=6b5f2af796a3ea57405721407ab70520a93ec73f)",
+ "bhyve_api_sys 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=e5c85d84b0a51803caffb335a1063612edb02f6d)",
  "libc",
  "strum 0.26.3",
 ]
@@ -344,7 +343,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6b5f2af796a3ea57405721407ab70520a93ec73f#6b5f2af796a3ea57405721407ab70520a93ec73f"
+source = "git+https://github.com/oxidecomputer/propolis?rev=e5c85d84b0a51803caffb335a1063612edb02f6d#e5c85d84b0a51803caffb335a1063612edb02f6d"
 dependencies = [
  "libc",
  "strum 0.26.3",
@@ -644,7 +643,6 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 [[package]]
 name = "clickhouse-admin-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "anyhow",
  "atomicwrites",
@@ -844,8 +842,8 @@ dependencies = [
  "dropshot",
  "futures",
  "futures-core",
- "internal-dns-resolver",
- "internal-dns-types",
+ "internal-dns-resolver 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "internal-dns-types 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "itertools 0.14.0",
  "libc",
  "nexus-client",
@@ -941,13 +939,13 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=81a3528adacdbde18fcbf3938247fef17233db11#81a3528adacdbde18fcbf3938247fef17233db11"
+source = "git+https://github.com/oxidecomputer/crucible?rev=da3cf198a0e000bb89efc3a1c77d7ba09340a600#da3cf198a0e000bb89efc3a1c77d7ba09340a600"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
  "num-derive 0.4.2",
  "num-traits",
- "thiserror 1.0.64",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1745,13 +1743,12 @@ dependencies = [
 [[package]]
 name = "gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "gateway-messages",
  "omicron-workspace-hack",
- "progenitor 0.9.1",
+ "progenitor",
  "rand 0.8.5",
  "reqwest 0.12.7",
  "schemars",
@@ -2403,7 +2400,6 @@ dependencies = [
 [[package]]
 name = "id-map"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "daft",
  "derive-where",
@@ -2447,11 +2443,10 @@ source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aaf
 [[package]]
 name = "illumos-utils"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "anyhow",
  "async-trait",
- "bhyve_api 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=6b5f2af796a3ea57405721407ab70520a93ec73f)",
+ "bhyve_api 0.0.0 (git+https://github.com/oxidecomputer/propolis?rev=e5c85d84b0a51803caffb335a1063612edb02f6d)",
  "byteorder",
  "camino",
  "camino-tempfile",
@@ -2593,17 +2588,45 @@ dependencies = [
 [[package]]
 name = "internal-dns-resolver"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "futures",
  "hickory-resolver",
- "internal-dns-types",
+ "internal-dns-types 0.1.0",
  "omicron-common",
  "omicron-workspace-hack",
  "qorb",
  "reqwest 0.12.7",
  "slog",
  "thiserror 1.0.64",
+]
+
+[[package]]
+name = "internal-dns-resolver"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
+dependencies = [
+ "futures",
+ "hickory-resolver",
+ "internal-dns-types 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "omicron-common",
+ "omicron-workspace-hack",
+ "qorb",
+ "reqwest 0.12.7",
+ "slog",
+ "thiserror 1.0.64",
+]
+
+[[package]]
+name = "internal-dns-types"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "omicron-common",
+ "omicron-uuid-kinds",
+ "omicron-workspace-hack",
+ "schemars",
+ "serde",
 ]
 
 [[package]]
@@ -2987,12 +3010,12 @@ dependencies = [
 [[package]]
 name = "mg-admin-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/maghemite?rev=caafd889f31faacfaa51e02902990c220c20ef60#caafd889f31faacfaa51e02902990c220c20ef60"
+source = "git+https://github.com/oxidecomputer/maghemite?rev=5a0d6edd0ecc7f26225a5bf3849d8508956682d0#5a0d6edd0ecc7f26225a5bf3849d8508956682d0"
 dependencies = [
  "anyhow",
  "chrono",
  "percent-encoding",
- "progenitor 0.8.0",
+ "progenitor",
  "reqwest 0.12.7",
  "schemars",
  "serde",
@@ -3122,7 +3145,6 @@ dependencies = [
 [[package]]
 name = "nexus-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "chrono",
  "futures",
@@ -3133,7 +3155,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oxnet",
- "progenitor 0.9.1",
+ "progenitor",
  "regress",
  "reqwest 0.12.7",
  "schemars",
@@ -3146,7 +3168,6 @@ dependencies = [
 [[package]]
 name = "nexus-sled-agent-shared"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "daft",
  "illumos-utils",
@@ -3166,7 +3187,6 @@ dependencies = [
 [[package]]
 name = "nexus-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -3186,7 +3206,7 @@ dependencies = [
  "humantime",
  "id-map",
  "illumos-utils",
- "internal-dns-types",
+ "internal-dns-types 0.1.0",
  "ipnetwork",
  "newtype-uuid",
  "newtype_derive",
@@ -3474,7 +3494,6 @@ dependencies = [
 [[package]]
 name = "omicron-common"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -3494,7 +3513,7 @@ dependencies = [
  "omicron-workspace-hack",
  "oxnet",
  "parse-display",
- "progenitor-client 0.9.1",
+ "progenitor-client",
  "rand 0.8.5",
  "regress",
  "reqwest 0.12.7",
@@ -3516,7 +3535,6 @@ dependencies = [
 [[package]]
 name = "omicron-passwords"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "argon2",
  "omicron-workspace-hack",
@@ -3530,7 +3548,6 @@ dependencies = [
 [[package]]
 name = "omicron-uuid-kinds"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "daft",
  "newtype-uuid",
@@ -3736,7 +3753,6 @@ dependencies = [
 [[package]]
 name = "oximeter"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3755,7 +3771,6 @@ dependencies = [
 [[package]]
 name = "oximeter-instruments"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -3773,7 +3788,6 @@ dependencies = [
 [[package]]
 name = "oximeter-macro-impl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
@@ -3784,12 +3798,11 @@ dependencies = [
 [[package]]
 name = "oximeter-producer"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "chrono",
  "dropshot",
- "internal-dns-resolver",
- "internal-dns-types",
+ "internal-dns-resolver 0.1.0",
+ "internal-dns-types 0.1.0",
  "nexus-client",
  "omicron-common",
  "omicron-workspace-hack",
@@ -3806,7 +3819,6 @@ dependencies = [
 [[package]]
 name = "oximeter-schema"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3827,7 +3839,6 @@ dependencies = [
 [[package]]
 name = "oximeter-timeseries-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "omicron-workspace-hack",
  "oximeter-schema",
@@ -3840,7 +3851,6 @@ dependencies = [
 [[package]]
 name = "oximeter-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "bytes",
  "chrono",
@@ -3860,7 +3870,6 @@ dependencies = [
 [[package]]
 name = "oxlog"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "anyhow",
  "camino",
@@ -3886,7 +3895,6 @@ dependencies = [
 [[package]]
 name = "oxql-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4417,39 +4425,13 @@ dependencies = [
 
 [[package]]
 name = "progenitor"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293df5b79211fbf0c1ebad6513ba451d267e9c15f5f19ee5d3da775e2dd27331"
-dependencies = [
- "progenitor-client 0.8.0",
- "progenitor-impl 0.8.0",
- "progenitor-macro 0.8.0",
-]
-
-[[package]]
-name = "progenitor"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88f54bd2506c3e7b6e45b6ab16500abef551689021264f3be260ef7e295ac327"
 dependencies = [
- "progenitor-client 0.9.1",
- "progenitor-impl 0.9.1",
- "progenitor-macro 0.9.1",
-]
-
-[[package]]
-name = "progenitor-client"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a5db54eac3cae7007a0785854bc3e89fd418cca7dfc2207b99b43979154c1b"
-dependencies = [
- "bytes",
- "futures-core",
- "percent-encoding",
- "reqwest 0.12.7",
- "serde",
- "serde_json",
- "serde_urlencoded",
+ "progenitor-client",
+ "progenitor-impl",
+ "progenitor-macro",
 ]
 
 [[package]]
@@ -4465,28 +4447,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
-]
-
-[[package]]
-name = "progenitor-impl"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85934a440963a69f9f04f48507ff6e7aa2952a5b2d8f96cc37fa3dd5c270f66"
-dependencies = [
- "heck 0.5.0",
- "http 1.2.0",
- "indexmap 2.8.0",
- "openapiv3",
- "proc-macro2",
- "quote",
- "regex",
- "schemars",
- "serde",
- "serde_json",
- "syn 2.0.100",
- "thiserror 1.0.64",
- "typify 0.2.0",
- "unicode-ident",
 ]
 
 [[package]]
@@ -4507,26 +4467,8 @@ dependencies = [
  "serde_json",
  "syn 2.0.100",
  "thiserror 2.0.12",
- "typify 0.3.0",
+ "typify",
  "unicode-ident",
-]
-
-[[package]]
-name = "progenitor-macro"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99a5a259e2d65a4933054aa51717c70b6aba0522695731ac354a522124efc9b"
-dependencies = [
- "openapiv3",
- "proc-macro2",
- "progenitor-impl 0.8.0",
- "quote",
- "schemars",
- "serde",
- "serde_json",
- "serde_tokenstream 0.2.2",
- "serde_yaml",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -4537,7 +4479,7 @@ checksum = "fc3b2b9f0d5ba58375c5e8e89d5dff949108e234c1d9f22a3336d2be4daaf292"
 dependencies = [
  "openapiv3",
  "proc-macro2",
- "progenitor-impl 0.9.1",
+ "progenitor-impl",
  "quote",
  "schemars",
  "serde",
@@ -4626,8 +4568,8 @@ dependencies = [
  "base64 0.21.7",
  "crucible-client-types",
  "futures",
- "progenitor 0.9.1",
- "progenitor-client 0.9.1",
+ "progenitor",
+ "progenitor-client",
  "propolis_api_types",
  "rand 0.8.5",
  "reqwest 0.12.7",
@@ -4665,7 +4607,7 @@ dependencies = [
  "dropshot",
  "futures",
  "hyper 1.6.0",
- "progenitor 0.9.1",
+ "progenitor",
  "propolis_types",
  "rand 0.8.5",
  "reqwest 0.12.7",
@@ -4716,11 +4658,12 @@ dependencies = [
  "futures",
  "hex",
  "hyper 1.6.0",
- "internal-dns-resolver",
- "internal-dns-types",
+ "internal-dns-resolver 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
+ "internal-dns-types 0.1.0 (git+https://github.com/oxidecomputer/omicron?branch=main)",
  "itertools 0.13.0",
  "kstat-rs",
  "lazy_static",
+ "libc",
  "mockall",
  "nexus-client",
  "omicron-common",
@@ -4754,6 +4697,7 @@ dependencies = [
  "toml 0.7.8",
  "usdt 0.5.0",
  "uuid",
+ "zerocopy 0.7.34",
 ]
 
 [[package]]
@@ -5900,7 +5844,6 @@ dependencies = [
 [[package]]
 name = "sled-hardware-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "illumos-utils",
  "omicron-common",
@@ -6065,9 +6008,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -6957,42 +6900,12 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "typify"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c644dda9862f0fef3a570d8ddb3c2cfb1d5ac824a1f2ddfa7bc8f071a5ad8a"
-dependencies = [
- "typify-impl 0.2.0",
- "typify-macro 0.2.0",
-]
-
-[[package]]
-name = "typify"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e03ba3643450cfd95a1aca2e1938fef63c1c1994489337998aff4ad771f21ef8"
 dependencies = [
- "typify-impl 0.3.0",
- "typify-macro 0.3.0",
-]
-
-[[package]]
-name = "typify-impl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59ab345b6c0d8ae9500b9ff334a4c7c0d316c1c628dc55726b95887eb8dbd11"
-dependencies = [
- "heck 0.5.0",
- "log",
- "proc-macro2",
- "quote",
- "regress",
- "schemars",
- "semver 1.0.26",
- "serde",
- "serde_json",
- "syn 2.0.100",
- "thiserror 1.0.64",
- "unicode-ident",
+ "typify-impl",
+ "typify-macro",
 ]
 
 [[package]]
@@ -7017,23 +6930,6 @@ dependencies = [
 
 [[package]]
 name = "typify-macro"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785e2cdcef0df8160fdd762ed548a637aaec1e83704fdbc14da0df66013ee8d0"
-dependencies = [
- "proc-macro2",
- "quote",
- "schemars",
- "semver 1.0.26",
- "serde",
- "serde_json",
- "serde_tokenstream 0.2.2",
- "syn 2.0.100",
- "typify-impl 0.2.0",
-]
-
-[[package]]
-name = "typify-macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b5780d745920ed73c5b7447496a9b5c42ed2681a9b70859377aec423ecf02b"
@@ -7046,7 +6942,7 @@ dependencies = [
  "serde_json",
  "serde_tokenstream 0.2.2",
  "syn 2.0.100",
- "typify-impl 0.3.0",
+ "typify-impl",
 ]
 
 [[package]]
@@ -7116,7 +7012,6 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "update-engine"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#0c92213cbf480848862926873d1c8e633102471e"
 dependencies = [
  "anyhow",
  "cancel-safe-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,14 +182,17 @@ zerocopy = "0.7.34"
 #
 [patch."https://github.com/oxidecomputer/omicron"]
 #internal-dns = { path = "../omicron/internal-dns" }
-nexus-client = { path = "../omicron/clients/nexus-client" }
-omicron-uuid-kinds = { path = "../omicron/uuid-kinds" }
-nexus-types = { path = "../omicron/nexus/types" }
-illumos-utils = { path = "../omicron/illumos-utils" }
-omicron-common = { path = "../omicron/common" }
-oximeter-instruments = { path = "../omicron/oximeter/instruments" }
-oximeter-producer = { path = "../omicron/oximeter/producer" }
-oximeter = { path = "../omicron/oximeter/oximeter" }
+nexus-client = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
+omicron-uuid-kinds = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
+nexus-types = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
+illumos-utils = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
+omicron-common = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
+oximeter-instruments = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
+oximeter-producer = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
+oximeter = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
+
+# i've just picked what Omicron happens to currently point to.
+tufaceous-artifact = { git = "https://github.com/oxidecomputer//tufaceous.git", rev = "04681f26ba09e144e5467dd6bd22c4887692a670" }
 # [patch."https://github.com/oxidecomputer/crucible"]
 # crucible = { path = "../crucible/upstairs" }
 # crucible-client-types = { path = "../crucible/crucible-client-types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,13 +180,16 @@ zerocopy = "0.7.34"
 # It's common during development to use a local copy of various complex
 # dependencies.  If you want to use those, uncomment one of these blocks.
 #
-# [patch."https://github.com/oxidecomputer/omicron"]
-# internal-dns = { path = "../omicron/internal-dns" }
-# nexus-client = { path = "../omicron/clients/nexus-client" }
-# omicron-common = { path = "../omicron/common" }
-# oximeter-instruments = { path = "../omicron/oximeter/instruments" }
-# oximeter-producer = { path = "../omicron/oximeter/producer" }
-# oximeter = { path = "../omicron/oximeter/oximeter" }
+[patch."https://github.com/oxidecomputer/omicron"]
+#internal-dns = { path = "../omicron/internal-dns" }
+nexus-client = { path = "../omicron/clients/nexus-client" }
+omicron-uuid-kinds = { path = "../omicron/uuid-kinds" }
+nexus-types = { path = "../omicron/nexus/types" }
+illumos-utils = { path = "../omicron/illumos-utils" }
+omicron-common = { path = "../omicron/common" }
+oximeter-instruments = { path = "../omicron/oximeter/instruments" }
+oximeter-producer = { path = "../omicron/oximeter/producer" }
+oximeter = { path = "../omicron/oximeter/oximeter" }
 # [patch."https://github.com/oxidecomputer/crucible"]
 # crucible = { path = "../crucible/upstairs" }
 # crucible-client-types = { path = "../crucible/crucible-client-types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,14 +182,14 @@ zerocopy = "0.7.34"
 #
 [patch."https://github.com/oxidecomputer/omicron"]
 #internal-dns = { path = "../omicron/internal-dns" }
-nexus-client = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
-omicron-uuid-kinds = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
-nexus-types = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
-illumos-utils = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
-omicron-common = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
-oximeter-instruments = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
-oximeter-producer = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
-oximeter = { git = "https://github.com/oxidecomputer//omicron.git", rev = "3950a44ba51c1696b19392d20fd2cbb9457a000d" }
+nexus-client = { git = "https://github.com/oxidecomputer//omicron.git", rev = "da5f7706119b3f39dc5dfb2fde823c2294476b5a" }
+omicron-uuid-kinds = { git = "https://github.com/oxidecomputer//omicron.git", rev = "da5f7706119b3f39dc5dfb2fde823c2294476b5a" }
+nexus-types = { git = "https://github.com/oxidecomputer//omicron.git", rev = "da5f7706119b3f39dc5dfb2fde823c2294476b5a" }
+illumos-utils = { git = "https://github.com/oxidecomputer//omicron.git", rev = "da5f7706119b3f39dc5dfb2fde823c2294476b5a" }
+omicron-common = { git = "https://github.com/oxidecomputer//omicron.git", rev = "da5f7706119b3f39dc5dfb2fde823c2294476b5a" }
+oximeter-instruments = { git = "https://github.com/oxidecomputer//omicron.git", rev = "da5f7706119b3f39dc5dfb2fde823c2294476b5a" }
+oximeter-producer = { git = "https://github.com/oxidecomputer//omicron.git", rev = "da5f7706119b3f39dc5dfb2fde823c2294476b5a" }
+oximeter = { git = "https://github.com/oxidecomputer//omicron.git", rev = "da5f7706119b3f39dc5dfb2fde823c2294476b5a" }
 
 # i've just picked what Omicron happens to currently point to.
 tufaceous-artifact = { git = "https://github.com/oxidecomputer//tufaceous.git", rev = "04681f26ba09e144e5467dd6bd22c4887692a670" }

--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -37,6 +37,7 @@ internal-dns-types.workspace = true
 itertools.workspace = true
 kstat-rs.workspace = true
 lazy_static.workspace = true
+libc.workspace = true
 nexus-client.workspace = true
 omicron-common.workspace = true
 oximeter-instruments.workspace = true

--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -67,6 +67,7 @@ uuid.workspace = true
 usdt.workspace = true
 base64.workspace = true
 schemars = { workspace = true, features = ["chrono", "uuid1"] }
+zerocopy.workspace = true
 
 [dev-dependencies]
 hex.workspace = true

--- a/bin/propolis-server/src/lib/stats/process.rs
+++ b/bin/propolis-server/src/lib/stats/process.rs
@@ -89,17 +89,15 @@ struct psinfo {
 pub fn process_stats() -> anyhow::Result<ProcessStats> {
     let mut psinfo_file = std::fs::File::open("/proc/self/psinfo")?;
 
-    let mut stats = ProcessStats {
-        measurement_time: Duration::ZERO,
-        vss: 0,
-        rss: 0,
-    };
+    let mut stats =
+        ProcessStats { measurement_time: Duration::ZERO, vss: 0, rss: 0 };
 
     let mut info: psinfo = FromZeroes::new_zeroed();
 
     let stats_read_start = Instant::now();
 
-    psinfo_file.read(info.as_bytes_mut())
+    psinfo_file
+        .read(info.as_bytes_mut())
         .context("reading struct psinfo from file")?;
 
     stats.measurement_time = stats_read_start.elapsed();

--- a/bin/propolis-server/src/lib/stats/process.rs
+++ b/bin/propolis-server/src/lib/stats/process.rs
@@ -1,0 +1,166 @@
+use std::io::Read;
+use std::time::{Duration, Instant};
+
+use anyhow::Context;
+use tokio::sync::watch;
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
+
+#[derive(Debug, Default)]
+pub(crate) struct ProcessStats {
+    pub(crate) measurement_time: Duration,
+    pub(crate) unshared_rss: u64,
+    pub(crate) unshared_vss: u64,
+    pub(crate) shared_rss: u64,
+    pub(crate) shared_vss: u64,
+}
+
+impl ProcessStats {
+    pub fn new() -> watch::Receiver<ProcessStats> {
+        let (tx, rx) = watch::channel::<ProcessStats>(ProcessStats::default());
+
+        tokio::task::spawn(process_stats_task(tx));
+
+        rx
+    }
+}
+
+/// There are some arrays with size `PRMAPSZ` holding names in `struct prmap`
+/// and `struct prxmap`.
+const PRMAPSZ: usize = 64;
+
+/// We're going to query our `/proc/<self>/xmap` here, which contains a series o
+/// `struct prxmap` records. So, define it here in the same way it's defined in
+/// illumos' `common/sys/procfs.h`
+#[derive(Copy, Clone, Debug, FromZeroes, AsBytes, FromBytes)]
+// Kind of weird to need packed here, but the struct size is 0x
+#[repr(C)]
+struct prxmap {
+    /// virtual address of the mapping
+    pr_vaddr: usize,
+    /// size of the mapping in bytes
+    pr_size: usize,
+    /// name in /proc/<pid>/object
+    pr_mapname: [u8; PRMAPSZ],
+    /// offset into mapped object, if any
+    pr_offset: i64,
+    /// protection and attribute flags. See procfs.h' `MA_*` flags
+    pr_mflags: i32,
+    /// Pagesize (bytes) for this mapping
+    pr_pagesize: i32,
+    /// SysV shmid, -1 if not SysV shared memory
+    pr_shmid: i32,
+    /// illumos' `struct prxmap` on 64-bit operating systems has implicit
+    /// internal padding between `pr_shmid` and `pr_dev`. This should always be
+    /// zero.
+    // Rust rules are that padding bytes are uninitialized, so transforming
+    // `&prxmap` to a `&[u8]` is UB if there is internal padding.
+    // Consequently, `AsBytes` and `FromBytes` require no internal padding, so
+    // put a small field here to make the "padding" explicit.
+    _internal_pad: i32,
+    /// st_dev from stat64() of mapped object, or PRNODEV
+    pr_dev: i64,
+    /// st_ino from stat64() of mapped object, if any
+    pr_ino: u64,
+    /// pages of resident memory
+    pr_rss: isize,
+    /// pages of resident anonymous memory
+    pr_anon: isize,
+    /// pages of locked memory
+    pr_locked: isize,
+    /// currently unused
+    pr_pad: isize,
+    /// pagesize of the hat mapping
+    pr_hatpagesize: usize,
+    /// filler for future expansion
+    // illumos uses `ulong_t` here, which should be 32-bit, but
+    // sizes only line up if it's u64?
+    pr_filler: [u64; 7],
+}
+
+const MA_SHARED: i32 = 0x08;
+
+// Computed here just because it's used in a few places in this file.
+const PRXMAPSZ: usize = std::mem::size_of::<prxmap>();
+
+impl prxmap {
+    fn is_shared(&self) -> bool {
+        self.pr_mflags & MA_SHARED == MA_SHARED
+    }
+}
+
+pub fn process_stats() -> anyhow::Result<ProcessStats> {
+    let stats_read_start = Instant::now();
+
+    // Safety: getpid() does not alter any state, or even read mutable state.
+    let mypid = unsafe { libc::getpid() };
+    let xmap_path = format!("/proc/{}/xmap", mypid);
+    let mut xmap_file = std::fs::File::open(&xmap_path)?;
+
+    let mut stats = ProcessStats {
+        measurement_time: Duration::ZERO,
+        unshared_rss: 0,
+        unshared_vss: 0,
+        shared_rss: 0,
+        shared_vss: 0,
+    };
+
+    let mut buf: [prxmap; 256] = [FromZeroes::new_zeroed(); 256];
+    loop {
+        let nread = xmap_file
+            .read(buf.as_bytes_mut())
+            .context("reading struct prxmap from file")?;
+        if nread == 0 {
+            // we've read all maps this go around.
+            stats.measurement_time = stats_read_start.elapsed();
+            return Ok(stats);
+        }
+
+        assert!(nread % PRXMAPSZ == 0);
+        let maps_read = nread / PRXMAPSZ;
+
+        for buf in buf[0..maps_read].iter() {
+            let map_rss = buf.pr_rss as u64 * buf.pr_pagesize as u64;
+            let map_vss = buf.pr_size as u64;
+            if buf.is_shared() {
+                stats.shared_rss += map_rss;
+                stats.shared_vss += map_vss;
+            } else {
+                stats.unshared_rss += map_rss;
+                stats.unshared_vss += map_vss;
+            }
+        }
+    }
+}
+
+async fn process_stats_task(tx: watch::Sender<ProcessStats>) {
+    while !tx.is_closed() {
+        let new_process_stats = tokio::task::spawn_blocking(process_stats)
+            .await
+            .expect("collecting address space stats does not panic")
+            .expect("process_stats() does not error");
+
+        // [there isn't a nice way to plumb a slog Logger here, so this is an
+        // eprintln for demonstrative purposes but otherwise should be removed.]
+        eprintln!(
+            "Sending new stats at least.. {:?}, took {}ms",
+            new_process_stats,
+            new_process_stats.measurement_time.as_millis()
+        );
+        tx.send_replace(new_process_stats);
+
+        tokio::time::sleep(std::time::Duration::from_millis(15000)).await;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::prxmap;
+    use std::mem::size_of;
+
+    #[test]
+    fn prxmap_size() {
+        // Double check `prxmap` size against that of structures in
+        // /proc/<pid>/xmap..
+        assert_eq!(size_of::<prxmap>(), 0xd8);
+    }
+}

--- a/bin/propolis-server/src/lib/stats/process.rs
+++ b/bin/propolis-server/src/lib/stats/process.rs
@@ -12,10 +12,8 @@ use zerocopy::{AsBytes, FromBytes, FromZeroes};
 #[derive(Debug, Default)]
 pub(crate) struct ProcessStats {
     pub(crate) measurement_time: Duration,
-    pub(crate) unshared_rss: u64,
-    pub(crate) unshared_vss: u64,
-    pub(crate) shared_rss: u64,
-    pub(crate) shared_vss: u64,
+    pub(crate) rss: usize,
+    pub(crate) vss: usize,
 }
 
 impl ProcessStats {
@@ -28,112 +26,88 @@ impl ProcessStats {
     }
 }
 
-/// There are some arrays with size `PRMAPSZ` holding names in `struct prmap`
-/// and `struct prxmap`.
-const PRMAPSZ: usize = 64;
+const PRFNSZ: usize = 16;
+const PRARGSZ: usize = 80;
 
-/// We're going to query our `/proc/<self>/xmap` here, which contains a series o
-/// `struct prxmap` records. So, define it here in the same way it's defined in
-/// illumos' `common/sys/procfs.h`
+/// From `sys/types.h`
+#[allow(non_camel_case_types)]
+type taskid_t = i32;
+/// From `sys/time_impl.h`
+#[allow(non_camel_case_types)]
+type timespec_t = [i64; 2];
+/// From `sys/time_impl.h`
+#[allow(non_camel_case_types)]
+type timestruc_t = timespec_t;
+/// From `sys/types.h`
+#[allow(non_camel_case_types)]
+type dev_t = u64;
+
+/// `psinfo`'s definition depends on the data model reported by illumos. This is
+/// in line with the 64-bit version of the struct, and ignores a few fields at
+/// the end of the struct.
 #[derive(Copy, Clone, Debug, FromZeroes, AsBytes, FromBytes)]
-// Kind of weird to need packed here, but the struct size is 0x
+#[cfg(target_arch = "x86_64")]
 #[repr(C)]
-struct prxmap {
-    /// virtual address of the mapping
-    pr_vaddr: usize,
-    /// size of the mapping in bytes
+struct psinfo {
+    pr_flag: i32,
+    pr_nlwp: i32,
+    pr_pid: u32,
+    pr_ppid: u32,
+    pr_pgid: u32,
+    pr_sid: u32,
+    pr_uid: u32,
+    pr_euid: u32,
+    pr_gid: u32,
+    pr_egid: u32,
+    pr_addr: usize,
     pr_size: usize,
-    /// name in /proc/<pid>/object
-    pr_mapname: [u8; PRMAPSZ],
-    /// offset into mapped object, if any
-    pr_offset: i64,
-    /// protection and attribute flags. See procfs.h' `MA_*` flags
-    pr_mflags: i32,
-    /// Pagesize (bytes) for this mapping
-    pr_pagesize: i32,
-    /// SysV shmid, -1 if not SysV shared memory
-    pr_shmid: i32,
-    /// illumos' `struct prxmap` on 64-bit operating systems has implicit
-    /// internal padding between `pr_shmid` and `pr_dev`. This should always be
-    /// zero.
-    // Rust rules are that padding bytes are uninitialized, so transforming
-    // `&prxmap` to a `&[u8]` is UB if there is internal padding.
-    // Consequently, `AsBytes` and `FromBytes` require no internal padding, so
-    // put a small field here to make the "padding" explicit.
-    _internal_pad: i32,
-    /// st_dev from stat64() of mapped object, or PRNODEV
-    pr_dev: i64,
-    /// st_ino from stat64() of mapped object, if any
-    pr_ino: u64,
-    /// pages of resident memory
-    pr_rss: isize,
-    /// pages of resident anonymous memory
-    pr_anon: isize,
-    /// pages of locked memory
-    pr_locked: isize,
-    /// currently unused
-    pr_pad: isize,
-    /// pagesize of the hat mapping
-    pr_hatpagesize: usize,
-    /// filler for future expansion
-    // illumos uses `ulong_t` here, which should be 32-bit, but
-    // sizes only line up if it's u64?
-    pr_filler: [u64; 7],
-}
-
-const MA_SHARED: i32 = 0x08;
-
-// Computed here just because it's used in a few places in this file.
-const PRXMAPSZ: usize = std::mem::size_of::<prxmap>();
-
-impl prxmap {
-    fn is_shared(&self) -> bool {
-        self.pr_mflags & MA_SHARED == MA_SHARED
-    }
+    pr_rssize: usize,
+    // From `struct psinfo`. This seems to be present to ensure that `pr_ttydev`
+    // is 64-bit aligned even on 32-bit targets.
+    pr_pad1: usize,
+    pr_ttydev: dev_t,
+    pr_pctcpu: u16,
+    pr_pctmem: u16,
+    // This padding is not explicitly present in illumos' `struct procfs`, but
+    // is none the less there due to C struct layout rules.
+    _pad2: u32,
+    pr_start: timestruc_t,
+    pr_time: timestruc_t,
+    pr_ctime: timestruc_t,
+    pr_fname: [u8; PRFNSZ],
+    pr_psargs: [u8; PRARGSZ],
+    pr_wstat: u32,
+    pr_argc: u32,
+    pr_argv: usize,
+    pr_envp: usize,
+    pr_dmodel: u8,
+    // More padding from `struct psinfo`.
+    pr_pad2: [u8; 3],
+    pr_taskid: taskid_t,
 }
 
 pub fn process_stats() -> anyhow::Result<ProcessStats> {
-    let stats_read_start = Instant::now();
-
-    // Safety: getpid() does not alter any state, or even read mutable state.
-    let mypid = unsafe { libc::getpid() };
-    let xmap_path = format!("/proc/{}/xmap", mypid);
-    let mut xmap_file = std::fs::File::open(&xmap_path)?;
+    let mut psinfo_file = std::fs::File::open("/proc/self/psinfo")?;
 
     let mut stats = ProcessStats {
         measurement_time: Duration::ZERO,
-        unshared_rss: 0,
-        unshared_vss: 0,
-        shared_rss: 0,
-        shared_vss: 0,
+        vss: 0,
+        rss: 0,
     };
 
-    let mut buf: [prxmap; 256] = [FromZeroes::new_zeroed(); 256];
-    loop {
-        let nread = xmap_file
-            .read(buf.as_bytes_mut())
-            .context("reading struct prxmap from file")?;
-        if nread == 0 {
-            // we've read all maps this go around.
-            stats.measurement_time = stats_read_start.elapsed();
-            return Ok(stats);
-        }
+    let mut info: psinfo = FromZeroes::new_zeroed();
 
-        assert!(nread % PRXMAPSZ == 0);
-        let maps_read = nread / PRXMAPSZ;
+    let stats_read_start = Instant::now();
 
-        for buf in buf[0..maps_read].iter() {
-            let map_rss = buf.pr_rss as u64 * buf.pr_pagesize as u64;
-            let map_vss = buf.pr_size as u64;
-            if buf.is_shared() {
-                stats.shared_rss += map_rss;
-                stats.shared_vss += map_vss;
-            } else {
-                stats.unshared_rss += map_rss;
-                stats.unshared_vss += map_vss;
-            }
-        }
-    }
+    psinfo_file.read(info.as_bytes_mut())
+        .context("reading struct psinfo from file")?;
+
+    stats.measurement_time = stats_read_start.elapsed();
+
+    stats.vss = info.pr_size;
+    stats.rss = info.pr_rssize;
+
+    Ok(stats)
 }
 
 async fn process_stats_task(tx: watch::Sender<ProcessStats>) {
@@ -153,18 +127,5 @@ async fn process_stats_task(tx: watch::Sender<ProcessStats>) {
         tx.send_replace(new_process_stats);
 
         tokio::time::sleep(std::time::Duration::from_millis(15000)).await;
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::prxmap;
-    use std::mem::size_of;
-
-    #[test]
-    fn prxmap_size() {
-        // Double check `prxmap` size against that of structures in
-        // /proc/<pid>/xmap..
-        assert_eq!(size_of::<prxmap>(), 0xd8);
     }
 }

--- a/bin/propolis-server/src/lib/stats/process.rs
+++ b/bin/propolis-server/src/lib/stats/process.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::io::Read;
 use std::time::{Duration, Instant};
 

--- a/bin/propolis-server/src/lib/stats/process.rs
+++ b/bin/propolis-server/src/lib/stats/process.rs
@@ -13,7 +13,7 @@ use zerocopy::{AsBytes, FromBytes, FromZeroes};
 pub(crate) struct ProcessStats {
     pub(crate) measurement_time: Duration,
     pub(crate) rss: usize,
-    pub(crate) vss: usize,
+    pub(crate) vsz: usize,
 }
 
 impl ProcessStats {
@@ -90,7 +90,7 @@ pub fn process_stats() -> anyhow::Result<ProcessStats> {
     let mut psinfo_file = std::fs::File::open("/proc/self/psinfo")?;
 
     let mut stats =
-        ProcessStats { measurement_time: Duration::ZERO, vss: 0, rss: 0 };
+        ProcessStats { measurement_time: Duration::ZERO, vsz: 0, rss: 0 };
 
     let mut info: psinfo = FromZeroes::new_zeroed();
 
@@ -102,7 +102,7 @@ pub fn process_stats() -> anyhow::Result<ProcessStats> {
 
     stats.measurement_time = stats_read_start.elapsed();
 
-    stats.vss = info.pr_size;
+    stats.vsz = info.pr_size;
     stats.rss = info.pr_rssize;
 
     Ok(stats)

--- a/bin/propolis-server/src/lib/stats/virtual_machine.rs
+++ b/bin/propolis-server/src/lib/stats/virtual_machine.rs
@@ -31,7 +31,7 @@ oximeter::use_timeseries!("virtual-machine.toml");
 pub use self::virtual_machine::Reset;
 // [this won't exist in CI until the oximeter schema is updated. hacked on this
 // locally with Cargo.toml patching.]
-pub use self::virtual_machine::VmmMaxRss;
+pub use self::virtual_machine::VmmVss;
 use self::virtual_machine::{
     VcpuUsage, VirtualMachine as VirtualMachineTarget,
 };

--- a/bin/propolis-server/src/lib/stats/virtual_machine.rs
+++ b/bin/propolis-server/src/lib/stats/virtual_machine.rs
@@ -29,9 +29,8 @@ use super::kstat_types::{KstatList, KstatTarget};
 // `./omicron/oximeter/oximeter/schema/virtual-machine.toml`.
 oximeter::use_timeseries!("virtual-machine.toml");
 pub use self::virtual_machine::Reset;
-// [this won't exist in CI until the oximeter schema is updated. hacked on this
-// locally with Cargo.toml patching.]
-pub use self::virtual_machine::VmmVss;
+// [this currently exists only due to Cargo.toml patching to a one-off Omicron.]
+pub use self::virtual_machine::VmmVsz;
 use self::virtual_machine::{
     VcpuUsage, VirtualMachine as VirtualMachineTarget,
 };

--- a/bin/propolis-server/src/lib/stats/virtual_machine.rs
+++ b/bin/propolis-server/src/lib/stats/virtual_machine.rs
@@ -29,6 +29,7 @@ use super::kstat_types::{KstatList, KstatTarget};
 // `./omicron/oximeter/oximeter/schema/virtual-machine.toml`.
 oximeter::use_timeseries!("virtual-machine.toml");
 pub use self::virtual_machine::Reset;
+pub use self::virtual_machine::VmmMaxRss;
 use self::virtual_machine::{
     VcpuUsage, VirtualMachine as VirtualMachineTarget,
 };

--- a/bin/propolis-server/src/lib/stats/virtual_machine.rs
+++ b/bin/propolis-server/src/lib/stats/virtual_machine.rs
@@ -29,6 +29,8 @@ use super::kstat_types::{KstatList, KstatTarget};
 // `./omicron/oximeter/oximeter/schema/virtual-machine.toml`.
 oximeter::use_timeseries!("virtual-machine.toml");
 pub use self::virtual_machine::Reset;
+// [this won't exist in CI until the oximeter schema is updated. hacked on this
+// locally with Cargo.toml patching.]
 pub use self::virtual_machine::VmmMaxRss;
 use self::virtual_machine::{
     VcpuUsage, VirtualMachine as VirtualMachineTarget,

--- a/bin/propolis-server/src/lib/vm/services.rs
+++ b/bin/propolis-server/src/lib/vm/services.rs
@@ -67,6 +67,7 @@ impl VmServices {
                 cfg,
                 registry,
                 vm_objects.instance_spec(),
+                vm_objects.machine().map_physmem.virtual_address_size(),
                 vm_properties,
             )
             .await
@@ -119,6 +120,7 @@ async fn register_oximeter_producer(
     cfg: &MetricsEndpointConfig,
     registry: &ProducerRegistry,
     spec: &Spec,
+    vm_va_size: usize,
     vm_properties: &InstanceProperties,
 ) -> OximeterState {
     let mut oximeter_state = OximeterState::default();
@@ -152,7 +154,7 @@ async fn register_oximeter_producer(
     // Assign our own metrics production for this VM instance to the
     // registry, letting the server actually return them to oximeter when
     // polled.
-    let stats = ServerStats::new(virtual_machine);
+    let stats = ServerStats::new(virtual_machine, vm_va_size);
     if let Err(e) = registry.register_producer(stats.clone()) {
         error!(
             log,

--- a/lib/propolis/src/util/aspace.rs
+++ b/lib/propolis/src/util/aspace.rs
@@ -184,9 +184,9 @@ fn safe_end(start: usize, len: usize) -> Option<usize> {
 // Flatten the K/V nested tuple
 fn kv_flatten<'a, T>(i: (&'a usize, &'a (usize, T))) -> SpaceItem<'a, T> {
     let start = *i.0;
-    let end = (i.1).0;
+    let size = (i.1).0;
     let item = &(i.1).1;
-    (start, end, item)
+    (start, size, item)
 }
 
 /// Iterator for all items in an [ASpace], constructed by [ASpace::iter].

--- a/lib/propolis/src/vmm/mem.rs
+++ b/lib/propolis/src/vmm/mem.rs
@@ -197,6 +197,19 @@ impl PhysMap {
         let mut guard = self.map.lock().unwrap();
         guard.clear();
     }
+
+    /// Sum the sizes of virtual address ranges supporting segments of memory
+    /// for this VM.
+    pub fn virtual_address_size(&self) -> usize {
+        let guard = self.map.lock().unwrap();
+        let mut va_size = 0usize;
+
+        for (_start, size, _item) in guard.iter() {
+            va_size += size;
+        }
+
+        va_size
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
collect VSS from `/proc/self/psinfo` and report it as an Oximeter metric for the VM. VSS is maintained as mappings are adjusted so it's about as close to free as a syscall can get. Propolis' VSS includes guest-mapped regions; this change subtracts out the size of a guest's `ASpace` so we only get the amount Propolis has a say in. no RSS measurement here, but that's really only useful to tell us if the virtual mappings are overly-large (like, do we have a 128 MiB heap when we're only using 4 MiB?) - that'd be nice to know in the limit, but somewhat less interesting now. most of our VSS comes from `propolis-server` itself anyway.

the original approach here was walking through `/proc/{getpid()}/xmap` to get both RSS and VSS, and letting us exclude mappings that are part of the guest's accessible memory - in some sense this is aesthetically pleasant, but collecting and iterating the thousands of mappings meant this took up to seconds(!) of time that potentially could block the guest VM (!) if it needed the process lock at any point while we were measuring.

