### PR TITLE
awful (2): prevent alloc elimination and size better

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -686,6 +686,11 @@ impl MachineInitializer<'_> {
                     &mut wanted_heap,
                 )
                 .await?;
+            info!(
+                self.log,
+                "raised balloon size";
+                "ballon_size" => wanted_heap
+            );
 
             self.block_backends.insert(backend_id.clone(), backend.clone());
             let block_dev: Arc<dyn block::Device> = match device_interface {


### PR DESCRIPTION
I'd tested the commit introducing this hack with one additional detail I'd overlooked: an `eprintln!("balloon: {:p}", balloon.as_ptr())`. This prevented rustc/LLVM from optimizing out the allocation. Of course, it would be unsightly to have a random `eprintln!()` committed so I removed that in the PR, not realizing the allocation was optimized out entirely.

Along the way testing on a racklette had one VM where the heap grew to ~450 MiB, beyond the ~350 MiB the balloon would have gotten things. So grow the constant earmark a bit. RFD 413 estimates Propolis heap as 512 MiB at worst, versus the balloon's worst case of ~483 MiB (on top of the baseline 30 MiB or so of heap, so a bunch of VMs with 11 local disks are a bit more than budgeted. RFD 413 doesn't think too hard about "what if there are 256 propolises" so the whole area is a bit weird.)

I've surgically swapped this into London where `fill.fio` has been running for about 30 minutes without issue, and from here I'll let it keep going!