### PR TITLE
Metrics for crucible disks

### DIFF
--- a/lib/propolis/src/block/attachment.rs
+++ b/lib/propolis/src/block/attachment.rs
@@ -179,12 +179,12 @@ impl QueueCollection {
     }
     fn set_metric_consumer(&self, consumer: Arc<dyn MetricConsumer>) {
         let mut state = self.state.lock().unwrap();
-        state.metric_consumer = Some(consumer.clone());
         for queue in self.queues.iter() {
             if let Some(minder) = queue.state.lock().unwrap().minder.as_ref() {
                 minder.set_metric_consumer(consumer.clone());
             }
         }
+        state.metric_consumer = Some(consumer);
     }
     fn associated_qids(&self) -> Versioned<Bitmap> {
         self.state.lock().unwrap().associated_qids


### PR DESCRIPTION
  Crucible disk metrics were missing because `set_metric_consumer` was called on a `DeviceAttachment` before Crucible's queues were associated with it. The original implementation only walked the already-associated queues and handed the consumer to each one's `QueueMinder`.  Any queue that arrived late simply never received it.

  The fix stores the `MetricConsumer` in `QueueColState` (the collection-level state guarded by the collection's mutex), then in `queue_associate` propagates it to any newly-arriving queue's minder before the minder is installed into the slot. This mirrors exactly how the paused flag is already propagated to late-associating queues. 

A minor correctness fix:  `as_mut()` -> `as_ref()` on the minder Option
was also included, since `set_metric_consumer` takes `&self`.