### PR TITLE
nvme: deadlock enabling doorbell buffer while doing I/O

### DIFF
--- a/lib/propolis/src/hw/nvme/queue.rs
+++ b/lib/propolis/src/hw/nvme/queue.rs
@@ -113,7 +113,13 @@ struct QueueState<QS> {
     /// a `SubQueueState` for a Submission Queue.
     inner: Mutex<QueueInner<QS>>,
 
-    pub acc_mem: MemAccessor,
+    /// This queue's memory accessor node.
+    ///
+    /// Be careful about lock ordering when using this accessor; access_borrow()
+    /// holds this node's lock. If a user of this queue state requires both
+    /// `access_borrow()` and `QueueInner`, the protocol is to lock queue
+    /// state first and this accessor second.
+    acc_mem: MemAccessor,
 }
 impl<QS> QueueState<QS> {
     fn new(size: u32, acc_mem: MemAccessor, inner: QS) -> Self {
@@ -649,9 +655,8 @@ impl SubQueue {
     pub fn pop(
         self: &Arc<SubQueue>,
     ) -> Option<(GuestData<SubmissionQueueEntry>, Permit, u16)> {
-        // Lock the SubQueueState early to order consistently with MemAccessor;
-        // in all cases we acquire the queue state lock before working with
-        // memory.
+        // Lock the SubQueueState early to conform to lock ordering requirement;
+        // see docs on QueueState::acc_mem.
         let mut state = self.state.lock();
 
         let Some(mem) = self.state.acc_mem.access_borrow() else { return None };


### PR DESCRIPTION
9a3a93a introduced a bug in the previously-okay SubQueue::pop; before, acc_mem.access() would go through MemAccessor, acquire a reference on the underlying MemCtx (an Arc refcount bump), drop the lock, and continue. immediately after, SubQueue::pop would lock the SubQueue's state and actually perform the pop.

this ordering is backwards from set_db_buf, which locks the SubQueue's state *then* conditionally performs acc_mem.access() if the buffer is set up as part of an import.

after 9a3a93a, SubQueue::pop uses access_borrowed() to avoid contention on the refcount for MemCtx, the cost of retaining the lock on the SubQueue's MemAccessor node while taking the lock on the same queue's SubQueueState. at this point a concurrent SubQueue::pop and SubQueue::set_db_buf could deadlock; one holds the queue state lock, the other holds the accessor node lock, and both will try to take the other.

resolve this tension by picking a consistent ordering for the SubQueue state and acc_mem locks: SubQueueState first, then acc_mem.{access,_borrow}(). this was already the ordering in CompQueue::push and set_db_buf, so pop() gets the trivial change.

this fixes https://github.com/oxidecomputer/propolis/issues/1035 as experienced in https://github.com/oxidecomputer/propolis/runs/66881499333 but I'm left _very_ confused; why did this only come up after @hawkw switched to running these tests on the lab Gimlet? this issue has been present since the commit was landed on Jan 9, and we'd been testing Propolis on Cosmos with it for at least a few weeks before.