### PR TITLE
Plumb sled_model and sled_serial into smbios Type1

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -1004,14 +1004,28 @@ impl MachineInitializer<'_> {
 
         let smb_type1 = smbios::table::Type1 {
             manufacturer: "Oxide".try_into().unwrap(),
-            product_name: "OxVM".try_into().unwrap(),
+            product_name: self
+                .properties
+                .metadata
+                .sled_model
+                .clone()
+                .try_into()
+                .unwrap_or_else(|_| "OxVM".try_into().unwrap()),
 
             serial_number: self
                 .properties
-                .id
-                .to_string()
+                .metadata
+                .sled_serial
+                .clone()
                 .try_into()
-                .unwrap_or_default(),
+                .unwrap_or_else(|_| {
+                    self.properties
+                        .id
+                        .to_string()
+                        .try_into()
+                        .unwrap_or_default()
+                }),
+
             uuid: self.properties.id.to_bytes_le(),
 
             wake_up_type: type1::WakeUpType::PowerSwitch,


### PR DESCRIPTION
This is necessary for a4x2 usage where we want the values in the smbios to match the values in the platform id of the certificates used for sprockets.

I'm not sure if this will cause any upstream consumer issues that rely on the the serial number being equivalent to the VM id, or the product name being equivalent to "OxVM". If so we'll need to find a way to work in both scenarios.