### PR TITLE
viona: Fix swapped RX/TX queue sizes.

### DIFF
--- a/lib/propolis/src/hw/virtio/viona.rs
+++ b/lib/propolis/src/hw/virtio/viona.rs
@@ -319,8 +319,8 @@ impl PciVirtioViona {
     ) -> io::Result<Arc<PciVirtioViona>> {
         Self::new_with_queue_sizes(
             vnic_name,
-            TX_QUEUE_SIZE,
             RX_QUEUE_SIZE,
+            TX_QUEUE_SIZE,
             CTL_QUEUE_SIZE,
             vm,
             viona_params,


### PR DESCRIPTION
Fixes #1055.

Before:
```
testvm:~# ethtool -g eth0
Ring parameters for eth0:
Pre-set maximums:
RX:             256
RX Mini:        n/a
RX Jumbo:       n/a
TX:             2048
Current hardware settings:
RX:             256
RX Mini:        n/a
RX Jumbo:       n/a
TX:             2048
```

After:
```
testvm:~# ethtool -g eth0
Ring parameters for eth0:
Pre-set maximums:
RX:             2048
RX Mini:        n/a
RX Jumbo:       n/a
TX:             256
Current hardware settings:
RX:             2048
RX Mini:        n/a
RX Jumbo:       n/a
TX:             256
```