### PR TITLE
Indicator should allow stopping instances at Init

### DIFF
--- a/lib/propolis/src/lifecycle.rs
+++ b/lib/propolis/src/lifecycle.rs
@@ -173,7 +173,7 @@ impl IndicatedState {
     const fn valid_transition(old: Self, new: Self) -> bool {
         use IndicatedState::*;
         match (old, new) {
-            (Init, Run) | (Init, Halt) => true,
+            (Init, Run) | (Init, Pause) => true,
             (Run, Pause) => true,
             (Pause, Run) | (Pause, Halt) => true,
             _ => false,

--- a/phd-tests/tests/src/server_state_machine.rs
+++ b/phd-tests/tests/src/server_state_machine.rs
@@ -30,6 +30,22 @@ async fn instance_start_stop_test(ctx: &Framework) {
 }
 
 #[phd_testcase]
+async fn instance_stop_unstarted_test(ctx: &Framework) {
+    let mut vm = ctx.spawn_default_vm("instance_stop_unstarted_test").await?;
+
+    vm.instance_ensure().await?;
+    let instance = vm.get().await?.instance;
+    assert_eq!(instance.state, InstanceState::Creating);
+
+    // At this point the VM is created and its resources are held as
+    // appropriate. Stopping the VM will cause propolis-server to destroy the
+    // VM, releasing those resources and getting the server ready for shutdown.
+    vm.stop().await?;
+    vm.wait_for_state(InstanceState::Destroyed, Duration::from_secs(60))
+        .await?;
+}
+
+#[phd_testcase]
 async fn instance_stop_causes_destroy_test(ctx: &Framework) {
     let mut vm =
         ctx.spawn_default_vm("instance_stop_causes_destroy_test").await?;


### PR DESCRIPTION
`lifecycle::Indicator` to date is only used for the virtio NIC, but `phd-tests` doesn't actually exercise that.. so, add an `Indicator` to `I440FxHostBrdige` as it is a component present at all times in all VMs, and glue it into Lifecycle as expected in any other application of Indicator.

With this, the new test to stop a created-but-not-started VM hangs and eventually fails with a timeout, and fixing the expected state transition in Indicator makes it pass. Incidentally, this exercises the rest of the state transitions, with various tests pausing or restarting VMs, migrating them, etc.

----

I'd pushed the patch and neglected to click the PR button :( this fixes #994.