### PR TITLE
Bump MAXCPU to 254 on Helios

### DIFF
--- a/lib/propolis/src/vcpu.rs
+++ b/lib/propolis/src/vcpu.rs
@@ -37,9 +37,9 @@ mod probes {
 #[cfg(not(feature = "omicron-build"))]
 pub const MAXCPU: usize = bhyve_api::VM_MAXCPU;
 
-// Helios (stlouis) is built with an expanded limit of 64
+// Helios (stlouis) is built with an expanded limit of 254
 #[cfg(feature = "omicron-build")]
-pub const MAXCPU: usize = 64;
+pub const MAXCPU: usize = 254;
 
 #[derive(Debug, Error)]
 pub enum GetCpuidError {


### PR DESCRIPTION
We've bumped the in-Helios figure again, so plumb that through to Propolis (which means a Propolis bump in Omicron soon too)

The stlouis side here has already been merged ([stlouis#828](https://github.com/oxidecomputer/stlouis/issues/828)). This is the Propolis diff I'd used to test that change out.