### PR TITLE
update usdt to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5387,7 +5387,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.64",
  "tokio",
- "usdt 0.5.0",
+ "usdt 0.6.0",
  "uuid",
  "viona_api",
  "zerocopy 0.8.27",
@@ -5569,7 +5569,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "toml 0.7.8",
- "usdt 0.5.0",
+ "usdt 0.6.0",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ tracing = "0.1.35"
 tracing-appender = "0.2.2"
 tracing-bunyan-formatter = "0.3.3"
 tracing-subscriber = "0.3.14"
-usdt = { version = "0.5", default-features = false }
+usdt = { version = "0.6", default-features = false }
 uuid = "1.3.2"
 zerocopy = "0.8.25"
 


### PR DESCRIPTION
dropshot includes usdt probes and as of 0.16.6 depends on usdt 0.6.0 to do so. this introduces a few duplicate-ish dependencies that feel a bit unsightly. in particular, usdt 0.5.0 -> 0.6.0 comes with a few major version bumps of usdt dependencies so they can't simply be unified to a common latest version.

bumping Propolis is not sufficient to dedupe these dependencies, as we get them from Crucible, Oximeter, `qorb`, `slog-dtrace`, and `tokio-dtrace`, as well as `usdt 0.3.5` from `p4rs`. but getting Propolis ahead of things means once they're all bumped and bumped here, we'll lose deps on `goblin 0.8.2`, `scroll 0.12.0`, `dof 0.3.0`, and probably a few others.

edit: one (me!) may ask if usdt 0.6.0 gets Propolis anything interesting, and the most I see is the (neat!) stap v3 probe support but since Propolis is so very illumos-only maybe that's not important here :)