### PR TITLE
Provide dummy NVMe controller identity values

### DIFF
--- a/lib/propolis/src/hw/nvme/mod.rs
+++ b/lib/propolis/src/hw/nvme/mod.rs
@@ -788,7 +788,7 @@ impl PciNvme {
         let mn = {
             // Use all spaces for the model: otherwise, OVMF's boot order may be
             // affected.
-            let mn = [20u8; 40];
+            let mn = [0x20u8; 40];
             mn
         };
 


### PR DESCRIPTION
Provide a dummy value for model and firmware rev, otherwise the latest `nvme-cli` main branch build crashes in a Linux guest.