### PR TITLE
Specialize CPUID leaves 4 and Bh for CPU topology

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -1294,7 +1294,7 @@ impl MachineInitializer<'_> {
                     requests to set hypervisor leaves",
             );
 
-            static UNSUPPORTED_TOPO: &'static [TopoKind] = &[
+            static UNSUPPORTED_TOPO: &[TopoKind] = &[
                 // `fix_cpu_topo` doesn't know how to produce specialized leaf
                 // 1Fh entries yet.
                 TopoKind::Std1F,

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -1301,6 +1301,7 @@ impl MachineInitializer<'_> {
                 .with_vcpuid(vcpu.id)
                 .with_cache_topo()
                 .clear_cpu_topo(propolis::cpuid::TopoKind::iter())
+                .with_cpu_topo(vec![propolis::cpuid::TopoKind::Std4].into_iter())
                 .execute(set)
                 .map_err(|e| {
                     MachineInitError::CpuidSpecializationFailed(vcpu.id, e)


### PR DESCRIPTION
This is kind of two parts:

* teach `cpuid-utils` and propolis' CPUID specializer about the Intel-only leaf 4 (at least as it relates to core/thread counts)
* include `with_cpu_topo()` so we update to-be-specialized topo leaves instead of just discard them

this fixes https://github.com/oxidecomputer/propolis/issues/921 and is part of fixing https://github.com/oxidecomputer/propolis/issues/940 (the other part being https://www.illumos.org/issues/17529 or getting leaf B from an instance spec)

draft because I haven't given this a test with anything _other_ than OmniOS r151054 on Intel yet, but I'd be kind of shocked if this changes anything on AMD or if other OSes somehow find this intolerable where they were fine with the leaves before...