### PR TITLE
Expand viona header pad to account for new Geneve options

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -786,9 +786,9 @@ impl MachineInitializer<'_> {
                     // - ethernet: 14
                     // - IPv6: 40
                     // - UDP: 8
-                    // - Geneve: 8
+                    // - Geneve: 8–16 (due to options)
                     // - (and then round up to nearest 8)
-                    header_pad: 72,
+                    header_pad: 80,
                 })
             } else {
                 None


### PR DESCRIPTION
With https://github.com/oxidecomputer/opte/pull/805 merged, we are pushing on an extra 8B for any rack-local TCP flow. Equally, we expect that any multicast packets will push Geneve options. This PR bumps the `header_pad` value to accomodate this extra requirement.