### PR TITLE
ASpace should allow spaces with size 1

### DIFF
--- a/lib/propolis/src/util/aspace.rs
+++ b/lib/propolis/src/util/aspace.rs
@@ -49,9 +49,9 @@ impl<T> ASpace<T> {
     ///
     /// # Panics
     ///
-    /// - Panics if start >= end.
+    /// - Panics if start > end.
     pub const fn new(start: usize, end: usize) -> ASpace<T> {
-        assert!(start < end);
+        assert!(start <= end);
         Self { start, end, map: BTreeMap::new() }
     }
 
@@ -284,9 +284,13 @@ mod test {
     use super::*;
 
     #[test]
-    #[should_panic]
-    fn create_zero_size() {
-        let _s: ASpace<u32> = ASpace::new(0, 0);
+    fn create_one_elem() {
+        let mut s: ASpace<u32> = ASpace::new(0, 0);
+        s.register(0, 1, 0xaa)
+            .expect("can register an element in one-elem ASpace");
+        assert_eq!(s.register(0, 2, 0x11), Err(Error::OutOfRange));
+        assert_eq!(s.register(1, 2, 0x22), Err(Error::OutOfRange));
+        assert_eq!(s.region_at(0), Ok((0, 1, &0xaa)));
     }
     #[test]
     fn create_max() {


### PR DESCRIPTION
There was a test that explicitly rejected this, but because ASpace is inclusive it's actually fine for `start == end`. Adjust the test to use such a one-wide address space instead; it worked fine the whole time.

This (should?) fix https://github.com/oxidecomputer/propolis/issues/1019.

@dancrossnyc theoretically from my analysis in #1019 I believe any access to a VirtIO ISR should have immediately panic'd propolis, but I know we've both seen NICs work before and after landing #998. Do the two observations of "typically working Propolis" and "lazy-static initializer const-eval' to panic()" make sense to you? In particular, does it seem possible that a guest wouldn't touch this register except in some odd circumstance? The alternative to me seems like a guest OS/driver that we missed in testing which does touch this register when others don't?