### PR TITLE
viona: reset device more completely

### DIFF
--- a/lib/propolis/src/hw/virtio/queue.rs
+++ b/lib/propolis/src/hw/virtio/queue.rs
@@ -1005,6 +1005,15 @@ impl VirtQueues {
         self.queues[..len].iter().chain([self.get_control()])
     }
 
+    /// Iterate all queues, regardless of the device's current configuration
+    /// happening to use them or not.
+    ///
+    /// This is primarily useful for operations like device reset and teardown
+    /// where we need to manage all *possible* device state.
+    pub fn iter_all(&self) -> impl std::iter::Iterator<Item = &Arc<VirtQueue>> {
+        self.queues.iter()
+    }
+
     pub fn export(&self) -> migrate::VirtQueuesV1 {
         let len = self.len() as u64;
         let queues = self.queues.iter().map(|q| q.export()).collect();


### PR DESCRIPTION
~~when I reboot a Debian 13 guest the NIC works again, but judging by viona.d output I think it's by.. accident? The reboot `SET_PAIRS 0xb` still returns 0x10 (EBUSY), and there's no `SET_USEPAIRS 0xb`. instead, there's a `SET_USEPAIRS 0x1`?~~ I think what I was seeing is that the guest negotiates multi-queue, configures the queues, then sets features again with the same bits (including MQ). We then try to SET_PAIRS to viona again but the queues are already out of reset because the guest just set them up. So our SET_PAIRS to the same value we'd set before fails, we don't SET_USEPAIRS to the same value again, and things continue "happily". This happens on first boot too, I just didn't see it above all the `RING_SET_MSI` and such.

@dancrossnyc suggested that it would be better to have a method on `VirtQueues` to go reset all the viona rings regardless of what `VirtQueues.len()` happens to be, which works out well.

I noticed along the way that we don't SET_PAIRS back down to 1 on reset. I think in the case that a guest would boot with a legacy driver, reconfigure the NIC for multiqueue, then reboot to a legacy driver (I'm thinking iPXE -> Linux -> reboot as a hypothesis), the driver would be pretty confused? So I'm SET_PAIRS and SET_USEPAIRS back to 1 on reset to get closer to the initial device state.