### PR TITLE
Panic with a clear message if the viona API is too old

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -771,6 +771,12 @@ impl MachineInitializer<'_> {
             info!(self.log, "Creating vNIC {}", device_name);
             let bdf: pci::Bdf = nic.device_spec.pci_path.into();
 
+            if virtio::viona::api_version().expect("can query viona version")
+                < virtio::viona::ApiVersion::V6
+            {
+                panic!("Kernel viona API is too old; need >= V6");
+            }
+
             // Set viona device parameters if possible.
             //
             // The values chosen here are tuned to maximize performance when

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -1247,6 +1247,13 @@ fn setup_instance(
                         dev.options.get("vnic").unwrap().as_str().unwrap();
                     let bdf = bdf.unwrap();
 
+                    if hw::virtio::viona::api_version()
+                        .expect("can query viona version")
+                        < hw::virtio::viona::ApiVersion::V6
+                    {
+                        panic!("Kernel viona API is too old; need >= V6");
+                    }
+
                     let viona_params =
                         config::VionaDeviceParams::from_opts(&dev.options)
                             .expect("viona params are valid");


### PR DESCRIPTION
Currently if one runs propolis on a system which does not have a new
enough viona API, a stacktrace like this is generated.

    failed to enable promisc mode on vnic0: Os { code: 22, kind: InvalidInput, message: "Invalid argument" }
    called `Result::unwrap()` on an `Err` value: Os { code: 25, kind: Uncategorized, message: "Inappropriate ioctl for device" }
    stack backtrace:
       0: __rustc::rust_begin_unwind
       1: core::panicking::panic_fmt
       2: core::result::unwrap_failed
       3: propolis::hw::virtio::viona::PciVirtioViona::new_with_queue_sizes
       4: propolis::hw::virtio::viona::PciVirtioViona::new

Since we don't currently support anything older than the V6 API in
propolis we should at least produce a useful error message to the
operator. It would be possible to fall back to the older API if we
wish to implement that.
