### PR TITLE
Want vsock packet dtrace probes

### DIFF
--- a/lib/propolis/src/hw/virtio/vsock.rs
+++ b/lib/propolis/src/hw/virtio/vsock.rs
@@ -19,6 +19,7 @@ use crate::vmm::MemCtx;
 use crate::vsock::packet::VsockPacket;
 use crate::vsock::packet::VsockPacketError;
 use crate::vsock::packet::VsockPacketHeader;
+use crate::vsock::probes;
 use crate::vsock::proxy::VsockPortMapping;
 use crate::vsock::GuestCid;
 use crate::vsock::VsockBackend;
@@ -84,6 +85,7 @@ impl RxPermit<'_> {
             });
         }
 
+        probes::vsock_pkt_rx!(|| header);
         queue.push_used(&mut chain, &mem);
     }
 }

--- a/lib/propolis/src/vsock/mod.rs
+++ b/lib/propolis/src/vsock/mod.rs
@@ -55,3 +55,13 @@ pub enum VsockError {
 pub trait VsockBackend: Send + Sync + 'static {
     fn queue_notify(&self, queue_id: u16) -> Result<(), VsockError>;
 }
+
+#[usdt::provider(provider = "propolis")]
+mod probes {
+    use crate::vsock::packet::VsockPacketHeader;
+
+    /// Host->Guest
+    fn vsock_pkt_rx(hdr: &VsockPacketHeader) {}
+    /// Guest->Host
+    fn vsock_pkt_tx(hdr: &VsockPacketHeader) {}
+}

--- a/lib/propolis/src/vsock/packet.rs
+++ b/lib/propolis/src/vsock/packet.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use serde::{Serialize, Serializer};
 use strum::FromRepr;
 use zerocopy::byteorder::little_endian::{U16, U32, U64};
 use zerocopy::{FromBytes, Immutable, IntoBytes};
