### PR TITLE
Rust 1.87.0 clippy lints

### DIFF
--- a/bin/propolis-server/src/lib/migrate/codec.rs
+++ b/bin/propolis-server/src/lib/migrate/codec.rs
@@ -57,7 +57,7 @@ pub enum ProtocolError {
 
     /// An error occurred in the underlying websocket transport
     #[error("error occurred in websocket layer: {0}")]
-    WebsocketError(tokio_tungstenite::tungstenite::Error),
+    WebsocketError(Box<tokio_tungstenite::tungstenite::Error>),
 
     /// All our codec's messages should be tungstenite::Message::Binary
     #[error("received empty message with no discriminant")]

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -845,7 +845,7 @@ impl<T: MigrateConn> RonV0Runner<'_, T> {
                     io::ErrorKind::BrokenPipe,
                 ))
             })?
-            .map_err(codec::ProtocolError::WebsocketError)
+            .map_err(|e| codec::ProtocolError::WebsocketError(Box::new(e)))
             // convert tungstenite::Message to codec::Message
             .and_then(std::convert::TryInto::try_into)
             // If this is an error message, lift that out

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -221,15 +221,16 @@ async fn instance_ensure(
     };
 
     let vm_init = match init {
-        InstanceInitializationMethod::Spec { spec } => {
-            spec.try_into().map(VmInitializationMethod::Spec).map_err(|e| {
+        InstanceInitializationMethod::Spec { spec } => spec
+            .try_into()
+            .map(|s| VmInitializationMethod::Spec(Box::new(s)))
+            .map_err(|e| {
                 if let Some(s) = e.source() {
                     format!("{e}: {s}")
                 } else {
                     e.to_string()
                 }
-            })
-        }
+            }),
         InstanceInitializationMethod::MigrationTarget {
             migration_id,
             src_addr,

--- a/bin/propolis-server/src/lib/vm/ensure.rs
+++ b/bin/propolis-server/src/lib/vm/ensure.rs
@@ -129,7 +129,7 @@ use super::{
 };
 
 pub(crate) enum VmInitializationMethod {
-    Spec(Spec),
+    Spec(Box<Spec>),
     Migration(MigrationTargetInfo),
 }
 

--- a/bin/propolis-standalone/src/snapshot.rs
+++ b/bin/propolis-standalone/src/snapshot.rs
@@ -233,13 +233,10 @@ pub(crate) fn restore_config(path: impl AsRef<Path>) -> anyhow::Result<Config> {
     let file = File::open(&path).context("Failed to open snapshot file")?;
     let mut archive = TarArchive::new(file);
 
-    let entry = archive.named_entry(CONFIG_NAME)?;
-    let raw_bytes = entry.bytes().collect::<Result<Vec<u8>, _>>()?;
-    toml::from_str(
-        std::str::from_utf8(&raw_bytes[..])
-            .context("config should be valid utf-8")?,
-    )
-    .context("could not parse config")
+    let mut entry = archive.named_entry(CONFIG_NAME)?;
+    let mut toml_str = String::new();
+    entry.read_to_string(&mut toml_str)?;
+    toml::from_str(toml_str.as_str()).context("could not parse config")
 }
 
 /// Create an instance from a previously saved snapshot.
@@ -275,10 +272,10 @@ pub(crate) fn restore(
     // XXX put instance in migrate-source state
 
     let global: VmGlobalState = {
-        let global_ent = archive.named_entry(GLOBAL_NAME)?;
-        let global_bytes =
-            global_ent.bytes().collect::<Result<Vec<u8>, _>>()?;
-        serde_json::from_slice(&global_bytes[..])
+        let mut json_bytes = Vec::new();
+        let mut global_ent = archive.named_entry(GLOBAL_NAME)?;
+        global_ent.read_to_end(&mut json_bytes)?;
+        serde_json::from_slice(json_bytes.as_slice())
             .context("could not parse global data")?
     };
     import_global(&hdl, &global).context("failed to import global VM state")?;

--- a/crates/bhyve-api/src/lib.rs
+++ b/crates/bhyve-api/src/lib.rs
@@ -467,10 +467,7 @@ impl From<VmmDataError> for Error {
             VmmDataError::SpaceNeeded(c) => {
                 // ErrorKind::StorageFull would more accurately match the underlying ENOSPC
                 // but that variant is unstable still
-                Error::new(
-                    ErrorKind::Other,
-                    format!("operation requires {} bytes", c),
-                )
+                Error::other(format!("operation requires {} bytes", c))
             }
         }
     }

--- a/crates/dladm/src/lib.rs
+++ b/crates/dladm/src/lib.rs
@@ -79,14 +79,14 @@ impl Handle {
             .stdout(Stdio::piped())
             .output()?;
         if !output.status.success() {
-            return Err(Error::new(ErrorKind::Other, "failed dladm"));
+            return Err(Error::other("failed dladm"));
         }
         BufReader::new(&output.stdout[..])
             .lines()
             .next()
             .and_then(Result::ok)
             .and_then(|line| line.parse::<u16>().ok())
-            .ok_or_else(|| Error::new(ErrorKind::Other, "invalid mtu"))
+            .ok_or_else(|| Error::other("invalid mtu"))
     }
     fn get_vnic_mac(name: &str, mac: &mut [u8]) -> Result<()> {
         // dladm show-vnic -p -o macaddress <VNIC_NAME>
@@ -99,7 +99,7 @@ impl Handle {
             .stdout(Stdio::piped())
             .output()?;
         if !output.status.success() {
-            return Err(Error::new(ErrorKind::Other, "failed dladm"));
+            return Err(Error::other("failed dladm"));
         }
         let addr = BufReader::new(&output.stdout[..])
             .lines()
@@ -115,9 +115,7 @@ impl Handle {
                     _ => None,
                 }
             })
-            .ok_or_else(|| {
-                Error::new(ErrorKind::Other, "cannot query mac addr")
-            })?;
+            .ok_or_else(|| Error::other("cannot query mac addr"))?;
         mac.copy_from_slice(&addr[..]);
         Ok(())
     }
@@ -171,13 +169,9 @@ impl Handle {
         })?;
 
         if state.n_seen == 0 {
-            return Err(Error::new(
-                ErrorKind::Other,
-                "no mac addrs found on link",
-            ));
+            return Err(Error::other("no mac addrs found on link"));
         } else if !state.written {
-            return Err(Error::new(
-                ErrorKind::Other,
+            return Err(Error::other(
                 "no mac addrs on link had correct length (6B)",
             ));
         }
@@ -190,7 +184,7 @@ impl Handle {
             .unwrap_or(dladm_status::DLADM_STATUS_FAILED)
         {
             dladm_status::DLADM_STATUS_OK => Ok(()),
-            e => Err(Error::new(ErrorKind::Other, format!("{:?}", e))),
+            e => Err(Error::other(format!("{:?}", e))),
         }
     }
 }

--- a/crates/rfb/src/tungstenite.rs
+++ b/crates/rfb/src/tungstenite.rs
@@ -20,7 +20,7 @@ use tokio_tungstenite::WebSocketStream;
 fn tung_err_to_io(err: TungError) -> io::Error {
     match err {
         TungError::Io(io_err) => io_err,
-        err => io::Error::new(io::ErrorKind::Other, err),
+        err => io::Error::other(err),
     }
 }
 
@@ -101,10 +101,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> AsyncRead for BinaryWs<T> {
                         return Poll::Ready(Err(ioe));
                     }
                     _ => {
-                        return Poll::Ready(Err(std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            e,
-                        )));
+                        return Poll::Ready(Err(std::io::Error::other(e)));
                     }
                 },
                 Poll::Ready(Some(Ok(rmsg))) => {

--- a/lib/propolis/src/block/file.rs
+++ b/lib/propolis/src/block/file.rs
@@ -409,7 +409,7 @@ mod dkioc {
             }
             DiscardMech::FnctlFreesp => {
                 let mut fl = libc::flock {
-                    l_type: libc::F_WRLCK as i16,
+                    l_type: libc::F_WRLCK,
                     l_whence: 0,
                     l_start: off as i64,
                     l_len: len as i64,

--- a/lib/propolis/src/firmware/smbios/mod.rs
+++ b/lib/propolis/src/firmware/smbios/mod.rs
@@ -169,7 +169,7 @@ impl TryFrom<Vec<u8>> for SmbString {
     type Error = SmbStringNulError;
 
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        if value.iter().any(|b| *b == 0) {
+        if value.contains(&0) {
             Err(SmbStringNulError())
         } else {
             Ok(Self(value))


### PR DESCRIPTION
* large size differences between enum variants warn now
  - Spec is the noisier case here, and it's only used in relatively infrequent codepaths (VM setup and rundown) so there shouldn't be much change one way or the other here
  - ProtocolError is more interesting, because the error variant being large makes the Result as a whole large, which can affect happy-path code since the extra bytes can end up zeroed or copied needlessly
  - On the whole, kinda neat
* std::io::Read::bytes() warns now
  - This only affects propolis-standalone but after looking more closely it's kind of shocking how problematic std::io::Read::bytes is. It produces an iterator of bytes of the thing to read, and the default impl produces those bytes by... reading the underlying source for one byte at a time. Like, `read(fd, buf, 1)` at a time. Easy change, glad it's linted.
* std::io::Error::new(ErrorKind::Other, ...) has a nicer shorthand
  - Error::other(...) has existed since 1.74.0, the longer form lints with a suggestion to it now. Seems nice.

.. and a few other tiny lints like casting i16 to i16 being pointless.