### PR TITLE
Crucible update plus a few other dependency changes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,7 +873,7 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=779775d5130ff7a4836f52f48b7e64d1479ee104#779775d5130ff7a4836f52f48b7e64d1479ee104"
+source = "git+https://github.com/oxidecomputer/crucible?rev=65ca41e821ef53ec9c28909357f23e3348169e4f#65ca41e821ef53ec9c28909357f23e3348169e4f"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -887,8 +901,8 @@ dependencies = [
  "omicron-uuid-kinds",
  "oximeter",
  "oximeter-producer",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rayon",
  "reqwest",
  "ringbuffer",
@@ -914,7 +928,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=779775d5130ff7a4836f52f48b7e64d1479ee104#779775d5130ff7a4836f52f48b7e64d1479ee104"
+source = "git+https://github.com/oxidecomputer/crucible?rev=65ca41e821ef53ec9c28909357f23e3348169e4f#65ca41e821ef53ec9c28909357f23e3348169e4f"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -927,7 +941,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=779775d5130ff7a4836f52f48b7e64d1479ee104#779775d5130ff7a4836f52f48b7e64d1479ee104"
+source = "git+https://github.com/oxidecomputer/crucible?rev=65ca41e821ef53ec9c28909357f23e3348169e4f#65ca41e821ef53ec9c28909357f23e3348169e4f"
 dependencies = [
  "anyhow",
  "atty",
@@ -951,12 +965,13 @@ dependencies = [
  "twox-hash",
  "uuid",
  "vergen",
+ "vergen-git2",
 ]
 
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=779775d5130ff7a4836f52f48b7e64d1479ee104#779775d5130ff7a4836f52f48b7e64d1479ee104"
+source = "git+https://github.com/oxidecomputer/crucible?rev=65ca41e821ef53ec9c28909357f23e3348169e4f#65ca41e821ef53ec9c28909357f23e3348169e4f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1067,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.9"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1077,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.9"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1091,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.9"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -1152,9 +1167,9 @@ checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1172,6 +1187,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,7 +1226,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
  "syn 2.0.101",
 ]
 
@@ -1875,9 +1921,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git2"
-version = "0.19.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
@@ -2758,9 +2804,9 @@ source = "git+https://github.com/oxidecomputer/dlpi-sys#4f750d9ee3ffbb3074f218ee
 
 [[package]]
 name = "libgit2-sys"
-version = "0.17.0+1.8.1"
+version = "0.18.2+1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
 dependencies = [
  "cc",
  "libc",
@@ -2798,7 +2844,7 @@ dependencies = [
  "nvpair 0.5.0",
  "nvpair-sys",
  "oxnet",
- "rand 0.9.0",
+ "rand 0.9.2",
  "rusty-doors",
  "socket2",
  "thiserror 2.0.12",
@@ -4081,7 +4127,7 @@ dependencies = [
  "omicron-common",
  "oximeter",
  "propolis-client",
- "rand 0.8.5",
+ "rand 0.9.2",
  "reqwest",
  "ring",
  "serde",
@@ -4108,7 +4154,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "clap",
  "phd-framework",
  "phd-tests",
@@ -4633,7 +4679,7 @@ dependencies = [
  "p9ds",
  "pin-project-lite",
  "propolis_types",
- "rand 0.8.5",
+ "rand 0.9.2",
  "rfb",
  "rgb_frame",
  "serde",
@@ -4688,7 +4734,7 @@ dependencies = [
  "progenitor 0.10.0",
  "progenitor-client 0.10.0",
  "propolis_api_types",
- "rand 0.8.5",
+ "rand 0.9.2",
  "reqwest",
  "schemars",
  "serde",
@@ -4727,7 +4773,7 @@ dependencies = [
  "progenitor 0.10.0",
  "propolis_api_types",
  "propolis_types",
- "rand 0.8.5",
+ "rand 0.9.2",
  "reqwest",
  "schemars",
  "semver 1.0.26",
@@ -5029,13 +5075,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -5334,9 +5379,9 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver 1.0.26",
 ]
@@ -5442,9 +5487,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-doors"
@@ -6545,9 +6590,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
@@ -6562,15 +6607,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7379,18 +7424,43 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "8.3.2"
+version = "9.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
+checksum = "6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777"
 dependencies = [
  "anyhow",
- "cargo_metadata",
- "cfg-if",
- "git2",
+ "cargo_metadata 0.19.2",
+ "derive_builder",
  "regex",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
+ "rustversion",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-git2"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6ee511ec45098eabade8a0750e76eec671e7fb2d9360c563911336bea9cac1"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "git2",
  "rustversion",
  "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
 ]
 
 [[package]]
@@ -7994,7 +8064,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "clap",
  "escargot",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,8 +87,8 @@ oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 sled-agent-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 
 # Crucible
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "779775d5130ff7a4836f52f48b7e64d1479ee104" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "779775d5130ff7a4836f52f48b7e64d1479ee104" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "65ca41e821ef53ec9c28909357f23e3348169e4f" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "65ca41e821ef53ec9c28909357f23e3348169e4f" }
 
 # External dependencies
 anyhow = "1.0"
@@ -141,7 +141,7 @@ progenitor = "0.10.0"
 progenitor-client = "0.10.0"
 proptest = "1.5.0"
 quote = "1.0"
-rand = "0.8"
+rand = "0.9.1"
 reqwest = { version = "0.12.0", default-features = false }
 ring = "0.17"
 ron = "0.8"

--- a/lib/propolis/src/hw/nvme/queue.rs
+++ b/lib/propolis/src/hw/nvme/queue.rs
@@ -1152,8 +1152,8 @@ mod test {
         // size to exercise the "kick" conditions where we have some
         // request available in the SQ but can't pop it until there's
         // space available in the CQ.
-        let mut rng = rand::thread_rng();
-        let sq_size = rng.gen_range(512..2048);
+        let mut rng = rand::rng();
+        let sq_size = rng.random_range(512..2048);
         let cq =
             Arc::new(CompQueue::new(1, 0, 4, write_base, hdl, &mem).unwrap());
         let sq = Arc::new(
@@ -1161,7 +1161,7 @@ mod test {
         );
 
         // We'll be generating a random number of submissions
-        let submissions_rand = rng.gen_range(2..sq.state.size - 1);
+        let submissions_rand = rng.random_range(2..sq.state.size - 1);
 
         let (doorbell_tx, doorbell_rx) =
             crossbeam_channel::unbounded::<Doorbell>();
@@ -1229,7 +1229,7 @@ mod test {
                     let mut submissions = 0;
                     let mem = child_acc.access().unwrap();
 
-                    let mut rng = rand::thread_rng();
+                    let mut rng = rand::rng();
                     while let Ok(()) = worker_rx.recv() {
                         while let Some((_, cqe_permit, _)) = worker_sq.pop(&mem)
                         {
@@ -1237,7 +1237,9 @@ mod test {
 
                             // Sleep for a bit to mimic actually doing
                             // some work before we complete the IO
-                            sleep(Duration::from_micros(rng.gen_range(0..500)));
+                            sleep(Duration::from_micros(
+                                rng.random_range(0..500),
+                            ));
 
                             cqe_permit.test_complete(&worker_sq, &mem);
 
@@ -1283,7 +1285,7 @@ mod test {
             assert!(doorbell_tx.send(Doorbell::Sq(1)).is_ok());
 
             // Sleep up to 100us in between
-            sleep(Duration::from_micros(rng.gen_range(0..100)));
+            sleep(Duration::from_micros(rng.random_range(0..100)));
         }
         drop(doorbell_tx);
 

--- a/lib/propolis/src/hw/virtio/softnpu.rs
+++ b/lib/propolis/src/hw/virtio/softnpu.rs
@@ -203,8 +203,8 @@ impl SoftNpu {
     /// Generate a mac address with the Oxide OUI for the leading bits and then
     /// something random in the range of 0xf00000 - 0xf00000 per RFD 174.
     fn generate_mac() -> [u8; 6] {
-        let mut rng = rand::thread_rng();
-        let m = rng.gen_range::<u32, _>(0xf00000..0xffffff).to_le_bytes();
+        let mut rng = rand::rng();
+        let m = rng.random_range::<u32, _>(0xf00000..0xffffff).to_le_bytes();
         [0xa8, 0x40, 0x25, m[0], m[1], m[2]]
     }
 

--- a/phd-tests/framework/src/disk/crucible.rs
+++ b/phd-tests/framework/src/disk/crucible.rs
@@ -370,7 +370,7 @@ impl Inner {
                 &base64::engine::general_purpose::STANDARD,
                 {
                     let mut bytes: [u8; 32] = [0; 32];
-                    StdRng::from_entropy().fill_bytes(&mut bytes);
+                    StdRng::from_os_rng().fill_bytes(&mut bytes);
                     bytes
                 },
             ),


### PR DESCRIPTION
Update crucible version, which required a few additional library updates.  One of which was rand, which then had some minor updates to resolve name changes.

Crucible updates:
update to latest `vergen` (#1770)
Update rand dependencies, and fallout from that. (#1764) [crucible-downstairs] migrate to API traits (#1768) [crucible-agent] migrate to API trait (#1766)
[crucible-pantry] migrate to API trait (#1767)
Add back job delays in the downstairs with the --lossy flag (#1761)