### PR TITLE
viona: only reset in-range queues

### DIFF
--- a/lib/propolis/src/hw/virtio/queue.rs
+++ b/lib/propolis/src/hw/virtio/queue.rs
@@ -971,15 +971,12 @@ impl VirtQueues {
         }
         self.len.store(len, Ordering::Release);
         let mut peak = self.peak.load(Ordering::Acquire);
-        loop {
-            if len <= peak {
-                break;
-            }
+        while len > peak {
             match self.peak.compare_exchange(
                 peak,
                 len,
-                Ordering::SeqCst,
-                Ordering::SeqCst,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
             ) {
                 Ok(_) => {
                     // We've updated the peak, all done


### PR DESCRIPTION
45af0f7 was too eager to reset rings. by resetting all rings regardless of previous SET_PAIRS, any RING_RESET beyond that point would EINVAL. Propolis then tracks that ring state as VRingState::Fatal, at which point operations like VqChange::Addresss immediately give up. I don't follow exactly how this turns into a non-functional NIC from the guest perspective, but Propolis is clearly operating viona incorrectly here.

I don't understand what is different about the Ubuntu 24.04 I'm using versus the one we saw this issue on. By tracing viona operations with viona.d it's quite clear that something in the image on mb-0 is resetting the device before (during?) Linux booting, and that is not at all happening locally. In both cases the kernels are 6.8, but the patch levels are slightly different: the problematic image is 6.8.0-94-generic versus my 6.8.0-88-generic.

Without this tracking of which rings are eligible *for* reset, that first device reset effectively bricks the NIC for the guest.

None of my Ubuntu 24.04, 22.04, or Debian 13 images have this behavior, which is upsetting in its own right. For good measure, I've checked this change on FreeBSD 14.1 and a relatively recent helios as well. At least as far as my (apparently well-behaved??) images go, the viona NIC functions at boot, after a reboot, can seemingly do TCP without issue, etc.

My test Windows image has not had functional networking since the VirtIO/multiqueue work landed, and is at least not *less* functional now. It's not clear if that's a my-image problem or a Propolis problem.