### PR TITLE
NVMe reset can discard request Permits early

### DIFF
--- a/lib/propolis/src/block/attachment.rs
+++ b/lib/propolis/src/block/attachment.rs
@@ -538,8 +538,9 @@ impl DeviceAttachment {
         let slot = self.0.queues.slot(queue_id);
         let mut slot_state = slot.state.lock().unwrap();
 
-        let _minder =
+        let minder =
             slot_state.minder.take().expect("queue slot should be occupied");
+        minder.destroy();
         drop(slot_state);
 
         let associated = state.queue_dissociate(queue_id);

--- a/lib/propolis/src/hw/nvme/requests.rs
+++ b/lib/propolis/src/hw/nvme/requests.rs
@@ -153,4 +153,10 @@ impl block::DeviceQueue for NvmeBlockQueue {
 
         permit.complete(Completion::from(result));
     }
+
+    /// In the unlikely case we must give up on an in-flight I/O, tear it down
+    /// without triggering the no-drop check on NVMe request permits.
+    fn abandon(&self, token: Self::Token) {
+        token.abandon();
+    }
 }

--- a/lib/propolis/src/hw/virtio/block.rs
+++ b/lib/propolis/src/hw/virtio/block.rs
@@ -255,6 +255,10 @@ impl block::DeviceQueue for BlockVq {
             self.0.push_used(chain, &mem);
         }
     }
+
+    fn abandon(&self, _token: Self::Token) {
+        // Nothing necessary to safely abandon a `CompletionToken`.
+    }
 }
 
 impl VirtioDevice for PciVirtioBlock {


### PR DESCRIPTION
fixes https://github.com/oxidecomputer/propolis/issues/975

I'd been using this in a much hackier form while causing a bunch of bad NVMe controller behavior in the few days, and it consistently stops Propolis from panicking due to dropping Permits early. Linux (and others?) will go reset the NVMe controller if it seems stuck (I/Os go unacked for some number of seconds). In my cases, I was chasing down "not sending completions" or "not sending interrupt after enqueuing completions", or in Angela's case it was "Crucible was partially down and not completing writes". None of those cases are *good* for the guest, but panicking is extra wrong.

I don't have a nice test case for this other than "if you stop sending completions you'll hit this pretty quick!" - realistically it'd be great to have a test block backend whose I/Os we can individually complete, fail, or delay.