### PR TITLE
Add project and silo ids to VM attestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10106,7 +10106,7 @@ dependencies = [
 [[package]]
 name = "vm-attest"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vm-attest?rev=2cdd17580a4fc6c871d24797016af8dbaac9421d#2cdd17580a4fc6c871d24797016af8dbaac9421d"
+source = "git+https://github.com/oxidecomputer/vm-attest?rev=acd6ca808d3b081d89b713d64dbce14ba7a50aec#acd6ca808d3b081d89b713d64dbce14ba7a50aec"
 dependencies = [
  "anyhow",
  "attest-data",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,25 +283,6 @@ dependencies = [
 [[package]]
 name = "attest-data"
 version = "0.5.0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=1d3084b514389847e8e0f5d966d2be4f18d02d32#1d3084b514389847e8e0f5d966d2be4f18d02d32"
-dependencies = [
- "const-oid",
- "der",
- "getrandom 0.3.4",
- "hex",
- "hubpack",
- "rats-corim",
- "salty",
- "serde",
- "serde_with",
- "sha3",
- "static_assertions",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "attest-data"
-version = "0.5.0"
 source = "git+https://github.com/oxidecomputer/dice-util?rev=d7472bfa91aee859c3fe0bdc1dbb1e320285228e#d7472bfa91aee859c3fe0bdc1dbb1e320285228e"
 dependencies = [
  "const-oid",
@@ -1790,10 +1771,10 @@ dependencies = [
 [[package]]
 name = "dice-verifier"
 version = "0.3.0-pre0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=1d3084b514389847e8e0f5d966d2be4f18d02d32#1d3084b514389847e8e0f5d966d2be4f18d02d32"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=d7472bfa91aee859c3fe0bdc1dbb1e320285228e#d7472bfa91aee859c3fe0bdc1dbb1e320285228e"
 dependencies = [
  "async-trait",
- "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?rev=1d3084b514389847e8e0f5d966d2be4f18d02d32)",
+ "attest-data",
  "const-oid",
  "ed25519-dalek",
  "env_logger",
@@ -1805,29 +1786,6 @@ dependencies = [
  "sha3",
  "sled-agent-client",
  "sled-agent-types-versions",
- "slog",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "x509-cert",
-]
-
-[[package]]
-name = "dice-verifier"
-version = "0.3.0-pre0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=d7472bfa91aee859c3fe0bdc1dbb1e320285228e#d7472bfa91aee859c3fe0bdc1dbb1e320285228e"
-dependencies = [
- "async-trait",
- "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?rev=d7472bfa91aee859c3fe0bdc1dbb1e320285228e)",
- "const-oid",
- "ed25519-dalek",
- "env_logger",
- "hex",
- "hubpack",
- "log",
- "p384",
- "rats-corim",
- "sha3",
  "slog",
  "tempfile",
  "thiserror 2.0.18",
@@ -6475,7 +6433,7 @@ dependencies = [
  "crossbeam-channel",
  "crucible",
  "crucible-client-types 0.1.0 (git+https://github.com/oxidecomputer/crucible?rev=ae1da83e66c648574827298f4bc444632bf4d047)",
- "dice-verifier 0.3.0-pre0 (git+https://github.com/oxidecomputer/dice-util?rev=1d3084b514389847e8e0f5d966d2be4f18d02d32)",
+ "dice-verifier",
  "dladm",
  "dlpi 0.2.0 (git+https://github.com/oxidecomputer/dlpi-sys?branch=main)",
  "erased-serde 0.4.5",
@@ -10151,9 +10109,9 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/vm-attest?rev=deaf0203ecfa8cbe8c0c28c9bd16645d5d7be4e8#deaf0203ecfa8cbe8c0c28c9bd16645d5d7be4e8"
 dependencies = [
  "anyhow",
- "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?rev=d7472bfa91aee859c3fe0bdc1dbb1e320285228e)",
+ "attest-data",
  "const-oid",
- "dice-verifier 0.3.0-pre0 (git+https://github.com/oxidecomputer/dice-util?rev=d7472bfa91aee859c3fe0bdc1dbb1e320285228e)",
+ "dice-verifier",
  "ed25519-dalek",
  "getrandom 0.3.4",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "attest-data"
+version = "0.5.0"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=d7472bfa91aee859c3fe0bdc1dbb1e320285228e#d7472bfa91aee859c3fe0bdc1dbb1e320285228e"
+dependencies = [
+ "const-oid",
+ "der",
+ "getrandom 0.3.4",
+ "hex",
+ "hubpack",
+ "rats-corim",
+ "salty",
+ "serde",
+ "serde_with",
+ "sha3",
+ "static_assertions",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,7 +1793,7 @@ version = "0.3.0-pre0"
 source = "git+https://github.com/oxidecomputer/dice-util?rev=1d3084b514389847e8e0f5d966d2be4f18d02d32#1d3084b514389847e8e0f5d966d2be4f18d02d32"
 dependencies = [
  "async-trait",
- "attest-data",
+ "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?rev=1d3084b514389847e8e0f5d966d2be4f18d02d32)",
  "const-oid",
  "ed25519-dalek",
  "env_logger",
@@ -1786,6 +1805,29 @@ dependencies = [
  "sha3",
  "sled-agent-client",
  "sled-agent-types-versions",
+ "slog",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "x509-cert",
+]
+
+[[package]]
+name = "dice-verifier"
+version = "0.3.0-pre0"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=d7472bfa91aee859c3fe0bdc1dbb1e320285228e#d7472bfa91aee859c3fe0bdc1dbb1e320285228e"
+dependencies = [
+ "async-trait",
+ "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?rev=d7472bfa91aee859c3fe0bdc1dbb1e320285228e)",
+ "const-oid",
+ "ed25519-dalek",
+ "env_logger",
+ "hex",
+ "hubpack",
+ "log",
+ "p384",
+ "rats-corim",
+ "sha3",
  "slog",
  "tempfile",
  "thiserror 2.0.18",
@@ -6433,7 +6475,7 @@ dependencies = [
  "crossbeam-channel",
  "crucible",
  "crucible-client-types 0.1.0 (git+https://github.com/oxidecomputer/crucible?rev=ae1da83e66c648574827298f4bc444632bf4d047)",
- "dice-verifier",
+ "dice-verifier 0.3.0-pre0 (git+https://github.com/oxidecomputer/dice-util?rev=1d3084b514389847e8e0f5d966d2be4f18d02d32)",
  "dladm",
  "dlpi 0.2.0 (git+https://github.com/oxidecomputer/dlpi-sys?branch=main)",
  "erased-serde 0.4.5",
@@ -10106,12 +10148,12 @@ dependencies = [
 [[package]]
 name = "vm-attest"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vm-attest?rev=acd6ca808d3b081d89b713d64dbce14ba7a50aec#acd6ca808d3b081d89b713d64dbce14ba7a50aec"
+source = "git+https://github.com/oxidecomputer/vm-attest?rev=deaf0203ecfa8cbe8c0c28c9bd16645d5d7be4e8#deaf0203ecfa8cbe8c0c28c9bd16645d5d7be4e8"
 dependencies = [
  "anyhow",
- "attest-data",
+ "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?rev=d7472bfa91aee859c3fe0bdc1dbb1e320285228e)",
  "const-oid",
- "dice-verifier",
+ "dice-verifier 0.3.0-pre0 (git+https://github.com/oxidecomputer/dice-util?rev=d7472bfa91aee859c3fe0bdc1dbb1e320285228e)",
  "ed25519-dalek",
  "getrandom 0.3.4",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ crucible = { git = "https://github.com/oxidecomputer/crucible", rev = "ae1da83e6
 crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev = "ae1da83e66c648574827298f4bc444632bf4d047" }
 
 # Attestation
-dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "1d3084b514389847e8e0f5d966d2be4f18d02d32", features = ["sled-agent"] }
+dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "d7472bfa91aee859c3fe0bdc1dbb1e320285228e", features = ["sled-agent"] }
 vm-attest = { git = "https://github.com/oxidecomputer/vm-attest", rev = "deaf0203ecfa8cbe8c0c28c9bd16645d5d7be4e8", default-features = false }
 
 # External dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev
 
 # Attestation
 dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "1d3084b514389847e8e0f5d966d2be4f18d02d32", features = ["sled-agent"] }
-vm-attest = { git = "https://github.com/oxidecomputer/vm-attest", rev = "acd6ca808d3b081d89b713d64dbce14ba7a50aec", default-features = false }
+vm-attest = { git = "https://github.com/oxidecomputer/vm-attest", rev = "deaf0203ecfa8cbe8c0c28c9bd16645d5d7be4e8", default-features = false }
 
 # External dependencies
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ crucible-client-types = { git = "https://github.com/oxidecomputer/crucible", rev
 
 # Attestation
 dice-verifier = { git = "https://github.com/oxidecomputer/dice-util", rev = "1d3084b514389847e8e0f5d966d2be4f18d02d32", features = ["sled-agent"] }
-vm-attest = { git = "https://github.com/oxidecomputer/vm-attest", rev = "2cdd17580a4fc6c871d24797016af8dbaac9421d", default-features = false }
+vm-attest = { git = "https://github.com/oxidecomputer/vm-attest", rev = "acd6ca808d3b081d89b713d64dbce14ba7a50aec", default-features = false }
 
 # External dependencies
 anyhow = "1.0"

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -703,6 +703,13 @@ impl MachineInitializer<'_> {
         let project = self.properties.metadata.project_id;
         let silo = self.properties.metadata.silo_id;
 
+        let vm_attestation_conf = vm_attest::VmInstanceConf {
+            uuid,
+            project,
+            silo,
+            boot_digest: None,
+        };
+
         // The first boot entry is a key into `self.spec.disks`, which is how
         // we'll get to a Crucible volume backing this boot option.
         let boot_disk_entry =
@@ -783,7 +790,7 @@ impl MachineInitializer<'_> {
             None
         };
 
-        vm_rot.prepare_instance_conf(uuid, project, silo, boot_backend);
+        vm_rot.prepare_init_state(vm_attestation_conf, boot_backend);
 
         Ok(())
     }

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -700,6 +700,8 @@ impl MachineInitializer<'_> {
         vm_rot: &mut AttestationSock,
     ) -> Result<(), MachineInitError> {
         let uuid = self.properties.id;
+        let project = self.properties.metadata.project_id;
+        let silo = self.properties.metadata.silo_id;
 
         // The first boot entry is a key into `self.spec.disks`, which is how
         // we'll get to a Crucible volume backing this boot option.
@@ -781,7 +783,7 @@ impl MachineInitializer<'_> {
             None
         };
 
-        vm_rot.prepare_instance_conf(uuid, boot_backend);
+        vm_rot.prepare_instance_conf(uuid, project, silo, boot_backend);
 
         Ok(())
     }

--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -790,7 +790,7 @@ impl MachineInitializer<'_> {
             None
         };
 
-        vm_rot.prepare_init_state(vm_attestation_conf, boot_backend);
+        vm_rot.measure_instance(vm_attestation_conf, boot_backend);
 
         Ok(())
     }

--- a/lib/propolis/src/attestation/server.rs
+++ b/lib/propolis/src/attestation/server.rs
@@ -67,7 +67,14 @@ impl AttestationSockInit {
     /// Do any any remaining work of collecting VM RoT measurements in support
     /// of this VM's attestation server.
     pub async fn run(self) {
-        let AttestationSockInit { log, vm_conf_send, uuid, project, silo, boot_backend_ref } = self;
+        let AttestationSockInit {
+            log,
+            vm_conf_send,
+            uuid,
+            project,
+            silo,
+            boot_backend_ref,
+        } = self;
 
         let mut vm_conf = vm_attest::VmInstanceConf {
             uuid,

--- a/lib/propolis/src/attestation/server.rs
+++ b/lib/propolis/src/attestation/server.rs
@@ -57,9 +57,7 @@ enum AttestationInitState {
 pub struct AttestationSockInit {
     log: slog::Logger,
     vm_conf_send: oneshot::Sender<VmInstanceConf>,
-    uuid: uuid::Uuid,
-    project: uuid::Uuid,
-    silo: uuid::Uuid,
+    vm_instance_conf: vm_attest::VmInstanceConf,
     boot_backend_ref: Option<boot_digest::Backend>,
 }
 
@@ -70,18 +68,9 @@ impl AttestationSockInit {
         let AttestationSockInit {
             log,
             vm_conf_send,
-            uuid,
-            project,
-            silo,
+            mut vm_instance_conf,
             boot_backend_ref,
         } = self;
-
-        let mut vm_conf = vm_attest::VmInstanceConf {
-            uuid,
-            project,
-            silo,
-            boot_digest: None,
-        };
 
         if let Some(digest_backend) = boot_backend_ref {
             let boot_digest = match crate::attestation::boot_digest::compute(
@@ -102,12 +91,12 @@ impl AttestationSockInit {
                 }
             };
 
-            vm_conf.boot_digest = Some(boot_digest);
+            vm_instance_conf.boot_digest = Some(boot_digest);
         } else {
             slog::warn!(log, "not computing boot disk digest");
         }
 
-        let send_res = vm_conf_send.send(vm_conf);
+        let send_res = vm_conf_send.send(vm_instance_conf);
         if let Err(_) = send_res {
             slog::error!(
                 log,
@@ -284,11 +273,9 @@ impl AttestationSock {
         Ok(())
     }
 
-    pub fn prepare_instance_conf(
+    pub fn prepare_init_state(
         &mut self,
-        uuid: uuid::Uuid,
-        project: uuid::Uuid,
-        silo: uuid::Uuid,
+        vm_instance_conf: vm_attest::VmInstanceConf,
         boot_backend_ref: Option<boot_digest::Backend>,
     ) {
         let init_state = std::mem::replace(
@@ -306,11 +293,9 @@ impl AttestationSock {
         };
         let init = AttestationSockInit {
             log: self.log.clone(),
-            uuid,
-            project,
-            silo,
             boot_backend_ref,
             vm_conf_send,
+            vm_instance_conf,
         };
         let init_task = tokio::spawn(init.run());
         self.init_state = AttestationInitState::Running { init_task };

--- a/lib/propolis/src/attestation/server.rs
+++ b/lib/propolis/src/attestation/server.rs
@@ -69,7 +69,12 @@ impl AttestationSockInit {
     pub async fn run(self) {
         let AttestationSockInit { log, vm_conf_send, uuid, project, silo, boot_backend_ref } = self;
 
-        let mut vm_conf = vm_attest::VmInstanceConf { uuid, project, silo, boot_digest: None };
+        let mut vm_conf = vm_attest::VmInstanceConf {
+            uuid,
+            project,
+            silo,
+            boot_digest: None,
+        };
 
         if let Some(digest_backend) = boot_backend_ref {
             let boot_digest = match crate::attestation::boot_digest::compute(

--- a/lib/propolis/src/attestation/server.rs
+++ b/lib/propolis/src/attestation/server.rs
@@ -58,6 +58,8 @@ pub struct AttestationSockInit {
     log: slog::Logger,
     vm_conf_send: oneshot::Sender<VmInstanceConf>,
     uuid: uuid::Uuid,
+    project: uuid::Uuid,
+    silo: uuid::Uuid,
     boot_backend_ref: Option<boot_digest::Backend>,
 }
 
@@ -65,10 +67,9 @@ impl AttestationSockInit {
     /// Do any any remaining work of collecting VM RoT measurements in support
     /// of this VM's attestation server.
     pub async fn run(self) {
-        let AttestationSockInit { log, vm_conf_send, uuid, boot_backend_ref } =
-            self;
+        let AttestationSockInit { log, vm_conf_send, uuid, project, silo, boot_backend_ref } = self;
 
-        let mut vm_conf = vm_attest::VmInstanceConf { uuid, boot_digest: None };
+        let mut vm_conf = vm_attest::VmInstanceConf { uuid, project, silo, boot_digest: None };
 
         if let Some(digest_backend) = boot_backend_ref {
             let boot_digest = match crate::attestation::boot_digest::compute(
@@ -274,6 +275,8 @@ impl AttestationSock {
     pub fn prepare_instance_conf(
         &mut self,
         uuid: uuid::Uuid,
+        project: uuid::Uuid,
+        silo: uuid::Uuid,
         boot_backend_ref: Option<boot_digest::Backend>,
     ) {
         let init_state = std::mem::replace(
@@ -292,6 +295,8 @@ impl AttestationSock {
         let init = AttestationSockInit {
             log: self.log.clone(),
             uuid,
+            project,
+            silo,
             boot_backend_ref,
             vm_conf_send,
         };

--- a/lib/propolis/src/attestation/server.rs
+++ b/lib/propolis/src/attestation/server.rs
@@ -273,7 +273,7 @@ impl AttestationSock {
         Ok(())
     }
 
-    pub fn prepare_init_state(
+    pub fn measure_instance(
         &mut self,
         vm_instance_conf: vm_attest::VmInstanceConf,
         boot_backend_ref: Option<boot_digest::Backend>,
@@ -286,7 +286,7 @@ impl AttestationSock {
             AttestationInitState::Preparing { vm_conf_send } => vm_conf_send,
             other => {
                 panic!(
-                    "VM RoT used incorrectly: prepare_instance_conf called \
+                    "VM RoT used incorrectly: measure_instance called \
                         more than once. current state {other:?}"
                 );
             }


### PR DESCRIPTION
This relies on [vm-attest#68](https://github.com/oxidecomputer/vm-attest/pull/68) to add support for including the project and silo ids in the VM instance configuration data provided by attestations. These PRs are meant as discussion points, and not intended to be merged yet. This change allows upstream callers to make richer policy decisions as project and silo ids are likely to be much more stable than VM ids. For instance if we are rolling deployments we may bring up multiple VMs and move IPs between them to roll a release forwards or backwards. It would be a lot of coordination to propagate that value to all of the policy deciders during a deploy when what we would really want is to specify a policy for all VMs in a project (or possibly with a tag in a future world).

There is not much interesting going on outside of piping the ids through. That said, it makes the API for `prepare_instance_conf` pretty nasty as we are passing three opaque Uuids that rely on their order to be correct. Happy to change this to something like a builder or some other pattern to avoid errors.

The primary focus of this PR though is to discuss if this the correct path to passing the data to the attestation. Notably we do **not** provide any access to sled metadata so as to split this conversion from concerns about exposing placement data.