### PR TITLE
Added block_size for file backends in propolis_server (workers is optional)

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -538,11 +538,13 @@ impl MachineInitializer<'_> {
                     );
                 }
 
-                let nworkers = NonZeroUsize::new(8).unwrap();
+                let nworkers =
+                    NonZeroUsize::new(spec.workers as usize).unwrap();
                 let be = propolis::block::FileBackend::create(
                     &spec.path,
                     propolis::block::BackendOpts {
                         read_only: Some(spec.readonly),
+                        block_size: Some(spec.block_size),
                         ..Default::default()
                     },
                     nworkers,

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -538,8 +538,19 @@ impl MachineInitializer<'_> {
                     );
                 }
 
-                let nworkers =
-                    NonZeroUsize::new(spec.workers as usize).unwrap();
+                let nworkers: NonZeroUsize = if spec.workers >= 1
+                    && spec.workers <= propolis::block::MAX_FILE_WORKERS
+                {
+                    NonZeroUsize::new(spec.workers).unwrap()
+                } else {
+                    slog::warn!(
+                        self.log,
+                        "workers must be between 1 and {} \
+                            Using default value of 8.",
+                        propolis::block::MAX_FILE_WORKERS
+                    );
+                    NonZeroUsize::new(8).unwrap()
+                };
                 let be = propolis::block::FileBackend::create(
                     &spec.path,
                     propolis::block::BackendOpts {

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -538,18 +538,23 @@ impl MachineInitializer<'_> {
                     );
                 }
 
