### PR TITLE
Be more specific about version errors, raise min required viona API

### DIFF
--- a/lib/propolis/src/api_version.rs
+++ b/lib/propolis/src/api_version.rs
@@ -7,8 +7,14 @@ pub enum Error {
     #[error("IO Error")]
     Io(#[from] std::io::Error),
 
-    #[error("API version {0} did not match expectation {1}")]
-    Mismatch(u32, u32),
+    // Newer APIs are backwards compatible with older (for now?), so don't
+    // bother trying to express "we need a version before .." or any of that.
+    //
+    // Also assume that the component being versioned is either part of the OS
+    // or that the OS version is a decent proxy for it. Not necessarily true in
+    // general, but true for viona and bhyve.
+    #[error("API version {have} is not at or above {want}. OS is too old?")]
+    TooLow { have: u32, want: u32 },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/lib/propolis/src/vmm/mod.rs
+++ b/lib/propolis/src/vmm/mod.rs
@@ -19,10 +19,10 @@ pub(crate) fn check_api_version() -> Result<(), crate::api_version::Error> {
     let vers = ctl.api_version()?;
 
     // propolis only requires the bits provided by V8, currently
-    let compare = bhyve_api::ApiVersion::V8;
+    let want = bhyve_api::ApiVersion::V8 as u32;
 
-    if vers < compare {
-        return Err(crate::api_version::Error::Mismatch(vers, compare as u32));
+    if vers < want {
+        return Err(crate::api_version::Error::TooLow { have: vers, want });
     }
 
     Ok(())


### PR DESCRIPTION
The recent multiqueue work includes an unconditional ioctl that was introduced in V6 of the viona API. Propolis' expectation should have been raised then, but it was missed in review; instead, trying to create a vNIC on a too-old OS results in propolis panicking about `Inappropriate ioctl for device`.

So, raise the minimum viona API as required. propolis-server will exit at start if the OS is too old.

The message wasn't super clear though, complaining that:

> viona API version mismatch 4 != 6

so this comes with some adjustments to the version error reporting that now produce this error on a too-old host:

>    0: checking version of viona
>    1: API version 4 is not at or above 6. OS is too old?

propolis-standalone allows you to try running something on a too-old host on the expectation you're actively hacking on either the host or Propolis, so it just offers

> ERRO viona: API version 4 is not at or above 6. OS is too old?

before continuing on (and in this case, panicking about the an inappropriate ioctl).

--

this ended up not being really derived off of #1022 much at all so it's a distinct PR rather than a force push over @citrus-it's `vionaver` :grin: 