### PR TITLE
Update Crucible to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,7 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 [[package]]
 name = "crucible"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=102b0bb8305cfbc3fa74c52d643d716653756372#102b0bb8305cfbc3fa74c52d643d716653756372"
+source = "git+https://github.com/oxidecomputer/crucible?rev=75ea3408643664877aa603ffc65996ed6dc34c0a#75ea3408643664877aa603ffc65996ed6dc34c0a"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -1060,7 +1060,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=102b0bb8305cfbc3fa74c52d643d716653756372#102b0bb8305cfbc3fa74c52d643d716653756372"
+source = "git+https://github.com/oxidecomputer/crucible?rev=75ea3408643664877aa603ffc65996ed6dc34c0a#75ea3408643664877aa603ffc65996ed6dc34c0a"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -1073,7 +1073,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=102b0bb8305cfbc3fa74c52d643d716653756372#102b0bb8305cfbc3fa74c52d643d716653756372"
+source = "git+https://github.com/oxidecomputer/crucible?rev=75ea3408643664877aa603ffc65996ed6dc34c0a#75ea3408643664877aa603ffc65996ed6dc34c0a"
 dependencies = [
  "anyhow",
  "atty",
@@ -1103,7 +1103,7 @@ dependencies = [
 [[package]]
 name = "crucible-protocol"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=102b0bb8305cfbc3fa74c52d643d716653756372#102b0bb8305cfbc3fa74c52d643d716653756372"
+source = "git+https://github.com/oxidecomputer/crucible?rev=75ea3408643664877aa603ffc65996ed6dc34c0a#75ea3408643664877aa603ffc65996ed6dc34c0a"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,8 @@ oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 sled-agent-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 
 # Crucible
-crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "102b0bb8305cfbc3fa74c52d643d716653756372" }
-crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "102b0bb8305cfbc3fa74c52d643d716653756372" }
+crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "75ea3408643664877aa603ffc65996ed6dc34c0a" }
+crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "75ea3408643664877aa603ffc65996ed6dc34c0a" }
 
 # External dependencies
 anyhow = "1.0"


### PR DESCRIPTION
Update crucible to latest

Enforce write order of blocks and dirty bit (#1798)
Remove unnecessary `unused_async` (#1795)
Add `crucible-downstairs validate` subcommand (#1792)
Remove incorrect `expect(unused)` annotation (#1789)
Handle errors in get-up-state.sh (#1787)
Handle final live-repair flush being skipped on all downstairs (#1783)
Offline downstairs go to faulted when LR starts (#1777)
update drift to pick up fix for OpenAPI type graph cycles (#1785)
make Crucible APIs versioned (#1782)