### PR TITLE
add a D script to report VMs' CPUID queries

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,3 +13,4 @@ individual files for details.
   of a live migration.
 - `vm_exit_codes.d`: Measure VM exits and information about them both for
   #VMEXIT events and returns to Propolis.
+- `cpuid-queries.d`: Report guest CPUID queries and returned leaves.

--- a/scripts/cpuid-queries.d
+++ b/scripts/cpuid-queries.d
@@ -32,7 +32,6 @@ BEGIN {
 }
 
 fbt::vcpu_emulate_cpuid:entry / arg0 == target_vm / {
-	self->interested = 1;
 	self->rax = (uint64_t*)arg2;
 	self->rbx = (uint64_t*)arg3;
 	self->rcx = (uint64_t*)arg4;
@@ -41,7 +40,7 @@ fbt::vcpu_emulate_cpuid:entry / arg0 == target_vm / {
 	self->subleaf = (uint32_t)*self->rcx;
 }
 
-fbt::vcpu_emulate_cpuid:return / self->interested == 1 / {
+fbt::vcpu_emulate_cpuid:return / self->rax != NULL / {
 	printf("CPUID query: leaf/subleaf 0x%08x/0x%08x, returns rax = 0x%08x, rbx = 0x%08x, rcx = 0x%08x, rdx = 0x%08x\n",
 		self->leaf,
 	 	self->subleaf,
@@ -50,5 +49,5 @@ fbt::vcpu_emulate_cpuid:return / self->interested == 1 / {
 		*self->rcx,
 		*self->rdx
 	);
-	self->interested = 0;
+	self->rax = 0;
 }

--- a/scripts/cpuid-queries.d
+++ b/scripts/cpuid-queries.d
@@ -1,0 +1,54 @@
+#pragma D option defaultargs
+#pragma D option quiet
+
+/*
+ * Report guest CPUID queries and returned leaves.
+ *
+ * Usage: ./cpuid-queries.d <target VM's struct vm*>
+ *
+ * You probably have a VM name you care about, not its `struct vm*`. How do you
+ * go from the name to the pointer required here? And why?
+ *
+ * To the first question, something like this will get you the `vmm_vm` pointer
+ * to use with this script:
+ * ```
+ * mdb -ke '::walk vmm | ::print struct vmm_softc vmm_vm vmm_name ! grep -B 1 <VM_NAME>'
+ * ```
+ *
+ * Why? Because the VM's name is on vmm_softc, which has a reference to the
+ * structure used in CPUID emulation and so on, but there's no back reference.
+ * So this is slightly less convoluted than capturing the `struct vm` pointer at
+ * some earlier point when we still have a softc. This may well get simplified
+ * with a backref in the future.
+ */
+
+BEGIN {
+	if ($$1 == "") {
+		printf("target `struct vm*` required");
+		exit(1);
+	}
+
+	target_vm = $1;
+}
+
+fbt::vcpu_emulate_cpuid:entry / arg0 == target_vm / {
+	self->interested = 1;
+	self->rax = (uint64_t*)arg2;
+	self->rbx = (uint64_t*)arg3;
+	self->rcx = (uint64_t*)arg4;
+	self->rdx = (uint64_t*)arg5;
+	self->leaf = *self->rax;
+	self->subleaf = *self->rcx;
+}
+
+fbt::vcpu_emulate_cpuid:return / self->interested == 1 / {
+	printf("CPUID query: leaf/subleaf 0x%08x/0x%08x, returns rax = 0x%08x, rbx = 0x%08x, rcx = 0x%08x, rdx = 0x%08x\n",
+		self->leaf,
+	 	self->subleaf,
+		*self->rax,
+		*self->rbx,
+		*self->rcx,
+		*self->rdx
+	);
+	self->interested = 0;
+}

--- a/scripts/cpuid-queries.d
+++ b/scripts/cpuid-queries.d
@@ -37,8 +37,8 @@ fbt::vcpu_emulate_cpuid:entry / arg0 == target_vm / {
 	self->rbx = (uint64_t*)arg3;
 	self->rcx = (uint64_t*)arg4;
 	self->rdx = (uint64_t*)arg5;
-	self->leaf = *self->rax;
-	self->subleaf = *self->rcx;
+	self->leaf = (uint32_t)*self->rax;
+	self->subleaf = (uint32_t)*self->rcx;
 }
 
 fbt::vcpu_emulate_cpuid:return / self->interested == 1 / {


### PR DESCRIPTION
a better version of the script from https://github.com/oxidecomputer/propolis/issues/933, actually worth holding on to.

here's a Debian 11 image booting:

```
# dtrace -s cpuid-queries.d 0xffffff35739b7000
<skipping some awfully noisy grub stuff>
CPUID query: leaf/subleaf 0x80000000/0x00000000, returns rax = 0x80000028, rbx = 0x68747541, rcx = 0x444d4163, rdx = 0x69746e65
CPUID query: leaf/subleaf 0x80000008/0x00000000, returns rax = 0x00003030, rbx = 0x00000007, rcx = 0x00000000, rdx = 0x00010000
CPUID query: leaf/subleaf 0x00000000/0x00000000, returns rax = 0x00000010, rbx = 0x68747541, rcx = 0x444d4163, rdx = 0x69746e65
CPUID query: leaf/subleaf 0x00000001/0x00000000, returns rax = 0x00a60f12, rbx = 0x00020800, rcx = 0xf6d83203, rdx = 0x178bfbff
CPUID query: leaf/subleaf 0x00000001/0x00000000, returns rax = 0x00a60f12, rbx = 0x00020800, rcx = 0xf6d83203, rdx = 0x178bfbff
CPUID query: leaf/subleaf 0x00000006/0x00000000, returns rax = 0x00000004, rbx = 0x00000000, rcx = 0x00000000, rdx = 0x00000000
CPUID query: leaf/subleaf 0x00000007/0x00000000, returns rax = 0x00000000, rbx = 0xf01703a9, rcx = 0x00000600, rdx = 0x00000000
CPUID query: leaf/subleaf 0x0000000d/0x00000001, returns rax = 0x00000001, rbx = 0x00000240, rcx = 0x00000000, rdx = 0x00000000
CPUID query: leaf/subleaf 0x80000000/0x00000000, returns rax = 0x80000028, rbx = 0x68747541, rcx = 0x444d4163, rdx = 0x69746e65
CPUID query: leaf/subleaf 0x80000001/0x00000000, returns rax = 0x00a60f12, rbx = 0x00000000, rcx = 0x444031fb, rdx = 0x25d3fbff
CPUID query: leaf/subleaf 0x80000007/0x00000000, returns rax = 0x00000000, rbx = 0x00000000, rcx = 0x00000000, rdx = 0x00000100
CPUID query: leaf/subleaf 0x80000008/0x00000000, returns rax = 0x00003030, rbx = 0x00000007, rcx = 0x00000000, rdx = 0x00010000
CPUID query: leaf/subleaf 0x8000000a/0x00000000, returns rax = 0x00000001, rbx = 0x00008000, rcx = 0x00000000, rdx = 0x1ebfbcff
CPUID query: leaf/subleaf 0x8000001f/0x00000000, returns rax = 0x00000001, rbx = 0x000000b3, rcx = 0x00000000, rdx = 0x00000000
CPUID query: leaf/subleaf 0x80000021/0x00000000, returns rax = 0x00062fcf, rbx = 0x0000015c, rcx = 0x00000000, rdx = 0x00000000
CPUID query: leaf/subleaf 0x00000000/0x00000000, returns rax = 0x00000010, rbx = 0x68747541, rcx = 0x444d4163, rdx = 0x69746e65
CPUID query: leaf/subleaf 0x00000006/0x00000000, returns rax = 0x00000004, rbx = 0x00000000, rcx = 0x00000000, rdx = 0x00000000
CPUID query: leaf/subleaf 0x00000000/0x00000000, returns rax = 0x00000010, rbx = 0x68747541, rcx = 0x444d4163, rdx = 0x69746e65
CPUID query: leaf/subleaf 0x00000006/0x00000000, returns rax = 0x00000004, rbx = 0x00000000, rcx = 0x00000000, rdx = 0x00000000
```

it'd be nice to elide the subleaf for leaves that do not have subleaves, output like
```
CPUID query: leaf/subleaf 0x00000000/0x7fac95621e97, returns rax = 0x00000010, rbx = 0x68747541, rcx = 0x444d4163, rdx = 0x69746e65
CPUID query: leaf/subleaf 0x00000001/0x7ffd11ee380c, returns rax = 0x00a60f12, rbx = 0x00020800, rcx = 0xfed83203, rdx = 0x178bfbff
```
is not ideal.. need to have a better treatment of CPUID leaves elsewhere so i might maybe generate a list of known leaf-y/subleaf-y leaves for this. but also if you're looking at this i assume you'll figure out pretty quick which "subleaf" items are not actually relevant.