### PR TITLE
[propolis-server] pass in api-version header to migrate requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5546,6 +5546,7 @@ version = "0.1.0"
 dependencies = [
  "crucible-client-types",
  "dropshot",
+ "dropshot-api-manager-types",
  "propolis_api_types",
 ]
 

--- a/crates/propolis-server-api/Cargo.toml
+++ b/crates/propolis-server-api/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2024"
 [dependencies]
 crucible-client-types.workspace = true
 dropshot.workspace = true
+dropshot-api-manager-types.workspace = true
 propolis_api_types.workspace = true

--- a/crates/propolis-server-api/src/lib.rs
+++ b/crates/propolis-server-api/src/lib.rs
@@ -7,6 +7,7 @@ use dropshot::{
     HttpResponseUpdatedNoContent, Path, Query, RequestContext, TypedBody,
     WebsocketChannelResult, WebsocketConnection,
 };
+use dropshot_api_manager_types::api_versions;
 use propolis_api_types::{
     InstanceEnsureRequest, InstanceEnsureResponse, InstanceGetResponse,
     InstanceMigrateStartRequest, InstanceMigrateStatusResponse,
@@ -16,6 +17,33 @@ use propolis_api_types::{
     InstanceStateRequested, InstanceVCRReplace, SnapshotRequestPathParams,
     VCRRequestPathParams, VolumeStatus, VolumeStatusPathParams,
 };
+
+api_versions!([
+    // WHEN CHANGING THE API (part 1 of 2):
+    //
+    // +- Pick a new semver and define it in the list below.  The list MUST
+    // |  remain sorted, which generally means that your version should go at
+    // |  the very top.
+    // |
+    // |  Duplicate this line, uncomment the *second* copy, update that copy for
+    // |  your new API version, and leave the first copy commented out as an
+    // |  example for the next person.
+    // v
+    // (next_int, IDENT),
+    (1, INITIAL),
+]);
+
+// WHEN CHANGING THE API (part 2 of 2):
+//
+// The call to `api_versions!` above defines constants of type
+// `semver::Version` that you can use in your Dropshot API definition to specify
+// the version when a particular endpoint was added or removed.  For example, if
+// you used:
+//
+//     (2, ADD_FOOBAR)
+//
+// Then you could use `VERSION_ADD_FOOBAR` as the version in which endpoints
+// were added or removed.
 
 #[dropshot::api_description]
 pub trait PropolisServerApi {
@@ -116,6 +144,12 @@ pub trait PropolisServerApi {
     //
     // Part 1 is verified by the Dropshot API manager. For part 2,
     // propolis-server has internal support for protocol negotiation.
+    //
+    // Note that we currently bypass Progenitor and always pass in
+    // VERSION_INITIAL. See `migration_start_connect` in
+    // propolis-server/src/lib/migrate/destination.rs for where we do it. If we
+    // introduce a change to this API, we'll have to carefully consider version
+    // skew between the source and destination servers.
     #[channel {
         protocol = WEBSOCKETS,
         path = "/instance/migrate/{migration_id}/start",


### PR DESCRIPTION
Split out of #955 -- for the `phd-run-migrate-from-base` tests to work, this has to be in its own PR that's landed first.
