### PR TITLE
server: build Tokio runtime using `oxide-tokio-rt`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,5 +11,5 @@ CARGO_WORKSPACE_DIR = { value = "", relative = true }
 # disabling the LIFO slot optimization.
 #
 # See here for details:
-# https://rfd.shared.oxide.computer/rfd/0579#_enabling_tokio_unstable_features
+# https://github.com/oxidecomputer/oxide-tokio-rt/blob/main/README.md#enabling-tokio_unstable-features
 rustflags = ["--cfg", "tokio_unstable"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,6 @@ xtask = "run --package xtask --quiet --"
 # Currently required by Falcon due to
 # https://github.com/rust-lang/cargo/issues/3946#issuecomment-973132993
 CARGO_WORKSPACE_DIR = { value = "", relative = true }
+
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,4 +7,9 @@ xtask = "run --package xtask --quiet --"
 CARGO_WORKSPACE_DIR = { value = "", relative = true }
 
 [build]
+# Tokio's unstable features are required by `tokio-dtrace` probes, and for
+# disabling the LIFO slot optimization.
+#
+# See here for details:
+# https://rfd.shared.oxide.computer/rfd/0579#_enabling_tokio_unstable_features
 rustflags = ["--cfg", "tokio_unstable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4816,6 +4816,7 @@ dependencies = [
  "fatfs",
  "futures",
  "libc",
+ "oxide-tokio-rt",
  "propolis",
  "propolis_types",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3681,6 +3681,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxide-tokio-rt"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84bd87abf37c68d414e4df90a545857542140e07206f75039b8f63b244da87b8"
+dependencies = [
+ "anyhow",
+ "tokio",
+ "tokio-dtrace",
+]
+
+[[package]]
 name = "oxide-vpc"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/opte?rev=cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa#cd9aa6467c5e62c6d97f6aafa2150d6930e3a0fa"
@@ -4756,6 +4767,7 @@ dependencies = [
  "mockall",
  "nexus-client",
  "omicron-common",
+ "oxide-tokio-rt",
  "oximeter",
  "oximeter-instruments",
  "oximeter-producer",
@@ -6558,9 +6570,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6572,6 +6584,17 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-dtrace"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db739893a356b146ee6a4535693ff90274ef305cb2b6cdd40f9576b1b34b01fe"
+dependencies = [
+ "thiserror 2.0.12",
+ "tokio",
+ "usdt 0.5.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ mockall = "0.12"
 newtype_derive = "0.1.6"
 newtype-uuid = { version = "1.0.1", features = [ "v4" ] }
 owo-colors = "4"
+oxide-tokio-rt = "0.1.2"
 pin-project-lite = "0.2.13"
 proc-macro2 = "1.0"
 proc-macro-error = "1"

--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -39,6 +39,7 @@ kstat-rs.workspace = true
 lazy_static.workspace = true
 nexus-client.workspace = true
 omicron-common.workspace = true
+oxide-tokio-rt.workspace = true
 oximeter-instruments.workspace = true
 oximeter-producer.workspace = true
 oximeter.workspace = true

--- a/bin/propolis-server/src/lib/vm/ensure.rs
+++ b/bin/propolis-server/src/lib/vm/ensure.rs
@@ -265,13 +265,10 @@ impl<'a> VmEnsureNotStarted<'a> {
             // VMM components (e.g. block device runtime tasks).
             let vmm_rt = {
                 let mut builder = tokio::runtime::Builder::new_multi_thread();
-                builder
-                    .thread_name("tokio-rt-vmm")
-                    .worker_threads(usize::max(
-                        VMM_MIN_RT_THREADS,
-                        VMM_BASE_RT_THREADS + spec.board.cpus as usize,
-                    ))
-                    .enable_all();
+                builder.thread_name("tokio-rt-vmm").worker_threads(usize::max(
+                    VMM_MIN_RT_THREADS,
+                    VMM_BASE_RT_THREADS + spec.board.cpus as usize,
+                ));
                 oxide_tokio_rt::build(&mut builder)?
             };
 

--- a/bin/propolis-server/src/lib/vm/ensure.rs
+++ b/bin/propolis-server/src/lib/vm/ensure.rs
@@ -263,14 +263,17 @@ impl<'a> VmEnsureNotStarted<'a> {
         let result: InitResult = tokio::task::spawn_blocking(move || {
             // Create the runtime that will host tasks created by
             // VMM components (e.g. block device runtime tasks).
-            let vmm_rt = tokio::runtime::Builder::new_multi_thread()
-                .thread_name("tokio-rt-vmm")
-                .worker_threads(usize::max(
-                    VMM_MIN_RT_THREADS,
-                    VMM_BASE_RT_THREADS + spec.board.cpus as usize,
-                ))
-                .enable_all()
-                .build()?;
+            let vmm_rt = {
+                let mut builder = tokio::runtime::Builder::new_multi_thread();
+                builder
+                    .thread_name("tokio-rt-vmm")
+                    .worker_threads(usize::max(
+                        VMM_MIN_RT_THREADS,
+                        VMM_BASE_RT_THREADS + spec.board.cpus as usize,
+                    ))
+                    .enable_all();
+                oxide_tokio_rt::build(&mut builder)?
+            };
 
             let init_result = vmm_rt
                 .block_on(async move {

--- a/bin/propolis-server/src/main.rs
+++ b/bin/propolis-server/src/main.rs
@@ -162,10 +162,7 @@ fn run_server(
     // emulation and other VM-related work will be spawned.
     let api_runtime = {
         let mut builder = tokio::runtime::Builder::new_multi_thread();
-        builder
-            .worker_threads(API_RT_THREADS)
-            .enable_all()
-            .thread_name("tokio-rt-api");
+        builder.worker_threads(API_RT_THREADS).thread_name("tokio-rt-api");
         oxide_tokio_rt::build(&mut builder)?
     };
     let _guard = api_runtime.enter();

--- a/bin/propolis-server/src/main.rs
+++ b/bin/propolis-server/src/main.rs
@@ -160,11 +160,14 @@ fn run_server(
     // Spawn the runtime for handling API processing
     // If/when a VM instance is created, a separate runtime for handling device
     // emulation and other VM-related work will be spawned.
-    let api_runtime = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(API_RT_THREADS)
-        .enable_all()
-        .thread_name("tokio-rt-api")
-        .build()?;
+    let api_runtime = {
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+        builder
+            .worker_threads(API_RT_THREADS)
+            .enable_all()
+            .thread_name("tokio-rt-api");
+        oxide_tokio_rt::build(&mut builder)?
+    };
     let _guard = api_runtime.enter();
 
     // Start TCP listener for VNC, if requested

--- a/bin/propolis-standalone/Cargo.toml
+++ b/bin/propolis-standalone/Cargo.toml
@@ -24,6 +24,7 @@ libc.workspace = true
 toml.workspace = true
 tokio = { workspace = true, features = ["io-util", "rt-multi-thread"] }
 serde = { workspace = true, features = ["derive"] }
+oxide_tokio_rt.workspace = true
 propolis.workspace = true
 propolis_types.workspace = true
 crucible-client-types = { workspace = true, optional = true }

--- a/bin/propolis-standalone/Cargo.toml
+++ b/bin/propolis-standalone/Cargo.toml
@@ -24,7 +24,7 @@ libc.workspace = true
 toml.workspace = true
 tokio = { workspace = true, features = ["io-util", "rt-multi-thread"] }
 serde = { workspace = true, features = ["derive"] }
-oxide_tokio_rt.workspace = true
+oxide-tokio-rt.workspace = true
 propolis.workspace = true
 propolis_types.workspace = true
 crucible-client-types = { workspace = true, optional = true }

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -1490,11 +1490,11 @@ fn main() -> anyhow::Result<ExitCode> {
     // since we'll block in main when we call `Instance::wait_for_state`
     let rt_threads =
         MIN_RT_THREADS.max(BASE_RT_THREADS + config.main.cpus as usize);
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(rt_threads)
-        .enable_all()
-        .thread_name("vmm-tokio")
-        .build()?;
+    let rt = {
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+        builder.worker_threads(rt_threads).thread_name("vmm-tokio");
+        oxide_tokio_rt::build(&mut builder)?
+    };
     let _rt_guard = rt.enter();
 
     // Create the VM afresh or restore it from a snapshot


### PR DESCRIPTION
As described in [RFD 579], we are now recommending that the [`oxide-tokio-rt`] crate be used to construct the Tokio runtime in all production software that uses Tokio. This crate provides common functions for constructing Tokio runtimes with the recommended configurations.

In particular, it currently does the following:

- On illumos, configures the runtime to emit DTrace probes, using [`tokio-dtrace`].
- Disables Tokio's LIFO slot optimization. This feature is intended to improve message-passing latency, but because tasks in the LIFO slot do not currently participate in work-stealing, it can result in extreme latency spikes in some cases (see omicron#8334 for a worked example).

Thus, this commit changes `propolis-server` to construct its Tokio runtimes using `oxide-tokio-rt` so that these common recommended configurations are included. This requires enabling Tokio's unstable features in the workspace.

[RFD 579]: https://rfd.shared.oxide.computer/rfd/0579
[`oxide-tokio-rt`]: https://github.com/oxidecomputer/oxide-tokio-rt
[`tokio-dtrace`]: https://github.com/oxidecomputer/tokio-dtrace