### PR TITLE
viona: do not retain peak nqueues across device reset

### DIFF
--- a/lib/propolis/src/hw/virtio/mod.rs
+++ b/lib/propolis/src/hw/virtio/mod.rs
@@ -252,4 +252,8 @@ mod probes {
     fn virtio_vq_notify(virtio_dev_addr: u64, virtqueue_id: u16) {}
     fn virtio_vq_pop(vq_addr: u64, desc_idx: u16, avail_idx: u16) {}
     fn virtio_vq_push(vq_addr: u64, used_idx: u16, used_len: u32) {}
+
+    fn virtio_viona_mq_set_use_pairs(cause: u8, npairs: u16) {}
+
+    fn virtio_device_needs_reset() {}
 }

--- a/lib/propolis/src/hw/virtio/pci.rs
+++ b/lib/propolis/src/hw/virtio/pci.rs
@@ -1072,6 +1072,11 @@ impl PciVirtioState {
         _dev: &dyn VirtioDevice,
         state: &mut MutexGuard<VirtioState>,
     ) {
+        // TODO: would be *great* to know which device needs a reset.. compare
+        // with device_id in nvme and how we can give out per-device IDs when
+        // setting things up.
+        probes::virtio_device_needs_reset!(|| ());
+
         if !state.status.contains(Status::NEEDS_RESET) {
             state.status.insert(Status::NEEDS_RESET);
             // XXX: interrupt needed?

--- a/lib/propolis/src/hw/virtio/queue.rs
+++ b/lib/propolis/src/hw/virtio/queue.rs
@@ -1003,6 +1003,11 @@ impl VirtQueues {
         self.peak.load(Ordering::Relaxed)
     }
 
+    pub fn reset_peak(&self) {
+        let current = self.len.load(Ordering::Relaxed);
+        self.peak.store(current, Ordering::Relaxed);
+    }
+
     pub const fn max_capacity(&self) -> usize {
         self.queues.len()
     }


### PR DESCRIPTION
1df49a4, also, was too eager to reset viona rings. the issue here is more subtle.

the "peak" count for used virtqueues was retained across device resets, so if a guest ever negotiates multiqueue, resets the NIC as for reboot (where we SET_PAIRS down to 1), and then does a virtio reset with the `device_status` register, we'll try to reset all queues even though the pairs after 1 are not actually in use. this EINVAL's and we get the device into `NEEDS_RESET`.