### PR TITLE
Update Crucible to latest.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,7 +859,7 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da3cf198a0e000bb89efc3a1c77d7ba09340a600#da3cf198a0e000bb89efc3a1c77d7ba09340a600"
+source = "git+https://github.com/oxidecomputer/crucible?rev=45801597f410685015ac2704d044919a41e3ff75#45801597f410685015ac2704d044919a41e3ff75"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -875,6 +875,7 @@ dependencies = [
  "crucible-protocol",
  "crucible-workspace-hack",
  "dropshot",
+ "fakedata_generator",
  "futures",
  "futures-core",
  "internal-dns-resolver",
@@ -912,7 +913,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da3cf198a0e000bb89efc3a1c77d7ba09340a600#da3cf198a0e000bb89efc3a1c77d7ba09340a600"
+source = "git+https://github.com/oxidecomputer/crucible?rev=45801597f410685015ac2704d044919a41e3ff75#45801597f410685015ac2704d044919a41e3ff75"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -925,7 +926,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da3cf198a0e000bb89efc3a1c77d7ba09340a600#da3cf198a0e000bb89efc3a1c77d7ba09340a600"
+source = "git+https://github.com/oxidecomputer/crucible?rev=45801597f410685015ac2704d044919a41e3ff75#45801597f410685015ac2704d044919a41e3ff75"
 dependencies = [
  "anyhow",
  "atty",
@@ -954,7 +955,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=da3cf198a0e000bb89efc3a1c77d7ba09340a600#da3cf198a0e000bb89efc3a1c77d7ba09340a600"
+source = "git+https://github.com/oxidecomputer/crucible?rev=45801597f410685015ac2704d044919a41e3ff75#45801597f410685015ac2704d044919a41e3ff75"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1525,6 +1526,18 @@ dependencies = [
  "console",
  "newline-converter",
  "similar",
+]
+
+[[package]]
+name = "fakedata_generator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b82fba4b485b819fde74012109688a9d2bd4ce7b22583ac12c9fa239f74a02"
+dependencies = [
+ "passt",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3918,6 +3931,12 @@ dependencies = [
  "structmeta",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "passt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13242a5ce97f39a8095d03c8b273e91d09f2690c0b7d69a2af844941115bab24"
 
 [[package]]
 name = "password-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,8 +86,8 @@ oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 sled-agent-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 
 # Crucible
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "da3cf198a0e000bb89efc3a1c77d7ba09340a600" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "da3cf198a0e000bb89efc3a1c77d7ba09340a600" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "45801597f410685015ac2704d044919a41e3ff75" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "45801597f410685015ac2704d044919a41e3ff75" }
 
 # External dependencies
 anyhow = "1.0"


### PR DESCRIPTION
Changes include:
Target replacement support for VCRs with multiple sub_volumes (#1551) Fix assorted clippy lints (#1710)
Cleanup some XXX comments (#1709)
Update Rust crate uuid to v1.16.0 (#1707)
Update Rust crate reedline to 0.39.0 (#1706)
Update Rust crate opentelemetry to 0.29.1 (#1704)
Update Rust crate humantime to 2.2.0 (#1703)
Update Rust crate test-strategy to 0.4.1 (#1701)
Update Rust crate tempfile to v3.19.1 (#1700)
Update Rust crate serde_json to v1.0.140 (#1699)
Update Rust crate serde to v1.0.219 (#1698)
Update Rust crate reqwest to v0.12.15 (#1697)
Update Rust crate tokio to v1.43.1 [SECURITY] (#1695) Update Rust crate clap to v4.5.35 (#1696)
Update dependency rust to v1.86.0 (#1619)
No color for git output for nightly test (#1694)
Add more extents for repair tests (#1689)
Make `IOop` use absolute block indices (#1693)
Remove ImpactedAddr entirely; clean up ImpactedBlocks proptests (#1688)