@@ -11,7 +12,7 @@ use crate::vsock::{GuestCid, VSOCK_HOST_CID};
 
 bitflags! {
     /// Shutdown flags for VIRTIO_VSOCK_OP_SHUTDOWN
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
     #[repr(transparent)]
     pub struct VsockPacketFlags: u32 {
         const VIRTIO_VSOCK_SHUTDOWN_F_RECEIVE = 1 << 0;
@@ -19,7 +20,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Clone, Copy, FromRepr, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, FromRepr, PartialEq, Eq, Serialize)]
 #[repr(u16)]
 pub enum VsockSocketType {
     Stream = 1,
@@ -52,7 +53,7 @@ pub enum VsockPacketError {
     InvalidDstCid { dst_cid: u64 },
 }
 
-#[derive(Clone, Copy, Debug, FromRepr, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, FromRepr, Eq, PartialEq, Serialize)]
 #[repr(u16)]
 pub enum VsockPacketOp {
     Request = 1,
@@ -88,6 +89,28 @@ pub struct VsockPacketHeader {
     flags: U32,
     buf_alloc: U32,
     fwd_cnt: U32,
+}
+
+// NB: This implementation is here to support dtrace usdt probes.
+impl Serialize for VsockPacketHeader {
+    fn serialize<S: Serializer>(
+        &self,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut s = serializer.serialize_struct("VsockPacketHeader", 10)?;
+        s.serialize_field("src_cid", &self.src_cid.get())?;
+        s.serialize_field("dst_cid", &self.dst_cid.get())?;
+        s.serialize_field("src_port", &self.src_port.get())?;
+        s.serialize_field("dst_port", &self.dst_port.get())?;
+        s.serialize_field("len", &self.len.get())?;
+        s.serialize_field("socket_type", &self.socket_type())?;
+        s.serialize_field("op", &self.op())?;
+        s.serialize_field("flags", &self.flags())?;
+        s.serialize_field("buf_alloc", &self.buf_alloc.get())?;
+        s.serialize_field("fwd_cnt", &self.fwd_cnt.get())?;
+        s.end()
+    }
 }
 
 impl VsockPacketHeader {

--- a/lib/propolis/src/vsock/poller.rs
+++ b/lib/propolis/src/vsock/poller.rs
@@ -22,6 +22,7 @@ use crate::hw::virtio::vsock::VSOCK_TX_QUEUE;
 use crate::vsock::packet::VsockPacket;
 use crate::vsock::packet::VsockPacketFlags;
 use crate::vsock::packet::VsockSocketType;
+use crate::vsock::probes;
 use crate::vsock::proxy::ConnKey;
 use crate::vsock::proxy::VsockPortMapping;
 use crate::vsock::proxy::VsockProxyConn;
@@ -302,6 +303,7 @@ impl VsockPoller {
                 }
             };
 
+            probes::vsock_pkt_tx!(|| &packet.header);
             // If the packet is not destined for the host drop it.
             if packet.header.dst_cid() != VSOCK_HOST_CID {
                 warn!(


### PR DESCRIPTION
We want the ability to trace packet flows from guest<-->host.
```
❯ pfexec dtrace -Zqn 'propolis*:::vsock_pkt_* {printf("%s\n\n", json(copyinstr(arg0), "ok"));}'  | jq
{
  "src_cid": 16,
  "dst_cid": 2,
  "src_port": 3308370434,
  "dst_port": 2222,
  "len": 0,
  "socket_type": "Stream",
  "op": "Request",
  "flags": "",
  "buf_alloc": 262144,
  "fwd_cnt": 0
}
{
  "src_cid": 2,
  "dst_cid": 16,
  "src_port": 2222,
  "dst_port": 3308370434,
  "len": 0,
  "socket_type": "Stream",
  "op": "Response",
  "flags": "",
  "buf_alloc": 131072,
  "fwd_cnt": 0
}
{
  "src_cid": 16,
  "dst_cid": 2,
  "src_port": 3308370434,
  "dst_port": 2222,
  "len": 22,
  "socket_type": "Stream",
  "op": "ReadWrite",
  "flags": "",
  "buf_alloc": 262144,
  "fwd_cnt": 0
}
{
  "src_cid": 2,
  "dst_cid": 16,
  "src_port": 2222,
  "dst_port": 3308370434,
  "len": 22,
  "socket_type": "Stream",
  "op": "ReadWrite",
  "flags": "",
  "buf_alloc": 131072,
  "fwd_cnt": 22
}
{
  "src_cid": 16,
  "dst_cid": 2,
  "src_port": 3308370434,
  "dst_port": 2222,
  "len": 0,
  "socket_type": "Stream",
  "op": "CreditUpdate",
  "flags": "",
  "buf_alloc": 262144,
  "fwd_cnt": 22
}
..... snip ......
{
  "src_cid": 16,
  "dst_cid": 2,
  "src_port": 3308370434,
  "dst_port": 2222,
  "len": 96,
  "socket_type": "Stream",
  "op": "ReadWrite",
  "flags": "",
  "buf_alloc": 262144,
  "fwd_cnt": 5278
}
{
  "src_cid": 16,
  "dst_cid": 2,
  "src_port": 3308370434,
  "dst_port": 2222,
  "len": 0,
  "socket_type": "Stream",
  "op": "Shutdown",
  "flags": "VIRTIO_VSOCK_SHUTDOWN_F_SEND",
  "buf_alloc": 262144,
  "fwd_cnt": 5278
}
{
  "src_cid": 16,
  "dst_cid": 2,
  "src_port": 3308370434,
  "dst_port": 2222,
  "len": 0,
  "socket_type": "Stream",
  "op": "Shutdown",
  "flags": "VIRTIO_VSOCK_SHUTDOWN_F_RECEIVE | VIRTIO_VSOCK_SHUTDOWN_F_SEND",
  "buf_alloc": 262144,
  "fwd_cnt": 5278
}
{
  "src_cid": 2,
  "dst_cid": 16,
  "src_port": 2222,
  "dst_port": 3308370434,
  "len": 0,
  "socket_type": "Stream",
  "op": "Reset",
  "flags": "",
  "buf_alloc": 131072,
  "fwd_cnt": 0
}
{
  "src_cid": 16,
  "dst_cid": 2,
  "src_port": 3308370434,
  "dst_port": 2222,
  "len": 0,
  "socket_type": "Stream",
  "op": "Reset",
  "flags": "",
  "buf_alloc": 262144,
  "fwd_cnt": 5278
}

```