### PR TITLE
update zerocopy to 0.8.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,7 +2500,7 @@ dependencies = [
  "ingot-types",
  "macaddr",
  "serde",
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -2523,7 +2523,7 @@ source = "git+https://github.com/oxidecomputer/ingot.git?rev=bff93247fe75ff88912
 dependencies = [
  "ingot-macros",
  "macaddr",
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -3693,7 +3693,7 @@ dependencies = [
  "smoltcp",
  "tabwriter",
  "uuid",
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -4620,7 +4620,7 @@ dependencies = [
  "usdt 0.5.0",
  "uuid",
  "viona_api",
- "zerocopy 0.7.34",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -4993,7 +4993,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -5227,7 +5227,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
- "zerocopy 0.7.34",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -7967,11 +7967,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -8009,9 +8009,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ tracing-bunyan-formatter = "0.3.3"
 tracing-subscriber = "0.3.14"
 usdt = { version = "0.5", default-features = false }
 uuid = "1.3.2"
-zerocopy = "0.7.34"
+zerocopy = "0.8.25"
 
 
 #

--- a/crates/rfb/src/proto.rs
+++ b/crates/rfb/src/proto.rs
@@ -437,7 +437,7 @@ fn read_data<T: FromBytes>(buf: &mut BytesMut) -> Option<T> {
     // It'd be kind of nice to return the error here instead of an Option, but
     // because the error borrows the buf we're going to try parsing from, rustc
     // believes the buffer to be immutably borrowed when we advance it below.
-    // As an option the Err and its borrow are discarded so we avoid the issue.
+    // As an Option, the Err and its borrow are discarded so we avoid the issue.
     let data = T::read_from_prefix(buf).ok()?.0;
     buf.advance(sz);
     Some(data)

--- a/crates/rfb/src/proto.rs
+++ b/crates/rfb/src/proto.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio_util::bytes::{Buf, BytesMut};
 use tokio_util::codec::Decoder;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use crate::encodings::{Encoding, EncodingType};
 use crate::keysym::KeySym;
@@ -262,7 +262,7 @@ impl Rectangle {
 }
 
 // Section 7.4
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Immutable)]
 pub struct PixelFormat {
     pub bits_per_pixel: u8, // TODO: must be 8, 16, or 32
     pub depth: u8,          // TODO: must be < bits_per_pixel
@@ -388,13 +388,13 @@ impl TryInto<FourCC> for &PixelFormat {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Immutable)]
 pub enum ColorSpecification {
     ColorFormat(ColorFormat),
     // Not covered: colormap support
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Immutable)]
 pub struct ColorFormat {
     // TODO: maxes must be 2^N - 1 for N bits per color
     pub red_max: u16,
@@ -434,7 +434,11 @@ enum ClientMessageType {
 
 fn read_data<T: FromBytes>(buf: &mut BytesMut) -> Option<T> {
     let sz = size_of::<T>();
-    let data = T::read_from_prefix(buf)?;
+    // It'd be kind of nice to return the error here instead of an Option, but
+    // because the error borrows the buf we're going to try parsing from, rustc
+    // believes the buffer to be immutably borrowed when we advance it below.
+    // As an option the Err and its borrow are discarded so we avoid the issue.
+    let data = T::read_from_prefix(buf).ok()?.0;
     buf.advance(sz);
     Some(data)
 }
@@ -633,10 +637,10 @@ impl From<raw::PointerEvent> for PointerEvent {
 
 mod raw {
     use zerocopy::big_endian::{U16, U32};
-    use zerocopy::{AsBytes, FromBytes, FromZeroes};
+    use zerocopy::{FromBytes, Immutable, IntoBytes};
 
     #[allow(dead_code)]
-    #[derive(Copy, Clone, FromBytes, FromZeroes, AsBytes)]
+    #[derive(Copy, Clone, FromBytes, IntoBytes, Immutable)]
     #[repr(C, packed)]
     pub(crate) struct PixelFormat {
         pub bits_per_pixel: u8,
@@ -652,7 +656,7 @@ mod raw {
         pub _padding: [u8; 3],
     }
 
-    #[derive(Copy, Clone, FromBytes, FromZeroes)]
+    #[derive(Copy, Clone, FromBytes, Immutable)]
     #[repr(C, packed)]
     pub(crate) struct FramebufferUpdateRequest {
         pub incremental: u8,
@@ -660,7 +664,7 @@ mod raw {
         pub resolution: Resolution,
     }
 
-    #[derive(Copy, Clone, FromBytes, FromZeroes)]
+    #[derive(Copy, Clone, FromBytes)]
     #[repr(C, packed)]
     pub(crate) struct KeyEvent {
         pub down_flag: u8,
@@ -668,14 +672,14 @@ mod raw {
         pub key: U32,
     }
 
-    #[derive(Copy, Clone, FromBytes, FromZeroes)]
+    #[derive(Copy, Clone, FromBytes)]
     #[repr(C, packed)]
     pub(crate) struct PointerEvent {
         pub button_mask: u8,
         pub position: Position,
     }
 
-    #[derive(Copy, Clone, FromBytes, FromZeroes)]
+    #[derive(Copy, Clone, FromBytes, Immutable)]
     #[repr(C, packed)]
     pub(crate) struct Position {
         pub x: U16,
@@ -687,7 +691,7 @@ mod raw {
         }
     }
 
-    #[derive(Copy, Clone, FromBytes, FromZeroes)]
+    #[derive(Copy, Clone, FromBytes, Immutable)]
     #[repr(C, packed)]
     pub(crate) struct Resolution {
         width: U16,
@@ -699,7 +703,7 @@ mod raw {
         }
     }
 
-    #[derive(Copy, Clone, AsBytes)]
+    #[derive(Copy, Clone, IntoBytes, Immutable)]
     #[repr(C, packed)]
     #[allow(dead_code)]
     pub(crate) struct FramebufferUpdateHeader {

--- a/lib/propolis/Cargo.toml
+++ b/lib/propolis/Cargo.toml
@@ -31,7 +31,7 @@ erased-serde.workspace = true
 serde_json.workspace = true
 strum = { workspace = true, features = ["derive"] }
 uuid.workspace = true
-zerocopy = { workspace = true, features = ["derive", "byteorder" ] }
+zerocopy = { workspace = true, features = ["derive"] }
 crucible-client-types = { workspace = true, optional = true }
 crucible = { workspace = true, optional = true }
 oximeter = { workspace = true, optional = true }

--- a/lib/propolis/src/enlightenment/hyperv/tsc.rs
+++ b/lib/propolis/src/enlightenment/hyperv/tsc.rs
@@ -143,7 +143,7 @@ use crate::{
     vmm::Pfn,
 };
 
-use zerocopy::AsBytes;
+use zerocopy::{Immutable, IntoBytes};
 
 const ENABLED_BIT: u64 = 0;
 const ENABLED_MASK: u64 = 1 << ENABLED_BIT;
@@ -184,7 +184,7 @@ impl MsrReferenceTscValue {
 }
 
 /// The contents of a reference TSC page, defined in TLFS section 12.7.2.
-#[derive(Clone, Copy, Debug, Default, AsBytes)]
+#[derive(Clone, Copy, Debug, Default, IntoBytes, Immutable)]
 #[repr(packed, C)]
 pub(super) struct ReferenceTscPage {
     /// Incremented whenever the `scale` or `offset` fields of this page are

--- a/lib/propolis/src/hw/nvme/bits.rs
+++ b/lib/propolis/src/hw/nvme/bits.rs
@@ -5,12 +5,12 @@
 #![allow(dead_code)]
 
 use bitstruct::bitstruct;
-use zerocopy::{FromBytes, FromZeroes};
+use zerocopy::FromBytes;
 
 /// A Submission Queue Entry as represented in memory.
 ///
 /// See NVMe 1.0e Section 4.2 Submission Queue Entry - Command Format
-#[derive(Debug, Default, Copy, Clone, FromBytes, FromZeroes)]
+#[derive(Debug, Default, Copy, Clone, FromBytes)]
 #[repr(C, packed(1))]
 pub struct SubmissionQueueEntry {
     /// Command Dword 0 (CDW0)

--- a/lib/propolis/src/hw/virtio/queue.rs
+++ b/lib/propolis/src/hw/virtio/queue.rs
@@ -17,10 +17,10 @@ use crate::common::*;
 use crate::migrate::MigrateStateError;
 use crate::vmm::MemCtx;
 
-use zerocopy::{FromBytes, FromZeroes};
+use zerocopy::FromBytes;
 
 #[repr(C)]
-#[derive(Copy, Clone, FromBytes, FromZeroes)]
+#[derive(Copy, Clone, FromBytes)]
 struct VqdDesc {
     addr: u64,
     len: u32,


### PR DESCRIPTION
aside from keeping us up to date, the way i have the E820 code represents the memory type as an enum with `#[repr(u32)]`, which is only supported as of `0.8.x`. (or i navigated the crate poorly? either way this won't hurt and i made it work on `0.8.x`.)