### PR TITLE
propolis-cli should be able to send TOML-defined CPU profiles

### DIFF
--- a/crates/propolis-config-toml/src/lib.rs
+++ b/crates/propolis-config-toml/src/lib.rs
@@ -10,7 +10,9 @@ use std::str::FromStr;
 use serde_derive::{Deserialize, Serialize};
 use thiserror::Error;
 
-pub use cpuid_profile_config::CpuidProfile;
+pub use cpuid_profile_config::{
+    CpuVendor, CpuidEntry, CpuidParseError, CpuidProfile,
+};
 
 pub mod spec;
 

--- a/lib/propolis-client/src/lib.rs
+++ b/lib/propolis-client/src/lib.rs
@@ -43,6 +43,7 @@ progenitor::generate_api!(
         ReplacementComponent = crate::instance_spec::ReplacementComponent,
         InstanceSpecV0 = crate::instance_spec::InstanceSpecV0,
         VersionedInstanceSpec = crate::instance_spec::VersionedInstanceSpec,
+        CpuidEntry = crate::instance_spec::CpuidEntry,
     },
     // Automatically derive JsonSchema for instance spec-related types so that
     // they can be reused in sled-agent's API. This can't be done with a


### PR DESCRIPTION
some plumbing I wrote up to help check the CPU profile from Omicron#8728 across more OS types. I think shortly after 8728 is sorted it makes sense to move a lot of the CPUID stuff to a crate shared with Propolis, one reason being we could bake in known-to-Nexus CPUID profiles in `propolis-cli` as well. Then we could make `--cpuid-profile milan_v1` _Just Work_ without having to copy around blobs of hex for well-defined profiles. but, this is sufficient for now.