### PR TITLE
PHD: make `lshw_lifecycle_test` actually do that on Alpine

### DIFF
--- a/phd-tests/tests/src/hw.rs
+++ b/phd-tests/tests/src/hw.rs
@@ -7,8 +7,8 @@ use phd_testcase::*;
 
 #[phd_testcase]
 async fn lspci_lifecycle_test(ctx: &Framework) {
-    const LSPCI: &str = "sudo lspci -vvx";
-    const LSHW: &str = "sudo lshw -notime";
+    const LSPCI: &str = "lspci -vvx";
+    const LSHW: &str = "lshw -notime";
 
     let mut vm = ctx
         .spawn_vm(&ctx.vm_config_builder("lspci_lifecycle_test"), None)


### PR DESCRIPTION
That PHD test `lshw_lifecycle_test`, which starts a VM, runs `lspci`
and `lshw`, stops, and restarts the VM, and asserts that the output of 
those commands on the original and subsequent VM are the same. This is
intended to demonstrate that guest devices are not arbitrarily scrambled
after restarting the guest, which is important.

Fortunately for us, when running PHD tests with Alpine Linux as the
guest OS (as we do on CI), the output of those commands on the initial
and subsequent guests are, in fact, the same.

Unfortunately, however, the output is:

```console
localhost:~# stty -F `tty` cols 9999
localhost:~# sudo lspci -vvx
-ash: sudo: not found
localhost:~# sudo lshw -notime
-ash: sudo: not found
```

Which, as you can see, _does_ in fact successfully demonstrate that both
guests are seeing the same PCIe devices and such. :)

Yeah.

That sucks lol.

This commit fixes that by removing the `sudo`, which doth not exist on
Alpine Linux without having installed it. We don't actually need `sudo`
on Alpine, since we log in as root anyway, [which is the correct and
proper thing to do on linux][1].

This should be fine when running the tests with other Linuces as the
guest OS, since the very first thing the `GuestOs` implementation for
Ubuntu 22.04, does is [to immediately `sudo bash` to become root
immediately][2], and the Debian 11 one [also does the morally correct
thing and logs in as root][3].

Fixes #1036

[1]: https://loginasroot.net/linux_root_login_faq
[2]: https://github.com/oxidecomputer/propolis/blob/21b3da87b70b4342eb22d861eedb083c32cf08b7/phd-tests/framework/src/guest_os/ubuntu22_04.rs#L20-L21
[3]: https://github.com/oxidecomputer/propolis/blob/21b3da87b70b4342eb22d861eedb083c32cf08b7/phd-tests/framework/src/guest_os/debian11_nocloud.rs#L13-L17