### PR TITLE
client: re-export instance spec types for use in sled-agent

### DIFF
--- a/crates/propolis-api-types/src/instance_spec/components/board.rs
+++ b/crates/propolis-api-types/src/instance_spec/components/board.rs
@@ -38,6 +38,12 @@ pub enum Chipset {
     I440Fx(I440Fx),
 }
 
+impl Default for Chipset {
+    fn default() -> Self {
+        Self::I440Fx(I440Fx { enable_pcie: false })
+    }
+}
+
 /// A set of CPUID values to expose to a guest.
 #[derive(Clone, Deserialize, Serialize, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/crates/propolis-api-types/src/instance_spec/mod.rs
+++ b/crates/propolis-api-types/src/instance_spec/mod.rs
@@ -217,10 +217,16 @@ impl std::fmt::Display for SpecKey {
 impl std::str::FromStr for SpecKey {
     type Err = core::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match Uuid::parse_str(s) {
+        Ok(s.into())
+    }
+}
+
+impl From<&str> for SpecKey {
+    fn from(s: &str) -> Self {
+        match Uuid::parse_str(s) {
             Ok(uuid) => Self::Uuid(uuid),
             Err(_) => Self::Name(s.to_owned()),
-        })
+        }
     }
 }
 

--- a/crates/propolis-config-toml/src/spec.rs
+++ b/crates/propolis-config-toml/src/spec.rs
@@ -10,14 +10,13 @@ use std::{
 };
 
 use propolis_client::{
-    support::nvme_serial_from_str,
-    types::{
+    instance_spec::{
         ComponentV0, DlpiNetworkBackend, FileStorageBackend,
-        MigrationFailureInjector, NvmeDisk, P9fs, PciPciBridge, SoftNpuP9,
-        SoftNpuPciPort, SoftNpuPort, SpecKey, VirtioDisk, VirtioNetworkBackend,
-        VirtioNic,
+        MigrationFailureInjector, NvmeDisk, P9fs, PciPath, PciPciBridge,
+        SoftNpuP9, SoftNpuPciPort, SoftNpuPort, SpecKey, VirtioDisk,
+        VirtioNetworkBackend, VirtioNic,
     },
-    PciPath,
+    support::nvme_serial_from_str,
 };
 use thiserror::Error;
 

--- a/lib/propolis-client/src/lib.rs
+++ b/lib/propolis-client/src/lib.rs
@@ -4,9 +4,28 @@
 
 //! A client for the Propolis hypervisor frontend's server API.
 
-// Re-export types from propolis_api_types where callers may want to use
-// constructors or From impls.
-pub use propolis_api_types::instance_spec::{PciPath, SpecKey};
+/// Re-exports of types related to instance specs.
+///
+/// These types are re-exported for the convenience of components like
+/// sled-agent that may wish to expose instance specs in their own APIs.
+/// Defining the sled-agent API in terms of these "native" types allows
+/// sled-agent to reuse their trait implementations (and in particular use
+/// "manual" impls of things that Progenitor would otherwise derive).
+///
+/// In the generated client, the native "top-level" instance spec and component
+/// types ([`VersionedInstanceSpec`], [`InstanceSpecV0`], and
+/// [`ReplacementComponent`]) replace their generated counterparts. This
+/// obviates the need to maintain `From` impls to convert between native and
+/// generated types.
+pub mod instance_spec {
+    pub use propolis_api_types::instance_spec::{
+        components::{backends::*, board::*, devices::*},
+        v0::*,
+        *,
+    };
+
+    pub use propolis_api_types::ReplacementComponent;
+}
 
 // Re-export Crucible client types that appear in their serialized forms in
 // instance specs. This allows clients to ensure they serialize/deserialize
@@ -19,7 +38,10 @@ progenitor::generate_api!(
     interface = Builder,
     tags = Separate,
     replace = {
-        PciPath = crate::PciPath,
+        PciPath = crate::instance_spec::PciPath,
+        ReplacementComponent = crate::instance_spec::ReplacementComponent,
+        InstanceSpecV0 = crate::instance_spec::InstanceSpecV0,
+        VersionedInstanceSpec = crate::instance_spec::VersionedInstanceSpec,
     },
     // Automatically derive JsonSchema for instance spec-related types so that
     // they can be reused in sled-agent's API. This can't be done with a

--- a/lib/propolis-client/src/lib.rs
+++ b/lib/propolis-client/src/lib.rs
@@ -48,8 +48,8 @@ progenitor::generate_api!(
     // `derives = [schemars::JsonSchema]` directive because the `SpecKey` type
     // needs to implement that trait manually (see below).
     patch = {
-        BootSettings = { derives = [ Default] },
-        CpuidEntry = { derives = [ PartialEq, Eq, Copy ]},
+        BootSettings = { derives = [ Default ] },
+        CpuidEntry = { derives = [ PartialEq, Eq, Copy ] },
         InstanceMetadata = { derives = [ PartialEq ] },
         SpecKey = { derives = [ PartialEq, Eq, Ord, PartialOrd, Hash ] },
     }

--- a/lib/propolis-client/src/lib.rs
+++ b/lib/propolis-client/src/lib.rs
@@ -48,99 +48,11 @@ progenitor::generate_api!(
     // `derives = [schemars::JsonSchema]` directive because the `SpecKey` type
     // needs to implement that trait manually (see below).
     patch = {
-        BlobStorageBackend = { derives = [ schemars::JsonSchema ]},
-        Board = { derives = [ schemars::JsonSchema ]},
-        BootOrderEntry = { derives = [ schemars::JsonSchema ]},
-        BootSettings = { derives = [ schemars::JsonSchema, Default] },
-        ComponentV0 = { derives = [ schemars::JsonSchema ]},
-        Chipset = { derives = [ schemars::JsonSchema ]},
-        CrucibleStorageBackend = { derives = [ schemars::JsonSchema ]},
-        Cpuid = { derives = [ schemars::JsonSchema ]},
-        CpuidEntry = { derives = [ schemars::JsonSchema, PartialEq, Eq, Copy ]},
-        CpuidVendor = { derives = [ schemars::JsonSchema ]},
-        DlpiNetworkBackend = { derives = [ schemars::JsonSchema ]},
-        FileStorageBackend = { derives = [ schemars::JsonSchema ]},
-        GuestHypervisorInterface = { derives = [ schemars::JsonSchema ]},
-        I440Fx = { derives = [ schemars::JsonSchema ]},
-        HyperVFeatureFlag = { derives = [ schemars::JsonSchema ]},
-        MigrationFailureInjector = { derives = [ schemars::JsonSchema ]},
-        NvmeDisk = { derives = [ schemars::JsonSchema ]},
+        BootSettings = { derives = [ Default] },
+        CpuidEntry = { derives = [ PartialEq, Eq, Copy ]},
         InstanceMetadata = { derives = [ PartialEq ] },
-        InstanceSpecV0 = { derives = [ schemars::JsonSchema ]},
-        PciPciBridge = { derives = [ schemars::JsonSchema ]},
-        P9fs = { derives = [ schemars::JsonSchema ]},
-        QemuPvpanic = { derives = [ schemars::JsonSchema ]},
-        SerialPort = { derives = [ schemars::JsonSchema ]},
-        SerialPortNumber = { derives = [ schemars::JsonSchema ]},
-        SoftNpuP9 = { derives = [ schemars::JsonSchema ]},
-        SoftNpuPort = { derives = [ schemars::JsonSchema ]},
-        SoftNpuPciPort = { derives = [ schemars::JsonSchema ]},
         SpecKey = { derives = [ PartialEq, Eq, Ord, PartialOrd, Hash ] },
-        VirtioDisk = { derives = [ schemars::JsonSchema ]},
-        VirtioNic = { derives = [ schemars::JsonSchema ]},
-        VirtioNetworkBackend = { derives = [ schemars::JsonSchema ]},
     }
 );
-
-// Supply the same JsonSchema implementation for the generated SpecKey type that
-// the native type has. This allows sled-agent (or another consumer) to reuse
-// the generated type in its own API to produce an API document that generates
-// the correct type for sled-agent's (or the other consumer's) clients.
-impl schemars::JsonSchema for types::SpecKey {
-    fn schema_name() -> String {
-        "SpecKey".to_owned()
-    }
-
-    fn json_schema(
-        generator: &mut schemars::gen::SchemaGenerator,
-    ) -> schemars::schema::Schema {
-        use schemars::schema::*;
-        fn label_schema(label: &str, schema: Schema) -> Schema {
-            SchemaObject {
-                metadata: Some(
-                    Metadata {
-                        title: Some(label.to_string()),
-                        ..Default::default()
-                    }
-                    .into(),
-                ),
-                subschemas: Some(
-                    SubschemaValidation {
-                        all_of: Some(vec![schema]),
-                        ..Default::default()
-                    }
-                    .into(),
-                ),
-                ..Default::default()
-            }
-            .into()
-        }
-
-        SchemaObject {
-            metadata: Some(
-                Metadata {
-                    description: Some(
-                        "A key identifying a component in an instance spec."
-                            .to_string(),
-                    ),
-                    ..Default::default()
-                }
-                .into(),
-            ),
-            subschemas: Some(Box::new(SubschemaValidation {
-                one_of: Some(vec![
-                    label_schema(
-                        "uuid",
-                        generator.subschema_for::<uuid::Uuid>(),
-                    ),
-                    label_schema("name", generator.subschema_for::<String>()),
-                ]),
-                ..Default::default()
-            })),
-            ..Default::default()
-        }
-        .into()
-    }
-}
 
 pub mod support;

--- a/lib/propolis/src/block/file.rs
+++ b/lib/propolis/src/block/file.rs
@@ -409,7 +409,7 @@ mod dkioc {
             }
             DiscardMech::FnctlFreesp => {
                 let mut fl = libc::flock {
-                    l_type: libc::F_WRLCK,
+                    l_type: libc::F_WRLCK as i16,
                     l_whence: 0,
                     l_start: off as i64,
                     l_len: len as i64,

--- a/lib/propolis/src/block/file.rs
+++ b/lib/propolis/src/block/file.rs
@@ -409,7 +409,7 @@ mod dkioc {
             }
             DiscardMech::FnctlFreesp => {
                 let mut fl = libc::flock {
-                    l_type: libc::F_WRLCK as i16,
+                    l_type: libc::F_WRLCK,
                     l_whence: 0,
                     l_start: off as i64,
                     l_len: len as i64,

--- a/phd-tests/framework/src/disk/crucible.rs
+++ b/phd-tests/framework/src/disk/crucible.rs
@@ -13,7 +13,7 @@ use std::{
 
 use anyhow::Context;
 use propolis_client::{
-    types::{ComponentV0, CrucibleStorageBackend},
+    instance_spec::{ComponentV0, CrucibleStorageBackend},
     CrucibleOpts, VolumeConstructionRequest,
 };
 use rand::{rngs::StdRng, RngCore, SeedableRng};

--- a/phd-tests/framework/src/disk/file.rs
+++ b/phd-tests/framework/src/disk/file.rs
@@ -5,7 +5,7 @@
 //! Abstractions for disks with a raw file backend.
 
 use camino::{Utf8Path, Utf8PathBuf};
-use propolis_client::types::{ComponentV0, FileStorageBackend};
+use propolis_client::instance_spec::{ComponentV0, FileStorageBackend};
 use tracing::{debug, error, warn};
 use uuid::Uuid;
 

--- a/phd-tests/framework/src/disk/in_memory.rs
+++ b/phd-tests/framework/src/disk/in_memory.rs
@@ -4,7 +4,7 @@
 
 //! Abstractions for disks with an in-memory backend.
 
-use propolis_client::types::{BlobStorageBackend, ComponentV0};
+use propolis_client::instance_spec::{BlobStorageBackend, ComponentV0};
 
 use super::DiskConfig;
 use crate::disk::DeviceName;

--- a/phd-tests/framework/src/disk/mod.rs
+++ b/phd-tests/framework/src/disk/mod.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use camino::{Utf8Path, Utf8PathBuf};
 use in_memory::InMemoryDisk;
-use propolis_client::types::ComponentV0;
+use propolis_client::instance_spec::ComponentV0;
 use thiserror::Error;
 
 use crate::{

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -27,13 +27,14 @@ use anyhow::{anyhow, Context, Result};
 use camino::Utf8PathBuf;
 use core::result::Result as StdResult;
 use propolis_client::{
+    instance_spec::{ComponentV0, ReplacementComponent},
     support::{InstanceSerialConsoleHelper, WSClientOffset},
     types::{
-        ComponentV0, InstanceEnsureRequest, InstanceGetResponse,
+        InstanceEnsureRequest, InstanceGetResponse,
         InstanceInitializationMethod, InstanceMigrateStatusResponse,
         InstanceProperties, InstanceSerialConsoleHistoryResponse,
         InstanceSpecGetResponse, InstanceState, InstanceStateRequested,
-        MigrationState, ReplacementComponent,
+        MigrationState,
     },
 };
 use propolis_client::{Client, ResponseValue};
@@ -601,7 +602,7 @@ impl TestVm {
             match comp {
                 ComponentV0::MigrationFailureInjector(inj) => {
                     map.insert(
-                        id.clone(),
+                        id.to_string(),
                         ReplacementComponent::MigrationFailureInjector(
                             inj.clone(),
                         ),
@@ -609,7 +610,7 @@ impl TestVm {
                 }
                 ComponentV0::CrucibleStorageBackend(be) => {
                     map.insert(
-                        id.clone(),
+                        id.to_string(),
                         ReplacementComponent::CrucibleStorageBackend(
                             be.clone(),
                         ),

--- a/phd-tests/framework/src/test_vm/spec.rs
+++ b/phd-tests/framework/src/test_vm/spec.rs
@@ -9,7 +9,10 @@ use crate::{
     guest_os::GuestOsKind,
 };
 use camino::Utf8PathBuf;
-use propolis_client::types::{ComponentV0, InstanceMetadata, InstanceSpecV0};
+use propolis_client::{
+    instance_spec::{ComponentV0, InstanceSpecV0},
+    types::InstanceMetadata,
+};
 use uuid::Uuid;
 
 /// The set of objects needed to start and run a guest in a `TestVm`.
@@ -82,8 +85,12 @@ impl VmSpec {
             };
 
             let backend_spec = disk.backend_spec();
-            let backend_name =
-                disk.device_name().clone().into_backend_name().into_string();
+            let backend_name = disk
+                .device_name()
+                .clone()
+                .into_backend_name()
+                .into_string()
+                .into();
             if let Some(ComponentV0::CrucibleStorageBackend(_)) =
                 spec.components.get(&backend_name)
             {

--- a/phd-tests/tests/src/cpuid.rs
+++ b/phd-tests/tests/src/cpuid.rs
@@ -5,8 +5,9 @@
 use cpuid_utils::{CpuidIdent, CpuidSet, CpuidValues};
 use phd_framework::{test_vm::MigrationTimeout, TestVm};
 use phd_testcase::*;
-use propolis_client::types::{
-    CpuidEntry, InstanceSpecStatus, VersionedInstanceSpec,
+use propolis_client::{
+    instance_spec::{CpuidEntry, VersionedInstanceSpec},
+    types::InstanceSpecStatus,
 };
 use tracing::info;
 use uuid::Uuid;

--- a/phd-tests/tests/src/hyperv.rs
+++ b/phd-tests/tests/src/hyperv.rs
@@ -8,7 +8,9 @@ use phd_framework::{
     artifacts, lifecycle::Action, test_vm::MigrationTimeout, TestVm,
 };
 use phd_testcase::*;
-use propolis_client::types::HyperVFeatureFlag;
+use propolis_client::instance_spec::{
+    GuestHypervisorInterface, HyperVFeatureFlag,
+};
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -51,11 +53,9 @@ async fn guest_detect_hyperv(vm: &TestVm) -> anyhow::Result<()> {
 #[phd_testcase]
 async fn hyperv_smoke_test(ctx: &Framework) {
     let mut cfg = ctx.vm_config_builder("hyperv_smoke_test");
-    cfg.guest_hv_interface(
-        propolis_client::types::GuestHypervisorInterface::HyperV {
-            features: vec![],
-        },
-    );
+    cfg.guest_hv_interface(GuestHypervisorInterface::HyperV {
+        features: Default::default(),
+    });
     let mut vm = ctx.spawn_vm(&cfg, None).await?;
     vm.launch().await?;
     vm.wait_to_boot().await?;
@@ -66,11 +66,9 @@ async fn hyperv_smoke_test(ctx: &Framework) {
 #[phd_testcase]
 async fn hyperv_lifecycle_test(ctx: &Framework) {
     let mut cfg = ctx.vm_config_builder("hyperv_lifecycle_test");
-    cfg.guest_hv_interface(
-        propolis_client::types::GuestHypervisorInterface::HyperV {
-            features: vec![],
-        },
-    );
+    cfg.guest_hv_interface(GuestHypervisorInterface::HyperV {
+        features: Default::default(),
+    });
     let mut vm = ctx.spawn_vm(&cfg, None).await?;
     vm.launch().await?;
     vm.wait_to_boot().await?;
@@ -93,11 +91,9 @@ async fn hyperv_lifecycle_test(ctx: &Framework) {
 #[phd_testcase]
 async fn hyperv_reference_tsc_clocksource_test(ctx: &Framework) {
     let mut cfg = ctx.vm_config_builder("hyperv_reference_tsc_test");
-    cfg.guest_hv_interface(
-        propolis_client::types::GuestHypervisorInterface::HyperV {
-            features: vec![HyperVFeatureFlag::ReferenceTsc],
-        },
-    );
+    cfg.guest_hv_interface(GuestHypervisorInterface::HyperV {
+        features: [HyperVFeatureFlag::ReferenceTsc].into_iter().collect(),
+    });
     let mut vm = ctx.spawn_vm(&cfg, None).await?;
     vm.launch().await?;
     vm.wait_to_boot().await?;
@@ -281,11 +277,9 @@ async fn hyperv_reference_tsc_elapsed_time_test(ctx: &Framework) {
     }
 
     let mut cfg = ctx.vm_config_builder("hyperv_reference_tsc_elapsed_test");
-    cfg.guest_hv_interface(
-        propolis_client::types::GuestHypervisorInterface::HyperV {
-            features: vec![HyperVFeatureFlag::ReferenceTsc],
-        },
-    );
+    cfg.guest_hv_interface(GuestHypervisorInterface::HyperV {
+        features: [HyperVFeatureFlag::ReferenceTsc].into_iter().collect(),
+    });
     let mut vm = ctx.spawn_vm(&cfg, None).await?;
     vm.launch().await?;
     vm.wait_to_boot().await?;

--- a/phd-tests/tests/src/smoke.rs
+++ b/phd-tests/tests/src/smoke.rs
@@ -3,7 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use phd_testcase::*;
-use propolis_client::types::{InstanceSpecStatus, VersionedInstanceSpec};
+use propolis_client::{
+    instance_spec::VersionedInstanceSpec, types::InstanceSpecStatus,
+};
 
 #[phd_testcase]
 async fn nproc_test(ctx: &Framework) {

--- a/phd-tests/tests/src/stats.rs
+++ b/phd-tests/tests/src/stats.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use phd_framework::test_vm::{FakeOximeterSampler, MetricsLocation};
-use propolis_client::types::HyperVFeatureFlag;
+use propolis_client::instance_spec::HyperVFeatureFlag;
 
 use chrono::{DateTime, Utc};
 use oximeter::types::{ProducerResults, ProducerResultsItem, Sample};
@@ -217,8 +217,8 @@ async fn instance_vcpu_stats(ctx: &Framework) {
 
     let mut vm_config = ctx.vm_config_builder("instance_vcpu_stats");
     vm_config.guest_hv_interface(
-        propolis_client::types::GuestHypervisorInterface::HyperV {
-            features: vec![HyperVFeatureFlag::ReferenceTsc],
+        propolis_client::instance_spec::GuestHypervisorInterface::HyperV {
+            features: [HyperVFeatureFlag::ReferenceTsc].into_iter().collect(),
         },
     );
     // Having one CPU simplifies the math for time expectations later in the


### PR DESCRIPTION
Follow-up to #896. Using generated instance spec types in sled-agent's API has some substantial downsides:

1. Some component types (e.g. storage backends) have fields that we'd like to redact when logging their contents using their `Debug` impls. The native versions of these types manually impl `Debug` for these types, but their generated counterparts always derive Debug (and AFAIK there's no way to ask Progenitor not to add this derive).
2. The Dropshot-generated OpenAPI doc for sled-agent's API winds up having very gnarly type descriptions that include fully-escaped versions of the Progenitor-generated doc comments from propolis-client.[^1]

To get around these problems:

- Add a propolis-client submodule that re-exports all instance spec-related types from `propolis_api_types`.
- Add `replace` directives to the generated client that replace the generated versions of `InstanceSpecV0`, `VersionedInstanceSpec`, and `ReplacementComponent` with their re-exported equivalents.

This way, sled-agent can use the re-exported spec types internally and in its API. This reuses their manual `impl`s when they exist (solving problem 1) and avoids presenting generated JSON schema documentation when generating the sled-agent API document (solving problem 2).

Remove the `JsonSchema` implementations for generated spec types, since they're no longer needed. 

Finally, fix a one-line clippy nit that started showing up alongside these changes.

Tests: cargo test and PHD; picked up this change into oxidecomputer/omicron#8002 and verified that (a) that change still works (and that it produces a much cleaner sled-agent API document), and (b) log messages from sled-agent redact spec components that we want to be redacted.

[^1]: Concretely: suppose you have type `foo::Widget` with a doc comment, and you have a `foo_server` crate with a Dropshot API that makes use of this type. If you generate an OpenAPI document from this API, and then use Progenitor to generate a client from that document, `foo_client::types::Widget` will have a doc comment that includes both the original `foo::Widget` doc comment and a Progenitor-generated description of the type's JSON schema. This is all well and good and what we expect. Now suppose you then create crate `bar_server` and include `foo_client::types::Widget` in its Dropshot API. The description of `Widget` in `bar_server`'s API document will contain both the original `foo::Widget` description *and* the generated JSON schema text from `foo_client::types::Widget` in the type's "description" field. And if you then generate `bar_client::types::Widget`, the schema will be generated *again* and re-included in the generated type's doc comment. Needless to say: yuck.