### PR TITLE
Increase viona receive queue length

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -796,7 +796,8 @@ impl MachineInitializer<'_> {
 
             let viona = virtio::PciVirtioViona::new(
                 &nic.backend_spec.vnic_name,
-                0x100,
+                0x2000.try_into().unwrap(),
+                0x0100.try_into().unwrap(),
                 &self.machine.hdl,
                 params,
             )

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -796,7 +796,7 @@ impl MachineInitializer<'_> {
 
             let viona = virtio::PciVirtioViona::new(
                 &nic.backend_spec.vnic_name,
-                0x2000.try_into().unwrap(),
+                0x0800.try_into().unwrap(),
                 0x0100.try_into().unwrap(),
                 &self.machine.hdl,
                 params,

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -1236,7 +1236,7 @@ fn setup_instance(
 
                     let viona = hw::virtio::PciVirtioViona::new(
                         vnic_name,
-                        0x2000.try_into().unwrap(),
+                        0x0800.try_into().unwrap(),
                         0x0100.try_into().unwrap(),
                         &hdl,
                         viona_params,

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -1236,7 +1236,8 @@ fn setup_instance(
 
                     let viona = hw::virtio::PciVirtioViona::new(
                         vnic_name,
-                        0x100,
+                        0x2000.try_into().unwrap(),
+                        0x0100.try_into().unwrap(),
                         &hdl,
                         viona_params,
                     )?;

--- a/lib/propolis/src/hw/virtio/block.rs
+++ b/lib/propolis/src/hw/virtio/block.rs
@@ -47,7 +47,8 @@ impl PciVirtioBlock {
         let queues = VirtQueues::new(
             NonZeroU16::new(queue_size).unwrap(),
             NonZeroU16::new(1).unwrap(),
-        );
+        )
+        .unwrap();
         // virtio-block only needs two MSI-X entries for its interrupt needs:
         // - device config changes
         // - queue 0 notification

--- a/lib/propolis/src/hw/virtio/block.rs
+++ b/lib/propolis/src/hw/virtio/block.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::num::NonZeroU16;
 use std::sync::{Arc, Weak};
 
 use crate::accessors::MemAccessor;
@@ -44,11 +43,9 @@ pub struct PciVirtioBlock {
 }
 impl PciVirtioBlock {
     pub fn new(queue_size: u16) -> Arc<Self> {
-        let queues = VirtQueues::new(
-            NonZeroU16::new(queue_size).unwrap(),
-            NonZeroU16::new(1).unwrap(),
-        )
-        .unwrap();
+        let queues =
+            VirtQueues::new([VirtQueue::new(queue_size.try_into().unwrap())])
+                .unwrap();
         // virtio-block only needs two MSI-X entries for its interrupt needs:
         // - device config changes
         // - queue 0 notification

--- a/lib/propolis/src/hw/virtio/p9fs.rs
+++ b/lib/propolis/src/hw/virtio/p9fs.rs
@@ -83,7 +83,8 @@ impl PciVirtio9pfs {
         let queues = VirtQueues::new(
             NonZeroU16::new(queue_size).unwrap(),
             NonZeroU16::new(1).unwrap(),
-        );
+        )
+        .unwrap();
         let msix_count = Some(2); //guess
         let (virtio_state, pci_state) = PciVirtioState::create(
             queues,

--- a/lib/propolis/src/hw/virtio/p9fs.rs
+++ b/lib/propolis/src/hw/virtio/p9fs.rs
@@ -6,7 +6,6 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fs::{self, File};
 use std::mem::size_of;
-use std::num::NonZeroU16;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
@@ -80,11 +79,9 @@ pub struct PciVirtio9pfs {
 
 impl PciVirtio9pfs {
     pub fn new(queue_size: u16, handler: Arc<dyn P9Handler>) -> Arc<Self> {
-        let queues = VirtQueues::new(
-            NonZeroU16::new(queue_size).unwrap(),
-            NonZeroU16::new(1).unwrap(),
-        )
-        .unwrap();
+        let queues =
+            VirtQueues::new([VirtQueue::new(queue_size.try_into().unwrap())])
+                .unwrap();
         let msix_count = Some(2); //guess
         let (virtio_state, pci_state) = PciVirtioState::create(
             queues,

--- a/lib/propolis/src/hw/virtio/pci.rs
+++ b/lib/propolis/src/hw/virtio/pci.rs
@@ -272,12 +272,12 @@ impl PciVirtioState {
             }
             LegacyReg::QueueSize => {
                 let state = self.state.lock().unwrap();
-                if let Some(size) = self.queues.queue_size(state.queue_sel) {
-                    ro.write_u16(size);
-                } else {
-                    // bogus queue
-                    ro.write_u16(0);
-                }
+                let sz = self
+                    .queues
+                    .get(state.queue_sel)
+                    .map(|vq| vq.size())
+                    .unwrap_or(0);
+                ro.write_u16(sz);
             }
             LegacyReg::QueueSelect => {
                 let state = self.state.lock().unwrap();

--- a/lib/propolis/src/hw/virtio/pci.rs
+++ b/lib/propolis/src/hw/virtio/pci.rs
@@ -271,7 +271,13 @@ impl PciVirtioState {
                 }
             }
             LegacyReg::QueueSize => {
-                ro.write_u16(self.queues.queue_size().get());
+                let state = self.state.lock().unwrap();
+                if let Some(size) = self.queues.queue_size(state.queue_sel) {
+                    ro.write_u16(size);
+                } else {
+                    // bogus queue
+                    ro.write_u16(0);
+                }
             }
             LegacyReg::QueueSelect => {
                 let state = self.state.lock().unwrap();

--- a/lib/propolis/src/hw/virtio/queue.rs
+++ b/lib/propolis/src/hw/virtio/queue.rs
@@ -145,9 +145,43 @@ impl VqUsed {
     }
 }
 
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct VqSize(NonZeroU16);
+impl TryFrom<NonZeroU16> for VqSize {
+    type Error = VqSizeError;
+
+    fn try_from(value: NonZeroU16) -> Result<Self, Self::Error> {
+        if !value.is_power_of_two() {
+            Err(VqSizeError::NotPow2)
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+impl TryFrom<u16> for VqSize {
+    type Error = VqSizeError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        NonZeroU16::try_from(value).or(Err(VqSizeError::IsZero))?.try_into()
+    }
+}
+impl Into<u16> for VqSize {
+    fn into(self) -> u16 {
+        self.0.get()
+    }
+}
+
+#[derive(Copy, Clone, Debug, thiserror::Error)]
+pub enum VqSizeError {
+    #[error("virtqueue size must be power of 2")]
+    NotPow2,
+    #[error("virtqueue size must not be 0")]
+    IsZero,
+}
+
 pub struct VirtQueue {
     pub id: u16,
-    pub size: u16,
+    pub size: VqSize,
     pub live: AtomicBool,
     avail: Mutex<VqAvail>,
     used: Mutex<VqUsed>,
@@ -161,10 +195,9 @@ const fn qalign(addr: u64, align: u64) -> u64 {
     (addr + mask) & !mask
 }
 impl VirtQueue {
-    pub fn new(id: u16, size: u16) -> Self {
-        assert!(size.is_power_of_two());
+    pub fn new(size: VqSize) -> Self {
         Self {
-            id,
+            id: 0, // to be populated when stashed in VirtQueues
             size,
             live: AtomicBool::new(false),
             avail: Mutex::new(VqAvail {
@@ -196,6 +229,11 @@ impl VirtQueue {
         self.live.store(false, Ordering::Release);
     }
 
+    #[inline(always)]
+    pub fn size(&self) -> u16 {
+        self.size.into()
+    }
+
     /// Attempt to establish ring mappings at a specified physical address,
     /// using legacy-style split virtqueue layout.
     ///
@@ -203,7 +241,7 @@ impl VirtQueue {
     pub fn map_legacy(&self, addr: u64) {
         assert_eq!(addr & (LEGACY_QALIGN - 1), 0);
 
-        let size = self.size as usize;
+        let size = self.size() as usize;
 
         let desc_addr = addr;
         let desc_len = mem::size_of::<VqdDesc>() * size;
@@ -254,9 +292,9 @@ impl VirtQueue {
     ) -> Option<(u16, u32)> {
         assert!(chain.idx.is_none());
         let mut avail = self.avail.lock().unwrap();
-        let req = avail.read_next_avail(self.size, mem)?;
+        let req = avail.read_next_avail(self.size(), mem)?;
 
-        let mut desc = avail.read_ring_descr(req.desc_idx, self.size, mem)?;
+        let mut desc = avail.read_ring_descr(req.desc_idx, self.size(), mem)?;
         let mut flags = DescFlag::from_bits_truncate(desc.flags);
         let mut count = 0;
         let mut len = 0;
@@ -278,13 +316,13 @@ impl VirtQueue {
             chain.push_buf(buf);
 
             if flags.intersects(DescFlag::NEXT | DescFlag::INDIRECT) {
-                if count == self.size {
+                if count == self.size() {
                     // XXX: signal error condition?
                     chain.idx = None;
                     return None;
                 }
                 if let Some(next) =
-                    avail.read_ring_descr(desc.next, self.size, mem)
+                    avail.read_ring_descr(desc.next, self.size(), mem)
                 {
                     desc = next;
                     flags = DescFlag::from_bits_truncate(desc.flags);
@@ -338,7 +376,7 @@ impl VirtQueue {
         // XXX: for now, just go off of the write stats
         let len = chain.write_stat.bytes - chain.write_stat.bytes_remain;
         probes::virtio_vq_push!(|| (self as *const VirtQueue as u64, id, len));
-        used.write_used(id, len, self.size, mem);
+        used.write_used(id, len, self.size(), mem);
         if !used.intr_supressed(mem) {
             if let Some(intr) = used.interrupt.as_ref() {
                 intr.notify();
@@ -375,7 +413,7 @@ impl VirtQueue {
 
         migrate::VirtQueueV1 {
             id: self.id,
-            size: self.size,
+            size: self.size(),
             descr_gpa: avail.gpa_desc.0,
             mapping_valid: avail.valid && used.valid,
             live: self.live.load(Ordering::Acquire),
@@ -402,10 +440,11 @@ impl VirtQueue {
                 self.id, state.id,
             )));
         }
-        if self.size != state.size {
+        if self.size() != state.size {
             return Err(MigrateStateError::ImportFailed(format!(
                 "VirtQueue: mismatched size {} vs {}",
-                self.size, state.size,
+                self.size(),
+                state.size,
             )));
         }
 
@@ -699,62 +738,28 @@ pub struct Info {
 
 pub struct VirtQueues {
     queues: Vec<Arc<VirtQueue>>,
-    num: NonZeroU16,
 }
 impl VirtQueues {
     pub fn new(
-        size: NonZeroU16,
-        num: NonZeroU16,
+        queues: impl IntoIterator<Item = VirtQueue>,
     ) -> Result<Self, VirtQueuesError> {
-        let queues = (0..num.get())
-            .map(|id| {
-                if size.get().is_power_of_two() {
-                    Ok(Arc::new(VirtQueue::new(id, size.get())))
-                } else {
-                    Err(VirtQueuesError::NonPowerOfTwoQueueSize(
-                        usize::from(id),
-                        usize::from(size.get()),
-                    ))
-                }
-            })
-            .collect::<Result<_, _>>()?;
-
-        Ok(Self { queues, num })
-    }
-    pub fn new_from_sizes(
-        sizes: &[NonZeroU16],
-    ) -> Result<Self, VirtQueuesError> {
-        let num = u16::try_from(sizes.len())
-            .and_then(NonZeroU16::try_from)
-            .map_err(|_| VirtQueuesError::BadQueueCount(sizes.len()))?;
-
-        let queues = sizes
-            .iter()
+        let queues = queues
+            .into_iter()
             .enumerate()
-            .map(|(id, size)| {
-                if size.get().is_power_of_two() {
-                    Ok(Arc::new(VirtQueue::new(
-                        u16::try_from(id).expect(
-                            "proven to be drawn from a NonZeroU16 above",
-                        ),
-                        size.get(),
-                    )))
-                } else {
-                    Err(VirtQueuesError::NonPowerOfTwoQueueSize(
-                        id,
-                        usize::from(size.get()),
-                    ))
-                }
+            .map(|(id, mut vq)| {
+                vq.id = id as u16;
+                Arc::new(vq)
             })
-            .collect::<Result<_, _>>()?;
+            .collect::<Vec<_>>();
+        if !(0..(u16::MAX as usize)).contains(&queues.len()) {
+            return Err(VirtQueuesError::BadQueueCount(queues.len()));
+        }
 
-        Ok(Self { queues, num })
-    }
-    pub fn queue_size(&self, qid: u16) -> Option<u16> {
-        self.get(qid).map(|v| v.size)
+        Ok(Self { queues })
     }
     pub fn count(&self) -> NonZeroU16 {
-        self.num
+        NonZeroU16::try_from(self.queues.len() as u16)
+            .expect("queue count already validated")
     }
     pub fn get(&self, qid: u16) -> Option<&Arc<VirtQueue>> {
         self.queues.get(usize::from(qid))
@@ -774,8 +779,6 @@ impl<S: SliceIndex<[Arc<VirtQueue>]>> Index<S> for VirtQueues {
 
 #[derive(Copy, Clone, Debug, thiserror::Error)]
 pub enum VirtQueuesError {
-    #[error("queue {0}'s length ({1}) must be a power of two")]
-    NonPowerOfTwoQueueSize(usize, usize),
     #[error("queue count {0} must be nonzero and less than 65535")]
     BadQueueCount(usize),
 }

--- a/lib/propolis/src/hw/virtio/softnpu.rs
+++ b/lib/propolis/src/hw/virtio/softnpu.rs
@@ -148,7 +148,8 @@ impl PortVirtioState {
         let queues = VirtQueues::new(
             NonZeroU16::new(queue_size).unwrap(),
             NonZeroU16::new(2).unwrap(), //TX and RX
-        );
+        )
+        .unwrap();
         let msix_count = Some(2);
         let (pci_virtio_state, pci_state) = PciVirtioState::create(
             queues,

--- a/lib/propolis/src/hw/virtio/softnpu.rs
+++ b/lib/propolis/src/hw/virtio/softnpu.rs
@@ -6,7 +6,6 @@ use std::{
     collections::BTreeMap,
     fs::{self, File, OpenOptions},
     io::{Result, Write},
-    num::NonZeroU16,
     sync::{Arc, Mutex},
     thread::{sleep, spawn},
     time::Duration,
@@ -145,9 +144,10 @@ pub struct PortVirtioState {
 
 impl PortVirtioState {
     fn new(queue_size: u16) -> Self {
+        let queue_size = queue_size.try_into().unwrap();
         let queues = VirtQueues::new(
-            NonZeroU16::new(queue_size).unwrap(),
-            NonZeroU16::new(2).unwrap(), //TX and RX
+            // RX and TX queues
+            [VirtQueue::new(queue_size), VirtQueue::new(queue_size)],
         )
         .unwrap();
         let msix_count = Some(2);

--- a/lib/propolis/src/hw/virtio/viona.rs
+++ b/lib/propolis/src/hw/virtio/viona.rs
@@ -156,7 +156,8 @@ pub struct PciVirtioViona {
 impl PciVirtioViona {
     pub fn new(
         vnic_name: &str,
-        queue_size: u16,
+        rx_queue_size: NonZeroU16,
+        tx_queue_size: NonZeroU16,
         vm: &VmmHdl,
         viona_params: Option<DeviceParams>,
     ) -> io::Result<Arc<PciVirtioViona>> {
@@ -178,8 +179,6 @@ impl PciVirtioViona {
             vp.set(&hdl)?;
         }
 
-        // TX and RX
-        let queue_count = NonZeroU16::new(2).unwrap();
         // interrupts for TX, RX, and device config
         let msix_count = Some(3);
         let dev_features = hdl.get_avail_features()?;
@@ -198,7 +197,8 @@ impl PciVirtioViona {
         }
 
         let queues =
-            VirtQueues::new(NonZeroU16::new(queue_size).unwrap(), queue_count);
+            VirtQueues::new_from_sizes(&[rx_queue_size, tx_queue_size])
+                .unwrap();
         let (virtio_state, pci_state) = PciVirtioState::create(
             queues,
             msix_count,


### PR DESCRIPTION
This PR bumps the viona receive queue length to be a larger value (8192), matching what can be observed in GCP. One of the pieces here is that we're now allowing a list of virtqueues to be created with different lengths, all of which must be validated to fit the `u16` and power-of-two requirement.

We don't necessarily _want that particular value at this time_, since that's a lot of physically contiguous pages a needed to create the rx virtqueue. But this gives us the tools to investigate Rx and Tx queue lengths separately for #930, ideally on a racklette.