### PR TITLE
do not adverstise Doorbell Buffer support for now

### DIFF
--- a/lib/propolis/src/hw/nvme/admin.rs
+++ b/lib/propolis/src/hw/nvme/admin.rs
@@ -463,6 +463,7 @@ impl NvmeCtrl {
         }
     }
 
+    #[allow(dead_code)]
     pub(super) fn acmd_doorbell_buf_cfg(
         &mut self,
         cmd: &cmds::DoorbellBufCfgCmd,


### PR DESCRIPTION
While we don't know the mechanism yet, issue #1008 seems to point in the direction of doorbell buffers as a reason that guests sometimes determine I/Os sometimes go uncompleted. For now, mainline propolis will hide the feature until we've figured out what (or whose!) issue this is.