### PR TITLE
nvme: CQEs with command-specific error 0 are acceptable

### DIFF
--- a/lib/propolis/src/hw/nvme/bits.rs
+++ b/lib/propolis/src/hw/nvme/bits.rs
@@ -714,7 +714,7 @@ pub const IDENT_CNS_CONTROLLER: u8 = 0x1;
 /// The type of value specified in the Status Field (SF) of a command completion.
 ///
 /// See NVMe 1.0e Section 4.5.1.1 Status Code Type (SCT)
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u8)]
 pub enum StatusCodeType {
     Generic = 0,

--- a/lib/propolis/src/hw/nvme/cmds.rs
+++ b/lib/propolis/src/hw/nvme/cmds.rs
@@ -985,7 +985,7 @@ impl Completion {
     /// Create an error Completion result with a specific type and status
     pub fn specific_err(sct: StatusCodeType, status: u8) -> Self {
         // success doesn't belong in an error
-        assert_ne!(status, bits::STS_SUCCESS);
+        assert_ne!((sct, status), (StatusCodeType::Generic, bits::STS_SUCCESS));
 
         Self { dw0: 0, status: Self::status_field(sct, status) }
     }


### PR DESCRIPTION
STS_SUCCESS is represented by 0u16, but other command-specific error statuses may also be 0u16. `SYS_CREATE_IO_Q_INVAL_CQ` is also 0u16, returned when creating I/O submission queues. In NVMe 1.1 with multi-path support, path-specific error 0u16 indicates a nondescript "internal path error".

i'd set out to the circumstances i described [here](https://github.com/oxidecomputer/propolis/pull/953#discussion_r2461928846) by writing a very rudimentary fuzzer driving admin commands while another thread repeatedly resets the controller. this didn't work! my reasoning was pretty wrong: `NvmeCtrl` is already under a mutex in `PciNvme`, and the functions i'd conjectured were running concurrently both take `&mut self` so they definitely are not. i did find this though.