-                let nworkers: NonZeroUsize = if spec.workers >= 1
-                    && spec.workers <= propolis::block::MAX_FILE_WORKERS
-                {
-                    NonZeroUsize::new(spec.workers).unwrap()
-                } else {
-                    slog::warn!(
-                        self.log,
-                        "workers must be between 1 and {} \
-                            Using default value of 8.",
-                        propolis::block::MAX_FILE_WORKERS
-                    );
-                    NonZeroUsize::new(8).unwrap()
+                let nworkers: NonZeroUsize = match spec.workers {
+                    Some(workers) => {
+                        if (1..=propolis::block::MAX_FILE_WORKERS)
+                            .contains(&workers)
+                        {
+                            NonZeroUsize::new(workers).unwrap()
+                        } else {
+                            slog::warn!(
+                                self.log,
+                                "workers must be between 1 and {} \
+                                    Using default value of 8.",
+                                propolis::block::MAX_FILE_WORKERS
+                            );
+                            NonZeroUsize::new(8).unwrap()
+                        }
+                    }
+                    None => NonZeroUsize::new(8).unwrap(),
                 };
                 let be = propolis::block::FileBackend::create(
                     &spec.path,

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -544,8 +544,8 @@ impl MachineInitializer<'_> {
 
                 let nworkers: NonZeroUsize = match spec.workers {
                     Some(workers) => {
-                        if (1..=MAX_FILE_WORKERS).contains(&workers) {
-                            NonZeroUsize::new(workers).unwrap()
+                        if workers.get() <= MAX_FILE_WORKERS {
+                            workers
                         } else {
                             slog::warn!(
                                 self.log,

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -53,6 +53,10 @@ use slog::info;
 use strum::IntoEnumIterator;
 use thiserror::Error;
 
+// XXX: completely arb for now
+const MAX_FILE_WORKERS: usize = 32;
+const DEFAULT_WORKER_COUNT: usize = 8;
+
 /// An error that can arise while initializing a new machine.
 #[derive(Debug, Error)]
 pub enum MachineInitError {
@@ -540,21 +544,20 @@ impl MachineInitializer<'_> {
 
                 let nworkers: NonZeroUsize = match spec.workers {
                     Some(workers) => {
-                        if (1..=propolis::block::MAX_FILE_WORKERS)
-                            .contains(&workers)
-                        {
+                        if (1..=MAX_FILE_WORKERS).contains(&workers) {
                             NonZeroUsize::new(workers).unwrap()
                         } else {
                             slog::warn!(
                                 self.log,
                                 "workers must be between 1 and {} \
-                                    Using default value of 8.",
-                                propolis::block::MAX_FILE_WORKERS
+                                    Using default value of {}.",
+                                MAX_FILE_WORKERS,
+                                DEFAULT_WORKER_COUNT
                             );
-                            NonZeroUsize::new(8).unwrap()
+                            NonZeroUsize::new(DEFAULT_WORKER_COUNT).unwrap()
                         }
                     }
-                    None => NonZeroUsize::new(8).unwrap(),
+                    None => NonZeroUsize::new(DEFAULT_WORKER_COUNT).unwrap(),
                 };
                 let be = propolis::block::FileBackend::create(
                     &spec.path,

--- a/bin/propolis-server/src/lib/stats/mod.rs
+++ b/bin/propolis-server/src/lib/stats/mod.rs
@@ -269,7 +269,7 @@ pub(crate) async fn track_network_interface_kstats(
         let network_interface_ids = interface_ids
             .iter()
             .map(|(uuid, device_id)| {
-                format!("{} (kstat-instance: {})", uuid, device_id)
+                format!("{uuid} (kstat-instance: {device_id})")
             })
             .collect::<Vec<_>>()
             .join(", ");

--- a/bin/propolis-standalone/src/config.rs
+++ b/bin/propolis-standalone/src/config.rs
@@ -114,7 +114,7 @@ pub struct CloudInit {
 #[derive(Deserialize)]
 struct FileConfig {
     path: String,
-    workers: Option<usize>,
+    workers: Option<NonZeroUsize>,
 }
 #[derive(Deserialize)]
 struct MemAsyncConfig {
@@ -198,8 +198,8 @@ pub fn block_backend(
 
             let workers: NonZeroUsize = match parsed.workers {
                 Some(workers) => {
-                    if (1..=MAX_FILE_WORKERS).contains(&workers) {
-                        NonZeroUsize::new(workers).unwrap()
+                    if workers.get() <= MAX_FILE_WORKERS {
+                        workers
                     } else {
                         slog::warn!(
                             log,

--- a/bin/propolis-standalone/src/config.rs
+++ b/bin/propolis-standalone/src/config.rs
@@ -160,6 +160,7 @@ fn opt_deser<'de, T: Deserialize<'de>>(
 }
 
 const DEFAULT_WORKER_COUNT: usize = 8;
+const MAX_FILE_WORKERS: usize = 32;
 
 pub fn block_backend(
     config: &Config,
@@ -195,15 +196,24 @@ pub fn block_backend(
                     "path" => &parsed.path);
             }
 
-            block::FileBackend::create(
-                &parsed.path,
-                opts,
-                NonZeroUsize::new(
-                    parsed.workers.unwrap_or(DEFAULT_WORKER_COUNT),
-                )
-                .unwrap(),
-            )
-            .unwrap()
+            let workers: NonZeroUsize = match parsed.workers {
+                Some(workers) => {
+                    if (1..=MAX_FILE_WORKERS).contains(&workers) {
+                        NonZeroUsize::new(workers).unwrap()
+                    } else {
+                        slog::warn!(
+                            log,
+                            "workers must be between 1 and {} \
+                            Using default value of {}.",
+                            MAX_FILE_WORKERS,
+                            DEFAULT_WORKER_COUNT,
+                        );
+                        NonZeroUsize::new(DEFAULT_WORKER_COUNT).unwrap()
+                    }
+                }
+                None => NonZeroUsize::new(DEFAULT_WORKER_COUNT).unwrap(),
+            };
+            block::FileBackend::create(&parsed.path, opts, workers).unwrap()
         }
         "crucible" => create_crucible_backend(be, opts, log),
         "crucible-mem" => create_crucible_mem_backend(be, opts, log),

--- a/crates/propolis-api-types/src/instance_spec/components/backends.rs
+++ b/crates/propolis-api-types/src/instance_spec/components/backends.rs
@@ -52,7 +52,7 @@ pub struct FileStorageBackend {
     pub block_size: u32,
 
     /// Worker threads for the backend
-    pub workers: u32,
+    pub workers: usize,
 }
 
 /// A storage backend for a disk whose initial contents are given explicitly

--- a/crates/propolis-api-types/src/instance_spec/components/backends.rs
+++ b/crates/propolis-api-types/src/instance_spec/components/backends.rs
@@ -51,8 +51,8 @@ pub struct FileStorageBackend {
     /// Block size of the backend
     pub block_size: u32,
 
-    /// Worker threads for the backend
-    pub workers: usize,
+    /// Optional worker threads for the file backend, exposed for testing only.
+    pub workers: Option<usize>,
 }
 
 /// A storage backend for a disk whose initial contents are given explicitly

--- a/crates/propolis-api-types/src/instance_spec/components/backends.rs
+++ b/crates/propolis-api-types/src/instance_spec/components/backends.rs
@@ -8,6 +8,7 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroUsize;
 
 /// A Crucible storage backend.
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
@@ -52,7 +53,7 @@ pub struct FileStorageBackend {
     pub block_size: u32,
 
     /// Optional worker threads for the file backend, exposed for testing only.
-    pub workers: Option<usize>,
+    pub workers: Option<NonZeroUsize>,
 }
 
 /// A storage backend for a disk whose initial contents are given explicitly

--- a/crates/propolis-api-types/src/instance_spec/components/backends.rs
+++ b/crates/propolis-api-types/src/instance_spec/components/backends.rs
@@ -47,6 +47,12 @@ pub struct FileStorageBackend {
 
     /// Indicates whether the storage is read-only.
     pub readonly: bool,
+
+    /// Block size of the backend
+    pub block_size: u32,
+
+    /// Worker threads for the backend
+    pub workers: u32,
 }
 
 /// A storage backend for a disk whose initial contents are given explicitly

--- a/crates/propolis-config-toml/src/lib.rs
+++ b/crates/propolis-config-toml/src/lib.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -104,7 +105,7 @@ pub struct BlockOpts {
     pub block_size: Option<u32>,
     pub read_only: Option<bool>,
     pub skip_flush: Option<bool>,
-    pub workers: Option<usize>,
+    pub workers: Option<NonZeroUsize>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]

--- a/crates/propolis-config-toml/src/lib.rs
+++ b/crates/propolis-config-toml/src/lib.rs
@@ -104,7 +104,7 @@ pub struct BlockOpts {
     pub block_size: Option<u32>,
     pub read_only: Option<bool>,
     pub skip_flush: Option<bool>,
-    pub workers: Option<u32>,
+    pub workers: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]

--- a/crates/propolis-config-toml/src/lib.rs
+++ b/crates/propolis-config-toml/src/lib.rs
@@ -104,6 +104,7 @@ pub struct BlockOpts {
     pub block_size: Option<u32>,
     pub read_only: Option<bool>,
     pub skip_flush: Option<bool>,
+    pub workers: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]

--- a/crates/propolis-config-toml/src/spec.rs
+++ b/crates/propolis-config-toml/src/spec.rs
@@ -159,13 +159,11 @@ impl TryFrom<&super::Config> for SpecConfig {
                             },
                         )?;
 
-                    println!("ZZZ try_from got config: {backend_config:?}");
                     let backend_spec = parse_storage_backend_from_config(
                         &backend_name,
                         backend_config,
                     )?;
 
-                    println!("ZZZ try_from got spec: {backend_spec:?}");
                     spec_component_add(&mut spec, device_id, device_spec)?;
                     spec_component_add(&mut spec, backend_id, backend_spec)?;
                 }

--- a/crates/propolis-config-toml/src/spec.rs
+++ b/crates/propolis-config-toml/src/spec.rs
@@ -367,7 +367,7 @@ fn parse_storage_backend_from_config(
             }
             .unwrap_or(false),
             block_size: backend.opts.block_size.unwrap_or(512),
-            workers: backend.opts.workers.unwrap_or(8),
+            workers: backend.opts.workers,
         }),
         _ => {
             return Err(TomlToSpecError::InvalidStorageBackendType {

--- a/crates/propolis-config-toml/src/spec.rs
+++ b/crates/propolis-config-toml/src/spec.rs
@@ -6,7 +6,6 @@
 
 use std::{
     collections::BTreeMap,
-    num::ParseIntError,
     str::{FromStr, ParseBoolError},
 };
 
@@ -57,12 +56,6 @@ pub enum TomlToSpecError {
 
     #[error("failed to parse read-only option for file backend {0:?}")]
     FileBackendReadonlyParseFailed(String, #[source] ParseBoolError),
-
-    #[error("failed to parse block-size option for file backend {0:?}")]
-    FileBackendBlockSizeParseFailed(String, #[source] ParseIntError),
-
-    #[error("failed to parse workers option for file backend {0:?}")]
-    FileBackendWorkersParseFailed(String, #[source] ParseIntError),
 
     #[error("failed to get VNIC name for device {0:?}")]
     NoVnicName(String),

--- a/lib/propolis/src/block/file.rs
+++ b/lib/propolis/src/block/file.rs
@@ -10,14 +10,11 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use crate::accessors::MemAccessor;
-use crate::block::{self, DeviceInfo};
+use crate::block::{self, DeviceInfo, MAX_FILE_WORKERS};
 use crate::tasks::ThreadGroup;
 use crate::vmm::{MappingExt, MemCtx};
 
 use anyhow::Context;
-
-// XXX: completely arb for now
-const MAX_WORKERS: usize = 32;
 
 pub struct FileBackend {
     state: Arc<WorkerState>,
@@ -167,7 +164,7 @@ impl FileBackend {
         opts: block::BackendOpts,
         worker_count: NonZeroUsize,
     ) -> Result<Arc<Self>> {
-        if worker_count.get() > MAX_WORKERS {
+        if worker_count.get() > MAX_FILE_WORKERS {
             return Err(Error::new(
                 ErrorKind::InvalidInput,
                 "too many workers",

--- a/lib/propolis/src/block/file.rs
+++ b/lib/propolis/src/block/file.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use crate::accessors::MemAccessor;
-use crate::block::{self, DeviceInfo, MAX_FILE_WORKERS};
+use crate::block::{self, DeviceInfo};
 use crate::tasks::ThreadGroup;
 use crate::vmm::{MappingExt, MemCtx};
 
@@ -164,12 +164,6 @@ impl FileBackend {
         opts: block::BackendOpts,
         worker_count: NonZeroUsize,
     ) -> Result<Arc<Self>> {
-        if worker_count.get() > MAX_FILE_WORKERS {
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                "too many workers",
-            ));
-        }
         let p: &Path = path.as_ref();
 
         let meta = metadata(p)?;

--- a/lib/propolis/src/block/mod.rs
+++ b/lib/propolis/src/block/mod.rs
@@ -38,9 +38,6 @@ pub type ByteLen = usize;
 /// is not choosing a block size, a default of 512B is used.
 pub const DEFAULT_BLOCK_SIZE: u32 = 512;
 
-// XXX: completely arb for now
-pub const MAX_FILE_WORKERS: usize = 32;
-
 #[usdt::provider(provider = "propolis")]
 mod probes {
     fn block_begin_read(dev_id: u64, req_id: u64, offset: u64, len: u64) {}

--- a/lib/propolis/src/block/mod.rs
+++ b/lib/propolis/src/block/mod.rs
@@ -38,6 +38,9 @@ pub type ByteLen = usize;
 /// is not choosing a block size, a default of 512B is used.
 pub const DEFAULT_BLOCK_SIZE: u32 = 512;
 
+// XXX: completely arb for now
+pub const MAX_FILE_WORKERS: usize = 32;
+
 #[usdt::provider(provider = "propolis")]
 mod probes {
     fn block_begin_read(dev_id: u64, req_id: u64, offset: u64, len: u64) {}

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -1018,6 +1018,12 @@
         "description": "A storage backend backed by a file in the host system's file system.",
         "type": "object",
         "properties": {
+          "block_size": {
+            "description": "Block size of the backend",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
           "path": {
             "description": "A path to a file that backs a disk.",
             "type": "string"
@@ -1025,11 +1031,19 @@
           "readonly": {
             "description": "Indicates whether the storage is read-only.",
             "type": "boolean"
+          },
+          "workers": {
+            "description": "Worker threads for the backend",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
           }
         },
         "required": [
+          "block_size",
           "path",
-          "readonly"
+          "readonly",
+          "workers"
         ],
         "additionalProperties": false
       },

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -1037,7 +1037,7 @@
             "description": "Optional worker threads for the file backend, exposed for testing only.",
             "type": "integer",
             "format": "uint",
-            "minimum": 0
+            "minimum": 1
           }
         },
         "required": [

--- a/openapi/propolis-server.json
+++ b/openapi/propolis-server.json
@@ -1033,17 +1033,17 @@
             "type": "boolean"
           },
           "workers": {
-            "description": "Worker threads for the backend",
+            "nullable": true,
+            "description": "Optional worker threads for the file backend, exposed for testing only.",
             "type": "integer",
-            "format": "uint32",
+            "format": "uint",
             "minimum": 0
           }
         },
         "required": [
           "block_size",
           "path",
-          "readonly",
-          "workers"
+          "readonly"
         ],
         "additionalProperties": false
       },

--- a/phd-tests/framework/src/disk/file.rs
+++ b/phd-tests/framework/src/disk/file.rs
@@ -6,6 +6,7 @@
 
 use camino::{Utf8Path, Utf8PathBuf};
 use propolis_client::instance_spec::{ComponentV0, FileStorageBackend};
+use std::num::NonZeroUsize;
 use tracing::{debug, error, warn};
 use uuid::Uuid;
 
@@ -132,7 +133,7 @@ impl super::DiskConfig for FileBackedDisk {
             path: self.file.path().to_string(),
             readonly: false,
             block_size: 512,
-            workers: Some(8),
+            workers: Some(NonZeroUsize::new(8).unwrap()),
         })
     }
 

--- a/phd-tests/framework/src/disk/file.rs
+++ b/phd-tests/framework/src/disk/file.rs
@@ -131,6 +131,8 @@ impl super::DiskConfig for FileBackedDisk {
         ComponentV0::FileStorageBackend(FileStorageBackend {
             path: self.file.path().to_string(),
             readonly: false,
+            block_size: 512,
+            workers: 8,
         })
     }
 

--- a/phd-tests/framework/src/disk/file.rs
+++ b/phd-tests/framework/src/disk/file.rs
@@ -132,7 +132,7 @@ impl super::DiskConfig for FileBackedDisk {
             path: self.file.path().to_string(),
             readonly: false,
             block_size: 512,
-            workers: 8,
+            workers: Some(8),
         })
     }
 


### PR DESCRIPTION
Putting this out there to get an idea on what I'm doing wrong.
The "ZZZ" lines are my debugging.  

My goal here was to add `block_size` and `workers` as fields you could specify for a file based disk with `propolis-cli`
With these changes, the `--spec` option to `propolis-cli` is able to correctly parse and update the instance's `block_size` and `workers` filed if it finds those fields in the json.

What is not working the way I expect is the `--config-toml` option to `propolis-cli`.

I'm not sure where I missed it, but in  crates/propolis-config-toml/src/spec.rs:
https://github.com/oxidecomputer/propolis/blob/master/crates/propolis-config-toml/src/spec.rs#L154-L160

The `backend_config` that get back, it has only populated the `"path"` for `options`, not block_size or workers.
Here is the output of the log message after that call:
```
ZZZ try_from got config: BlockDevice { bdtype: "file", opts: BlockOpts { block_size: Some(4096), read_only: None, skip_flush: None, workers: Some(32) }, options: {"path": String("/dev/zvol/rdsk/oxp_247f8845-8f59-4669-a503-83e754c32327/crucible/local")} }
```

I modified `parse_storage_backend_from_config()` to look to the `opts` field for `block_size` and `workers` instead of looking in `options`, and that made all the rest work.

So, my question really is, what did I do wrong such that `block_size` and `workers` don't end up in the `options` field, or is what I did okay (and I'll remove the `TomlToSpecError`s I added).  Or, something else?