### PR TITLE
Elaborate on the constraints Mapping and SubMapping work under

### DIFF
--- a/lib/propolis/src/vmm/mem.rs
+++ b/lib/propolis/src/vmm/mem.rs
@@ -300,7 +300,7 @@ impl PhysMap {
 /// When emulating hardware in service of a VM we are often working with raw
 /// pointers into guest memory. `Mapping` and [`SubMapping`] together provide
 /// safe (in the Rust sense) operators to read and write guest memory, with
-/// escape hatches in some cases `Mapping` cannot directly support.
+/// escape hatches in some cases which `Mapping` cannot directly support.
 ///
 /// In general, the guest into which this `Mapping` points is assumed to be
 /// running and concurrently reading or writing all of its address space. For
@@ -314,9 +314,9 @@ impl PhysMap {
 /// # Safety
 ///
 /// Rust references of guest memory are inappropriate:
-/// - if we had an immutable reference of guest memory, guest vCPUs or host
-///   hardware may concurrently write and violate that immutability.
-/// - if we had a mutable reference of guest memory, guest vCPUs or host
+/// - if we had an immutable reference of guest memory, then guest vCPUs or
+///   host hardware may concurrently write and violate that immutability.
+/// - if we had a mutable reference of guest memory, then guest vCPUs or host
 ///   hardware may concurrently write or read and violate the exclusivity of a
 ///   mutable reference.
 ///


### PR DESCRIPTION
Along the way I realized the copying in #985 is somewhat more obviously correct when written in terms of `SubMapping` operations, so move that along with the docs.

---

for some context, in writing https://github.com/oxidecomputer/propolis/pull/985#discussion_r2662990120 I realized part of how I took an indirect path to `copy_nonoverlapping` was because I'd looked at `SubMapping`, skimmed the doc comment on `Mapping`, and misread the note about references as _and reference must follow reference safety_ rather than _and it is impossible to construct references to guest memory_. so, this reworks the `Mapping` doc comment to talk a bit more about the niche it's mediating (and be more clear that `SubMapping` really is constrained in all those same ways)

as I wrote this I realized that there isn't any reason that `MappingExt` shouldn't be able to use the `SubMapping` methods that already do the Harder Work of safety reasoning, so I've cleaned that up some too.