### PR TITLE
Fix new lints

### DIFF
--- a/bin/mock-server/src/lib/lib.rs
+++ b/bin/mock-server/src/lib/lib.rs
@@ -356,8 +356,7 @@ async fn instance_state_put(
     instance.set_target_state(&rqctx.log, requested_state).await.map_err(
         |err| {
             HttpError::for_internal_error(format!(
-                "Failed to transition: {}",
-                err
+                "Failed to transition: {err}"
             ))
         },
     )?;
@@ -758,8 +757,7 @@ mod serial {
             let mut entropy = hasher.finish();
             buf.extend(
                 format!(
-                    "This is simulated serial console output for {}.\r\n",
-                    name
+                    "This is simulated serial console output for {name}.\r\n"
                 )
                 .as_bytes(),
             );
@@ -780,8 +778,7 @@ mod serial {
             }
             buf.extend(
                 format!(
-                    "\x1b[2J\x1b[HOS/478 ({name}) (ttyl)\r\n\r\n{name} login: ",
-                    name = name
+                    "\x1b[2J\x1b[HOS/478 ({name}) (ttyl)\r\n\r\n{name} login: "
                 )
                 .as_bytes(),
             );

--- a/bin/propolis-cli/src/main.rs
+++ b/bin/propolis-cli/src/main.rs
@@ -679,7 +679,7 @@ async fn serial(
                                 stdout.flush().await?;
                             }
                             Ok(Message::Close(Some(CloseFrame {code, reason}))) => {
-                                eprint!("\r\nConnection closed: {:?}\r\n", code);
+                                eprint!("\r\nConnection closed: {code:?}\r\n");
                                 match code {
                                     CloseCode::Abnormal
                                     | CloseCode::Error
@@ -826,7 +826,7 @@ async fn migrate_instance(
                 }
 
                 let state = migration.state;
-                println!("{}({}) migration state={:?}", role, id, state);
+                println!("{role}({id}) migration state={state:?}");
                 if state == MigrationState::Finish {
                     return Ok::<_, anyhow::Error>(());
                 } else if state == MigrationState::Error {

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -224,7 +224,7 @@ impl MachineInitializer<'_> {
         }
 
         let (romfp, rom_len) = open_bootrom(path)
-            .unwrap_or_else(|e| panic!("Cannot open bootrom: {}", e));
+            .unwrap_or_else(|e| panic!("Cannot open bootrom: {e}"));
 
         let mem = self.machine.acc_mem.access().unwrap();
         let mapping = mem
@@ -649,7 +649,7 @@ impl MachineInitializer<'_> {
 
                     // Limit data transfers to 1MiB (2^8 * 4k) in size
                     let mdts = Some(8);
-                    let component = format!("nvme-{}", device_id);
+                    let component = format!("nvme-{device_id}");
                     let nvme = nvme::PciNvme::create(
                         &nvme_spec.serial_number,
                         mdts,

--- a/bin/propolis-server/src/lib/migrate/destination.rs
+++ b/bin/propolis-server/src/lib/migrate/destination.rs
@@ -570,9 +570,7 @@ impl<T: MigrateConn> RonV0<T> {
 
         let (dst_hrt, dst_wc) = vmm::time::host_time_snapshot(vmm_hdl)
             .map_err(|e| {
-                MigrateError::TimeData(format!(
-                    "could not read host time: {e}"
-                ))
+                MigrateError::TimeData(format!("could not read host time: {e}"))
             })?;
         let (time_data_dst, adjust) =
             vmm::time::adjust_time_data(time_data_src, dst_hrt, dst_wc)

--- a/bin/propolis-server/src/lib/migrate/destination.rs
+++ b/bin/propolis-server/src/lib/migrate/destination.rs
@@ -552,8 +552,7 @@ impl<T: MigrateConn> RonV0<T> {
         let time_data_src: vmm::time::VmTimeData = ron::from_str(&raw)
             .map_err(|e| {
                 MigrateError::TimeData(format!(
-                    "VMM Time Data deserialization error: {}",
-                    e
+                    "VMM Time Data deserialization error: {e}"
                 ))
             })?;
         probes::migrate_time_data_before!(|| {
@@ -572,16 +571,14 @@ impl<T: MigrateConn> RonV0<T> {
         let (dst_hrt, dst_wc) = vmm::time::host_time_snapshot(vmm_hdl)
             .map_err(|e| {
                 MigrateError::TimeData(format!(
-                    "could not read host time: {}",
-                    e
+                    "could not read host time: {e}"
                 ))
             })?;
         let (time_data_dst, adjust) =
             vmm::time::adjust_time_data(time_data_src, dst_hrt, dst_wc)
                 .map_err(|e| {
                     MigrateError::TimeData(format!(
-                        "could not adjust VMM Time Data: {}",
-                        e
+                        "could not adjust VMM Time Data: {e}"
                     ))
                 })?;
 
@@ -635,7 +632,7 @@ impl<T: MigrateConn> RonV0<T> {
 
         // Import the adjusted time data
         vmm::time::import_time_data(vmm_hdl, time_data_dst).map_err(|e| {
-            MigrateError::TimeData(format!("VMM Time Data import error: {}", e))
+            MigrateError::TimeData(format!("VMM Time Data import error: {e}"))
         })?;
 
         self.send_msg(codec::Message::Okay).await

--- a/bin/propolis-server/src/lib/migrate/mod.rs
+++ b/bin/propolis-server/src/lib/migrate/mod.rs
@@ -61,7 +61,7 @@ impl std::fmt::Display for MigratePhase {
             MigratePhase::Finish => "Finish",
         };
 
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -173,7 +173,7 @@ impl From<MigrateStateError> for MigrateError {
 
 impl From<MigrateError> for HttpError {
     fn from(err: MigrateError) -> Self {
-        let msg = format!("migration failed: {}", err);
+        let msg = format!("migration failed: {err}");
         match &err {
             MigrateError::Websocket(_)
             | MigrateError::Initiate

--- a/bin/propolis-server/src/lib/migrate/source.rs
+++ b/bin/propolis-server/src/lib/migrate/source.rs
@@ -748,8 +748,7 @@ impl<T: MigrateConn> RonV0Runner<'_, T> {
         let vm_time_data =
             vmm::time::export_time_data(vmm_hdl).map_err(|e| {
                 MigrateError::TimeData(format!(
-                    "VMM Time Data export error: {}",
-                    e
+                    "VMM Time Data export error: {e}"
                 ))
             })?;
         info!(self.log(), "VMM Time Data: {:#?}", vm_time_data);

--- a/bin/propolis-server/src/lib/server.rs
+++ b/bin/propolis-server/src/lib/server.rs
@@ -150,7 +150,7 @@ impl LazyNexusClient {
         let address = self.get_ip().await?;
 
         Ok(NexusClient::new(
-            &format!("http://{}", address),
+            &format!("http://{address}"),
             self.inner.log.clone(),
         ))
     }
@@ -336,8 +336,7 @@ async fn instance_state_monitor(
                 Some(api::ErrorCode::NoInstance.to_string()),
                 ClientErrorStatusCode::GONE,
                 format!(
-                    "No instance present; will never reach generation {}",
-                    gen
+                    "No instance present; will never reach generation {gen}",
                 ),
             )
         })?;
@@ -366,8 +365,7 @@ async fn instance_state_put(
             VmError::ForbiddenStateChange(reason) => {
                 HttpError::for_client_error_with_status(
                     Some(format!(
-                        "instance state change not allowed: {}",
-                        reason
+                        "instance state change not allowed: {reason}"
                     )),
                     ClientErrorStatusCode::FORBIDDEN,
                 )
@@ -469,7 +467,7 @@ async fn instance_serial(
         .websocks_ch
         .send(ws_stream)
         .await
-        .map_err(|e| format!("Serial socket hand-off failed: {}", e).into())
+        .map_err(|e| format!("Serial socket hand-off failed: {e}").into())
 }
 
 #[channel {
@@ -624,7 +622,7 @@ async fn instance_issue_crucible_vcr_request(
     .map_err(|e| match e {
         VmError::ForbiddenStateChange(reason) => {
             HttpError::for_client_error_with_status(
-                Some(format!("instance state change not allowed: {}", reason)),
+                Some(format!("instance state change not allowed: {reason}")),
                 ClientErrorStatusCode::FORBIDDEN,
             )
         }

--- a/bin/propolis-server/src/lib/stats/virtual_machine.rs
+++ b/bin/propolis-server/src/lib/stats/virtual_machine.rs
@@ -495,9 +495,9 @@ mod test {
                 )
                 .unwrap_or_else(|| {
                     panic!(
-                        "kstat state '{kstat_state}' did not map to an oximeter state, \
-                        which it should have done. Did that state get \
-                        mapped to a new oximeter-level state?"
+                        "kstat state '{kstat_state}' did not map to an \
+                        oximeter state, which it should have done. Did that \
+                        state get mapped to a new oximeter-level state?"
                     )
                 });
                 *observed_states.entry(oximeter_state).or_default() += count;

--- a/bin/propolis-server/src/lib/stats/virtual_machine.rs
+++ b/bin/propolis-server/src/lib/stats/virtual_machine.rs
@@ -495,10 +495,9 @@ mod test {
                 )
                 .unwrap_or_else(|| {
                     panic!(
-                        "kstat state '{}' did not map to an oximeter state, \
+                        "kstat state '{kstat_state}' did not map to an oximeter state, \
                         which it should have done. Did that state get \
-                        mapped to a new oximeter-level state?",
-                        kstat_state
+                        mapped to a new oximeter-level state?"
                     )
                 });
                 *observed_states.entry(oximeter_state).or_default() += count;

--- a/bin/propolis-server/src/lib/vm/state_driver.rs
+++ b/bin/propolis-server/src/lib/vm/state_driver.rs
@@ -321,11 +321,11 @@ impl guest_event::VcpuEventHandler for InputQueue {
         vcpu_id: i32,
         exit: propolis::exits::VmExitKind,
     ) {
-        panic!("vCPU {}: Unhandled VM exit: {:?}", vcpu_id, exit);
+        panic!("vCPU {vcpu_id}: Unhandled VM exit: {exit:?}");
     }
 
     fn io_error_event(&self, vcpu_id: i32, error: std::io::Error) {
-        panic!("vCPU {}: Unhandled vCPU error: {}", vcpu_id, error);
+        panic!("vCPU {vcpu_id}: Unhandled vCPU error: {error}");
     }
 }
 

--- a/bin/propolis-standalone/src/config.rs
+++ b/bin/propolis-standalone/src/config.rs
@@ -168,7 +168,7 @@ pub fn block_backend(
 ) -> (Arc<dyn block::Backend>, String) {
     let backend_name = dev.options.get("block_dev").unwrap().as_str().unwrap();
     let Some(be) = config.block_devs.get(backend_name) else {
-        panic!("No configured block device named \"{}\"", backend_name);
+        panic!("No configured block device named \"{backend_name}\"");
     };
     let opts = block::BackendOpts {
         block_size: be.block_opts.block_size,
@@ -184,8 +184,8 @@ pub fn block_backend(
             let meta = std::fs::metadata(&parsed.path)
                 .with_context(|| {
                     format!(
-                        "opening {} for block device \"{}\"",
-                        parsed.path, backend_name
+                        "opening {} for block device \"{backend_name}\"",
+                        parsed.path,
                     )
                 })
                 .expect("file device path is valid");

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -328,7 +328,7 @@ impl Instance {
                 State::Run => {
                     if first_boot {
                         device.start().unwrap_or_else(|_| {
-                            panic!("device {} failed to start", name)
+                            panic!("device {name} failed to start")
                         });
                     } else {
                         device.resume();
@@ -337,7 +337,7 @@ impl Instance {
                 State::Quiesce => device.pause(),
                 State::Halt => device.halt(),
                 State::Reset => device.reset(),
-                _ => panic!("invalid device state transition {:?}", state),
+                _ => panic!("invalid device state transition {state:?}"),
             }
         }
         if matches!(state, State::Quiesce) {

--- a/bin/propolis-standalone/src/snapshot.rs
+++ b/bin/propolis-standalone/src/snapshot.rs
@@ -153,7 +153,7 @@ pub(crate) fn save(
         header.set_size(device_bytes.len() as u64);
         builder.append_data(
             &mut header,
-            format!("{}/{}.json", DEVICE_DIR, name),
+            format!("{DEVICE_DIR}/{name}.json"),
             &device_bytes[..],
         )?;
     }
@@ -196,7 +196,7 @@ pub(crate) fn save(
         let end = start + hi as u64;
         let off = builder.append_space(
             &mut header,
-            format!("{}/{:08x}-{:08x}.bin", MEMORY_DIR, start, end),
+            format!("{MEMORY_DIR}/{start:08x}-{end:08x}.bin"),
         )?;
         hi_mapping.pwrite(&builder.rawfd(), hi_mapping.len(), off as i64)?;
     }

--- a/crates/bhyve-api/src/lib.rs
+++ b/crates/bhyve-api/src/lib.rs
@@ -467,7 +467,7 @@ impl From<VmmDataError> for Error {
             VmmDataError::SpaceNeeded(c) => {
                 // ErrorKind::StorageFull would more accurately match the underlying ENOSPC
                 // but that variant is unstable still
-                Error::other(format!("operation requires {} bytes", c))
+                Error::other(format!("operation requires {c} bytes"))
             }
         }
     }

--- a/crates/dladm/src/lib.rs
+++ b/crates/dladm/src/lib.rs
@@ -143,7 +143,7 @@ impl Handle {
 
             if (*macaddr).ma_addrlen == (ETHERADDRL as u32) {
                 let ma_addr = slice::from_raw_parts(
-                    ptr::addr_of!((*macaddr).ma_addr).cast::<u8>(),
+                    &raw const (*macaddr).ma_addr as *const u8,
                     ETHERADDRL,
                 );
                 state.mac.copy_from_slice(ma_addr);

--- a/crates/dladm/src/lib.rs
+++ b/crates/dladm/src/lib.rs
@@ -53,13 +53,13 @@ impl Handle {
             Some(c) => {
                 return Err(Error::new(
                     ErrorKind::InvalidInput,
-                    format!("{} is not vnic/misc class, but {:?}", name, c),
+                    format!("{name} is not vnic/misc class, but {c:?}"),
                 ));
             }
             None => {
                 return Err(Error::new(
                     ErrorKind::InvalidInput,
-                    format!("{} is of invalid class {:x}", name, class),
+                    format!("{name} is of invalid class {class:x}"),
                 ));
             }
         }
@@ -140,7 +140,7 @@ impl Handle {
             state.n_seen += 1;
 
             if (*macaddr).ma_addrlen == (ETHERADDRL as u32) {
-                state.mac.copy_from_slice(&(*macaddr).ma_addr[..ETHERADDRL]);
+                state.mac.copy_from_slice(&(&((*macaddr).ma_addr))[..ETHERADDRL]);
                 state.written = true;
                 sys::boolean_t::B_FALSE
             } else {
@@ -184,7 +184,7 @@ impl Handle {
             .unwrap_or(dladm_status::DLADM_STATUS_FAILED)
         {
             dladm_status::DLADM_STATUS_OK => Ok(()),
-            e => Err(Error::other(format!("{:?}", e))),
+            e => Err(Error::other(format!("{e:?}"))),
         }
     }
 }

--- a/crates/dladm/src/lib.rs
+++ b/crates/dladm/src/lib.rs
@@ -5,6 +5,8 @@
 use std::ffi::CString;
 use std::io::{BufRead, BufReader, Error, ErrorKind, Result};
 use std::process::{Command, Stdio};
+use std::ptr;
+use std::slice;
 
 #[allow(non_camel_case_types)]
 mod sys;
@@ -140,7 +142,11 @@ impl Handle {
             state.n_seen += 1;
 
             if (*macaddr).ma_addrlen == (ETHERADDRL as u32) {
-                state.mac.copy_from_slice(&(&((*macaddr).ma_addr))[..ETHERADDRL]);
+                let ma_addr = slice::from_raw_parts(
+                    ptr::addr_of!((*macaddr).ma_addr).cast::<u8>(),
+                    ETHERADDRL,
+                );
+                state.mac.copy_from_slice(ma_addr);
                 state.written = true;
                 sys::boolean_t::B_FALSE
             } else {

--- a/crates/dladm/src/lib.rs
+++ b/crates/dladm/src/lib.rs
@@ -5,7 +5,6 @@
 use std::ffi::CString;
 use std::io::{BufRead, BufReader, Error, ErrorKind, Result};
 use std::process::{Command, Stdio};
-use std::ptr;
 use std::slice;
 
 #[allow(non_camel_case_types)]

--- a/crates/propolis-api-types/src/instance_spec/mod.rs
+++ b/crates/propolis-api-types/src/instance_spec/mod.rs
@@ -333,7 +333,7 @@ mod test {
         let unser: TestMap = serde_json::from_str(&ser).unwrap();
         let key = unser.keys().next().expect("one key in the map");
         let SpecKey::Uuid(got_id) = key else {
-            panic!("expected SpecKey::Uuid, got {}", key);
+            panic!("expected SpecKey::Uuid, got {key}");
         };
 
         assert_eq!(*got_id, id);
@@ -355,7 +355,7 @@ mod test {
         let unser: TestMap = serde_json::from_str(&ser).unwrap();
         let key = unser.keys().next().expect("one key in the map");
         let SpecKey::Uuid(got_id) = key else {
-            panic!("expected SpecKey::Uuid, got {}", key);
+            panic!("expected SpecKey::Uuid, got {key}");
         };
 
         assert_eq!(*got_id, id);

--- a/crates/propolis-types/src/lib.rs
+++ b/crates/propolis-types/src/lib.rs
@@ -42,8 +42,7 @@ impl PciPath {
             return Err(Error::new(
                 ErrorKind::InvalidInput,
                 format!(
-                    "PCI device {} outside range of 0-{}",
-                    device,
+                    "PCI device {device} outside range of 0-{}",
                     PCI_DEVICES_PER_BUS - 1
                 ),
             ));
@@ -53,8 +52,7 @@ impl PciPath {
             return Err(Error::new(
                 ErrorKind::InvalidInput,
                 format!(
-                    "PCI function {} outside range of 0-{}",
-                    function,
+                    "PCI function {function} outside range of 0-{}",
                     PCI_FUNCTIONS_PER_DEVICE - 1
                 ),
             ));
@@ -87,7 +85,7 @@ impl FromStr for PciPath {
             fields.push(u8::from_str(f).map_err(|e| {
                 Self::Err::new(
                     ErrorKind::InvalidInput,
-                    format!("Failed to parse PCI path {}: {}", s, e),
+                    format!("Failed to parse PCI path {s}: {e}"),
                 )
             })?);
         }
@@ -96,8 +94,7 @@ impl FromStr for PciPath {
             return Err(Self::Err::new(
                 ErrorKind::InvalidInput,
                 format!(
-                    "Expected 3 fields in PCI path {}, got {}",
-                    s,
+                    "Expected 3 fields in PCI path {s}, got {}",
                     fields.len()
                 ),
             ));
@@ -109,7 +106,8 @@ impl FromStr for PciPath {
 
 impl Display for PciPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}.{}", self.bus, self.device, self.function)
+        let Self { bus, device, function } = self;
+        write!(f, "{bus}.{device}.{function}")
     }
 }
 
@@ -160,8 +158,7 @@ mod test {
                 Ok(path) => assert_eq!(path, expected.unwrap()),
                 Err(_) => assert!(
                     expected.is_err(),
-                    "Expected error parsing PCI path {}",
-                    input
+                    "Expected error parsing PCI path {input}"
                 ),
             }
         }

--- a/crates/rfb/examples/websock.rs
+++ b/crates/rfb/examples/websock.rs
@@ -152,7 +152,7 @@ async fn main() -> Result<(), String> {
         ..Default::default()
     };
     let server = HttpServerStarter::new(&config_dropshot, api, app, &log)
-        .map_err(|error| format!("failed to create server: {}", error))?
+        .map_err(|error| format!("failed to create server: {error}"))?
         .start();
 
     server.await

--- a/lib/propolis-client/src/support.rs
+++ b/lib/propolis-client/src/support.rs
@@ -96,7 +96,7 @@ impl SerialConsoleStreamBuilder for PropolisSerialBuilder {
         address: SocketAddr,
         offset: WSClientOffset,
     ) -> Result<Box<dyn SerialConsoleStream>, WSError> {
-        let client = PropolisClient::new(&format!("http://{}", address));
+        let client = PropolisClient::new(&format!("http://{address}"));
         let mut req = client.instance_serial();
 
         match offset {

--- a/phd-tests/framework/src/disk/crucible.rs
+++ b/phd-tests/framework/src/disk/crucible.rs
@@ -267,7 +267,7 @@ impl Inner {
         let disk_uuid = Uuid::new_v4();
         for port in downstairs_ports {
             let mut data_dir_path = data_dir_root.as_ref().to_path_buf();
-            data_dir_path.push(format!("{}_{}", disk_uuid, port));
+            data_dir_path.push(format!("{disk_uuid}_{port}"));
             std::fs::create_dir_all(&data_dir_path)?;
             data_dirs.push(DataDirectory { path: data_dir_path });
         }
@@ -340,7 +340,7 @@ impl Inner {
             // by the test runner.
             let (stdout, stderr) = log_config.output_mode.get_handles(
                 data_dir_root,
-                &format!("crucible_{}_{}", disk_uuid, port),
+                &format!("crucible_{disk_uuid}_{port}"),
             )?;
 
             info!(?crucible_args, "Launching Crucible downstairs server");

--- a/phd-tests/framework/src/disk/mod.rs
+++ b/phd-tests/framework/src/disk/mod.rs
@@ -221,7 +221,7 @@ impl DiskFactory {
             .get_guest_os_image(artifact_name)
             .await
             .with_context(|| {
-                format!("failed to get guest OS artifact '{}'", artifact_name)
+                format!("failed to get guest OS artifact '{artifact_name}'")
             })
             .map_err(Into::into)
     }
@@ -341,7 +341,7 @@ impl DiskFactory {
             DiskSource::Artifact(name) => {
                 let (path, _) = self.get_guest_artifact_info(name).await?;
                 std::fs::read(&path).with_context(|| {
-                    format!("reading source artifact {} from {}", name, path)
+                    format!("reading source artifact {name} from {path}")
                 })?
             }
             DiskSource::Blank(size) => vec![0; *size],

--- a/phd-tests/framework/src/guest_os/mod.rs
+++ b/phd-tests/framework/src/guest_os/mod.rs
@@ -144,7 +144,7 @@ impl FromStr for GuestOsKind {
             "windowsserver2022" => Ok(Self::WindowsServer2022),
             _ => Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
-                format!("Unrecognized guest OS kind {}", s),
+                format!("Unrecognized guest OS kind {s}"),
             )),
         }
     }

--- a/phd-tests/framework/src/lifecycle.rs
+++ b/phd-tests/framework/src/lifecycle.rs
@@ -59,7 +59,7 @@ impl Framework {
                         "stopping and starting VM for lifecycle test"
                     );
                     let new_vm_name =
-                        format!("{}_lifecycle_{}", original_name, idx);
+                        format!("{original_name}_lifecycle_{idx}");
                     vm.stop().await?;
                     let mut new_vm = self
                         .spawn_successor_vm(&new_vm_name, &vm, None)
@@ -77,7 +77,7 @@ impl Framework {
                     );
 
                     let new_vm_name =
-                        format!("{}_lifecycle_{}", original_name, idx);
+                        format!("{original_name}_lifecycle_{idx}");
 
                     let mut env = self.environment_builder();
                     env.propolis(propolis);

--- a/phd-tests/framework/src/log_config.rs
+++ b/phd-tests/framework/src/log_config.rs
@@ -63,10 +63,10 @@ impl OutputMode {
         match self {
             OutputMode::TmpFile => {
                 let mut stdout_path = directory.as_ref().to_path_buf();
-                stdout_path.push(format!("{}.stdout.log", file_prefix));
+                stdout_path.push(format!("{file_prefix}.stdout.log"));
 
                 let mut stderr_path = directory.as_ref().to_path_buf();
-                stderr_path.push(format!("{}.stderr.log", file_prefix));
+                stderr_path.push(format!("{file_prefix}.stderr.log"));
 
                 info!(?stdout_path, ?stderr_path, "Opening server log files");
                 Ok((

--- a/phd-tests/framework/src/serial/raw_buffer.rs
+++ b/phd-tests/framework/src/serial/raw_buffer.rs
@@ -31,7 +31,7 @@ impl RawBuffer {
     /// Constructs a new buffer.
     pub(super) fn new(log_path: Utf8PathBuf) -> Result<Self> {
         let log_file = std::fs::File::create(&log_path).with_context(|| {
-            format!("opening serial console log file {}", log_path)
+            format!("opening serial console log file {log_path}")
         })?;
         let writer = BufWriter::new(log_file);
         Ok(Self {

--- a/phd-tests/framework/src/test_vm/mod.rs
+++ b/phd-tests/framework/src/test_vm/mod.rs
@@ -256,7 +256,7 @@ impl TestVm {
             &vm_spec.bootrom_path,
         )?;
 
-        let client = Client::new(&format!("http://{}", server_addr));
+        let client = Client::new(&format!("http://{server_addr}"));
         let guest_os = guest_os::get_guest_os_adapter(vm_spec.guest_os_kind);
         Ok(Self {
             id: vm_id,

--- a/phd-tests/runner/src/main.rs
+++ b/phd-tests/runner/src/main.rs
@@ -125,7 +125,7 @@ fn list_tests(list_opts: &ListOptions) {
         count += 1
     }
 
-    println!("\n{} test(s) selected", count);
+    println!("\n{count} test(s) selected");
 }
 
 fn set_tracing_subscriber(args: &ProcessArgs) {

--- a/phd-tests/tests/src/boot_order/efi_utils.rs
+++ b/phd-tests/tests/src/boot_order/efi_utils.rs
@@ -64,11 +64,11 @@ pub(crate) const BOOT_ORDER_VAR: &str =
     "BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c";
 
 pub(crate) fn bootvar(num: u16) -> String {
-    format!("Boot{:04X}-8be4df61-93ca-11d2-aa0d-00e098032b8c", num)
+    format!("Boot{num:04X}-8be4df61-93ca-11d2-aa0d-00e098032b8c")
 }
 
 pub(crate) fn efipath(varname: &str) -> String {
-    format!("/sys/firmware/efi/efivars/{}", varname)
+    format!("/sys/firmware/efi/efivars/{varname}")
 }
 
 /// A (very limited) parse of an `EFI_LOAD_OPTION` descriptor.
@@ -377,7 +377,7 @@ pub(crate) async fn write_efivar(
     // as invalid UEFI variable data.
     let escaped: String =
         new_value.into_iter().fold(String::new(), |mut out, b| {
-            write!(out, "\\x{:02x}", b).expect("can append to String");
+            write!(out, "\\x{b:02x}").expect("can append to String");
             out
         });
 

--- a/phd-tests/tests/src/crucible/migrate.rs
+++ b/phd-tests/tests/src/crucible/migrate.rs
@@ -58,13 +58,12 @@ async fn load_test(ctx: &Framework) {
     let ddout = source
         .run_shell_command(
             format!(
-                "dd if=/dev/random of=./rand.txt bs=5M count={}",
-                block_count
+                "dd if=/dev/random of=./rand.txt bs=5M count={block_count}"
             )
             .as_str(),
         )
         .await?;
-    assert!(ddout.contains(format!("{}+0 records in", block_count).as_str()));
+    assert!(ddout.contains(format!("{block_count}+0 records in").as_str()));
 
     // Compute the data's hash.
     let sha256sum_out = source.run_shell_command("sha256sum rand.txt").await?;

--- a/phd-tests/tests/src/hyperv.rs
+++ b/phd-tests/tests/src/hyperv.rs
@@ -261,10 +261,8 @@ async fn hyperv_reference_tsc_elapsed_time_test(ctx: &Framework) {
 
         assert!(
             bad_diffs < good_diffs,
-            "more out-of-tolerance time diffs ({}) than in-tolerance diffs \
-            ({}); see test log for details",
-            bad_diffs,
-            good_diffs,
+            "more out-of-tolerance time diffs ({bad_diffs}) than in-tolerance \
+            diffs ({good_diffs}); see test log for details",
         );
 
         info!(good_diffs, bad_diffs, "TSC test results");

--- a/phd-tests/tests/src/stats.rs
+++ b/phd-tests/tests/src/stats.rs
@@ -92,7 +92,7 @@ fn producer_results_as_vm_metrics(
                 metrics.add_producer_result(&samples);
             }
             ProducerResultsItem::Err(e) => {
-                panic!("ProducerResultsItem error: {}", e);
+                panic!("ProducerResultsItem error: {e}");
             }
         }
     }
@@ -147,7 +147,7 @@ impl VirtualMachineMetrics {
                 let amount = if let Datum::CumulativeU64(amount) = datum {
                     amount.value()
                 } else {
-                    panic!("unexpected reset datum type: {:?}", datum);
+                    panic!("unexpected reset datum type: {datum:?}");
                 };
                 self.reset = Some(amount);
                 self.update_metric_times(last_sample.measurement.timestamp());
@@ -156,29 +156,29 @@ impl VirtualMachineMetrics {
                 let amount = if let Datum::CumulativeU64(amount) = datum {
                     amount.value()
                 } else {
-                    panic!("unexpected vcpu_usage datum type: {:?}", datum);
+                    panic!("unexpected vcpu_usage datum type: {datum:?}");
                 };
                 let field = &fields["state"];
                 let state: VcpuState = if let FieldValue::String(state) =
                     &field.value
                 {
                     VcpuState::from_str(state.as_ref()).unwrap_or_else(|_| {
-                        panic!("unknown Oximeter vpcu state name: {}", state);
+                        panic!("unknown Oximeter vpcu state name: {state}");
                     })
                 } else {
-                    panic!("unknown vcpu state datum type: {:?}", field);
+                    panic!("unknown vcpu state datum type: {field:?}");
                 };
                 let field = &fields["vcpu_id"];
                 let vcpu_id = if let FieldValue::U32(vcpu_id) = field.value {
                     vcpu_id
                 } else {
-                    panic!("unknown vcpu id datum type: {:?}", field);
+                    panic!("unknown vcpu id datum type: {field:?}");
                 };
                 let vcpu_metrics = self.vcpus.entry(vcpu_id).or_default();
                 if vcpu_metrics.metrics.contains_key(&state) {
                     panic!(
-                        "vcpu {} state {:?} has duplicate metric {:?}",
-                        vcpu_id, state, last_sample
+                        "vcpu {vcpu_id} state {state:?} has duplicate metric \
+                         {last_sample:?}"
                     );
                 }
                 trace!(
@@ -402,9 +402,8 @@ async fn instance_vcpu_stats(ctx: &Framework) {
         // busier test systems, or reasonable implementation changes.
         assert!(
             full_emul_delta < EMUL_LIMIT,
-            "full emul delta was above threshold: {} > {}",
-            full_emul_delta,
-            EMUL_LIMIT
+            "full emul delta was above threshold: \
+             {full_emul_delta} > {EMUL_LIMIT}"
         );
     } else {
         warn!(

--- a/xtask/src/task_license.rs
+++ b/xtask/src/task_license.rs
@@ -27,7 +27,7 @@ struct LicenseEnt {
 }
 
 fn commentify(raw: String) -> Vec<String> {
-    raw.lines().map(|l| format!("// {}", l)).collect::<Vec<String>>()
+    raw.lines().map(|l| format!("// {l}")).collect::<Vec<String>>()
 }
 
 fn check_file(fp: File, needle: &[String]) -> Result<Option<String>> {
@@ -67,8 +67,7 @@ pub(crate) fn cmd_license() -> Result<()> {
             let mut builder = globset::GlobSetBuilder::new();
             for path in paths.iter() {
                 builder.add(globset::Glob::new(path).context(format!(
-                    "'{}' is not valid path-ignore glob",
-                    path
+                    "'{path}' is not valid path-ignore glob"
                 ))?);
             }
             Some(builder.build()?)

--- a/xtask/src/task_phd.rs
+++ b/xtask/src/task_phd.rs
@@ -621,7 +621,7 @@ impl std::fmt::Debug for PrettyCmd<'_> {
             if f.alternate() && arg.starts_with("--") {
                 write!(f, " \\\n\t{arg}")?;
             } else {
-                write!(f, " {}", arg)?;
+                write!(f, " {arg}")?;
             }
         }
 


### PR DESCRIPTION
This branch fixes new Clippy and rustc lints that showed up in #913. In
particular, there are two warnings that needed to be fixed:

- `clippy::uninlined_format_args` (fixed in
  223d07221557f39170da09dad6d66079bf79915f): Clippy now suggests that
  all format strings with format arguments that could be inlined should
  be inlined. This is a very mechanical change, but the lint triggers on
  basically every format string in the project. Sigh.
- `dangerous_implicit_autorefs` (fixed in
  dc93665d20e2e2aee69e48622d957c17c9dddd0c). This is a new [compiler
  warning] that warns about the creation of implicit references to the
  dereference of a raw pointer, which may be invalid if the intermediate
  pointer is null or is not well-aligned. This one is actually somewhat
  interesting and requires some care.
  
  In this case, I've fixed this by using `ptr::addr_of!` and
  `slice::from_raw_parts` to construct the slice into `ma_addr`,
  avoiding the creation of temporary references through the raw pointer.
  In this case, the suggestions from the lint of just adding an
  additional explicit `&` reference as a way of saying "this is okay,
  because I know the pointer is non-null and well-aligned" would
  *probably* have been fine, but this felt less sketchy.

[compiler warning]:
    https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/autorefs/static.DANGEROUS_IMPLICIT_AUTOREFS.html