### PR TITLE
virtio: tolerate importing queues with adjusted size

### DIFF
--- a/lib/propolis/src/hw/virtio/pci.rs
+++ b/lib/propolis/src/hw/virtio/pci.rs
@@ -1326,7 +1326,7 @@ impl MigrateMulti for PciVirtioState {
         state.msix_queue_vec = dev.msix_queue_vec;
         self.isr_state.import(dev.isr_queue, dev.isr_cfg);
 
-        self.queues.import(&input.queues)?;
+        self.queues.import(&input.queues, state.mode)?;
 
         Ok(())
     }

--- a/lib/propolis/src/hw/virtio/queue.rs
+++ b/lib/propolis/src/hw/virtio/queue.rs
@@ -14,6 +14,7 @@ use super::probes;
 use super::{VirtioIntr, VqIntr};
 use crate::accessors::MemAccessor;
 use crate::common::*;
+use crate::hw::virtio;
 use crate::migrate::MigrateStateError;
 use crate::vmm::MemCtx;
 
@@ -614,6 +615,7 @@ impl VirtQueue {
     pub fn import(
         &self,
         state: &migrate::VirtQueueV1,
+        mode: virtio::Mode,
     ) -> Result<(), MigrateStateError> {
         let mut avail = self.avail.lock().unwrap();
         let mut used = self.used.lock().unwrap();
@@ -624,18 +626,48 @@ impl VirtQueue {
                 self.id, state.id,
             )));
         }
-        if self.size() != state.size {
-            return Err(MigrateStateError::ImportFailed(format!(
-                "VirtQueue: mismatched size {} vs {}",
-                self.size(),
-                state.size,
-            )));
+        if mode == virtio::Mode::Legacy {
+            // As VirtIO 1.0 notes, for a device operated as legacy,
+            //
+            // > There was no mechanism to negotiate the queue size.
+            //
+            // so if these sizes don't match, the payload is truly incompatible
+            // with this device.
+            if self.size() != state.size {
+                return Err(MigrateStateError::ImportFailed(format!(
+                    "VirtQueue: mismatched size {} vs {}",
+                    self.size(),
+                    state.size,
+                )));
+            }
+        } else {
+            // Otherwise, we expect to import into a freshly-created VirtIO PCI
+            // device, with queues all set to their maximum sizes. The sizes to
+            // import may be smaller if the guest OS's driver configured them
+            // down.
+            let mut queue_size = self.size.lock().unwrap();
+            if queue_size.0.get() < state.size {
+                return Err(MigrateStateError::ImportFailed(format!(
+                    "VirtQueue: larger than supported {} > {}",
+                    queue_size.0.get(),
+                    state.size,
+                )));
+            }
+            let new_size = match VqSize::try_from(state.size) {
+                Ok(size) => size,
+                Err(e) => {
+                    return Err(MigrateStateError::ImportFailed(format!(
+                        "VirtQueue: unacceptable queue size: {}",
+                        e
+                    )));
+                }
+            };
+            *queue_size = new_size;
         }
         if self.notify_data != state.notify_data {
             return Err(MigrateStateError::ImportFailed(format!(
                 "VirtQueue: mismatched notify data {} vs {}",
-                self.size(),
-                state.size,
+                self.notify_data, state.notify_data,
             )));
         }
 
@@ -1054,9 +1086,10 @@ impl VirtQueues {
     pub fn import(
         &self,
         state: &migrate::VirtQueuesV1,
+        mode: virtio::Mode,
     ) -> Result<(), MigrateStateError> {
         for (vq, vq_input) in self.queues.iter().zip(state.queues.iter()) {
-            vq.import(vq_input)?;
+            vq.import(vq_input, mode)?;
         }
         self.set_len(state.len as usize).map_err(|len| {
             MigrateStateError::ImportFailed(format!(

--- a/lib/propolis/src/hw/virtio/viona.rs
+++ b/lib/propolis/src/hw/virtio/viona.rs
@@ -1444,12 +1444,17 @@ mod test {
         VIRTIO_NET_F_STATUS,
     };
     use crate::hw::virtio::PciVirtioViona;
+    use crate::migrate::{
+        MigrateCtx, MigrateMulti, PayloadOffer, PayloadOffers, PayloadOutputs,
+    };
     use crate::Machine;
     use std::env::VarError;
     use std::sync::Arc;
     use tokio::process::Command;
 
     struct TestCtx {
+        test_name: &'static str,
+        vnic_name: String,
         machine: Machine,
         dev: Arc<PciVirtioViona>,
     }
@@ -1465,9 +1470,63 @@ mod test {
         fn create_driver(&self) -> VirtioNetDriver<'_, '_> {
             VirtioNetDriver::for_hardware(&self.machine, &self.dev)
         }
+
+        fn migrate(self) -> TestCtx {
+            let mut dev_payloads = PayloadOutputs::new();
+            let acc_mem =
+                self.machine.acc_mem.access().expect("machine has memory");
+            let ctx = MigrateCtx { mem: &acc_mem };
+            <PciVirtioViona>::export(&self.dev, &mut dev_payloads, &ctx)
+                .expect("can export PciVirtioViona");
+            let mut payloads = Vec::new();
+            for output in dev_payloads.into_iter() {
+                let bytes = serde_json::to_string(&output.payload)
+                    .expect("serializing payload output");
+                let serialized = (output.kind, output.version, bytes);
+                payloads.push(serialized);
+            }
+
+            // Loosely follow the structure of `import_device` as `propolis-server` would; the
+            // combination of type erasure and borrows make this somewhat more complicated than it
+            // would ideally be..
+            let mut desers = Vec::new();
+            for (_, _, bytes) in payloads.iter() {
+                desers.push(serde_json::Deserializer::from_str(&bytes));
+            }
+            let mut offers = Vec::new();
+            for ((kind, version, _bytes), deser) in
+                payloads.iter().zip(desers.iter_mut())
+            {
+                let deserialized =
+                    Box::new(<dyn erased_serde::Deserializer>::erase(deser));
+                offers.push(PayloadOffer {
+                    kind,
+                    version: *version,
+                    payload: deserialized,
+                });
+            }
+            let mut offers = PayloadOffers::new(offers);
+
+            let vnic_name = self.vnic_name.clone();
+            let test_name = self.test_name;
+
+            std::mem::drop(acc_mem);
+            std::mem::drop(self);
+
+            let new_ctx = create_test_ctx(test_name, &vnic_name);
+            let acc_mem = new_ctx
+                .machine
+                .acc_mem
+                .access()
+                .expect("new machine has memory");
+            let new_migrate = MigrateCtx { mem: &acc_mem };
+            <PciVirtioViona>::import(&new_ctx.dev, &mut offers, &new_migrate)
+                .expect("can import PciVirtioViona");
+            new_ctx
+        }
     }
 
-    fn create_test_ctx(test_name: &str, vnic_name: &str) -> TestCtx {
+    fn create_test_ctx(test_name: &'static str, vnic_name: &str) -> TestCtx {
         // Create the VM with `force: true`: if we're running tests concurrently
         // this will trample an existing test (which should then fail!). We do
         // this so that if a test misconfiguration left a stray old VM hanging
@@ -1513,7 +1572,12 @@ mod test {
             None,
         );
 
-        TestCtx { machine, dev: viona_dev }
+        TestCtx {
+            machine,
+            dev: viona_dev,
+            test_name,
+            vnic_name: vnic_name.to_owned(),
+        }
     }
 
     /// Glue for a nicer test interface to read/write a specific structure in a
@@ -1653,13 +1717,42 @@ mod test {
         dev: &'nic PciVirtioViona,
         common_config: BarAccessor<'nic>,
         device_config: BarAccessor<'nic>,
+        state: DriverState,
+    }
+
+    /// The "volatile" part of `VirtioNetDriver`: whatever "guest-side" part
+    /// should remain constant when tests migrate the corresponding
+    /// `PciVirtioViona`.
+    //
+    // Theoretically this state could live in the test VM, but that would
+    // require "migrating" guest memory, which is more work than is strictly
+    // necessary to test the de vice. On top of that it's a bit annoying to
+    // fulfill "driver memory" as reads/writes into the test VM, so we don't.
+    struct DriverState {
         next_queue_gpa: u64,
+    }
+
+    impl DriverState {
+        fn new() -> Self {
+            Self {
+                // Start virtio-nic queues somewhere other than address 0.
+                next_queue_gpa: 2 * MB as u64,
+            }
+        }
     }
 
     impl<'mach, 'nic> VirtioNetDriver<'mach, 'nic> {
         fn for_hardware(
             machine: &'mach Machine,
             dev: &'nic PciVirtioViona,
+        ) -> Self {
+            Self::import(machine, dev, DriverState::new())
+        }
+
+        fn import(
+            machine: &'mach Machine,
+            dev: &'nic PciVirtioViona,
+            state: DriverState,
         ) -> Self {
             // We place virtio_pci_common_cfg at BAR 2, offset 0, so hardcode this
             // in the test for now.
@@ -1675,13 +1768,11 @@ mod test {
             let device_config =
                 BarAccessor::at(dev, pci::BarN::BAR2, PAGE_SIZE);
 
-            Self {
-                machine,
-                dev,
-                common_config,
-                device_config,
-                next_queue_gpa: 2 * MB as u64,
-            }
+            Self { machine, dev, common_config, device_config, state }
+        }
+
+        fn export(self) -> DriverState {
+            self.state
         }
 
         fn read_status(&self) -> Status {
@@ -1738,7 +1829,7 @@ mod test {
             let acc_mem =
                 self.machine.acc_mem.access().expect("can access memory");
 
-            let descriptor_table_gpa = self.next_queue_gpa;
+            let descriptor_table_gpa = self.state.next_queue_gpa;
             self.common_config
                 .write_le64(common_cfg::queue_desc, descriptor_table_gpa);
 
@@ -1763,7 +1854,7 @@ mod test {
 
             // Finally, round up so the next queue (if there is one) starts
             // page-aligned like it should.
-            self.next_queue_gpa = used_gpa.next_multiple_of(page_u64);
+            self.state.next_queue_gpa = used_gpa.next_multiple_of(page_u64);
 
             let msi_vector = 0x100 + queue;
             self.common_config
@@ -1906,7 +1997,7 @@ mod test {
         }
     }
 
-    fn test_device_status_writes(test_ctx: &TestCtx) {
+    fn test_device_status_writes(test_ctx: TestCtx) -> TestCtx {
         // The device and driver collaborate via `device_status` to get the
         // device turned on. There's a subtlety here though, in VirtIO 1.2
         // section 2.1.2:
@@ -1971,9 +2062,11 @@ mod test {
         // We should not be able to clear NEEDS_RESET without .. a reset.
         let real_status = driver.read_status();
         assert!(real_status.contains(Status::NEEDS_RESET));
+
+        test_ctx
     }
 
-    fn basic_operation_modern(test_ctx: &TestCtx) {
+    fn basic_operation_modern(test_ctx: TestCtx) -> TestCtx {
         let expected_feats =
             VIRTIO_NET_F_MAC | VIRTIO_NET_F_STATUS | VIRTIO_NET_F_CTRL_VQ;
 
@@ -2005,9 +2098,11 @@ mod test {
         driver.modern_device_init(expected_feats);
         let mut driver = test_ctx.create_driver();
         driver.modern_device_init(expected_feats);
+
+        test_ctx
     }
 
-    fn basic_operation_multiqueue(test_ctx: &TestCtx) {
+    fn basic_operation_multiqueue(test_ctx: TestCtx) -> TestCtx {
         // All the same operation as `basic_operation_modern`, but with
         // `VIRTIO_NET_F_MQ`.
         let expected_feats = VIRTIO_NET_F_MAC
@@ -2026,11 +2121,13 @@ mod test {
         driver.modern_device_init(expected_feats);
         let mut driver = test_ctx.create_driver();
         driver.modern_device_init(expected_feats);
+
+        test_ctx
     }
 
     /// Roughly approximation of a MQ-capable OS restarting, booting through
     /// with a simple single-queue driver, then booting back to a MQ-capable OS.
-    fn multiqueue_to_singlequeue_to_multiqueue(test_ctx: &TestCtx) {
+    fn multiqueue_to_singlequeue_to_multiqueue(test_ctx: TestCtx) -> TestCtx {
         // All the same operation as `basic_operation_modern`, but with
         // `VIRTIO_NET_F_MQ`.
         let expected_feats =
@@ -2043,12 +2140,39 @@ mod test {
         driver.modern_device_init(expected_feats);
         let mut driver = test_ctx.create_driver();
         driver.modern_device_init(expected_feats | VIRTIO_NET_F_MQ);
+
+        test_ctx
+    }
+
+    /// The same operations as `multiqueue_to_singlequeue_to_multiqueue`, above,
+    /// but migrate the device between each operation.
+    fn multiqueue_migration(test_ctx: TestCtx) -> TestCtx {
+        // All the same operation as `basic_operation_modern`, but with
+        // `VIRTIO_NET_F_MQ`.
+        let expected_feats =
+            VIRTIO_NET_F_MAC | VIRTIO_NET_F_STATUS | VIRTIO_NET_F_CTRL_VQ;
+
+        let mut driver = test_ctx.create_driver();
+        driver.modern_device_init(expected_feats | VIRTIO_NET_F_MQ);
+        crate::lifecycle::Lifecycle::reset(test_ctx.dev.as_ref());
+        let drv_state = driver.export();
+        let test_ctx = test_ctx.migrate();
+        let mut driver = VirtioNetDriver::import(
+            &test_ctx.machine,
+            &test_ctx.dev,
+            drv_state,
+        );
+        driver.modern_device_init(expected_feats);
+        let mut driver = test_ctx.create_driver();
+        driver.modern_device_init(expected_feats | VIRTIO_NET_F_MQ);
+
+        test_ctx
     }
 
     // Bears an uncanny resemblance to `phd-test`...
     struct TestCase {
         name: &'static str,
-        test_fn: fn(&TestCtx),
+        test_fn: fn(TestCtx) -> TestCtx,
     }
 
     async fn create_vnic(phys_nic: &str, vnic_name: &str) {
@@ -2100,6 +2224,7 @@ mod test {
             testcase!(basic_operation_modern),
             testcase!(basic_operation_multiqueue),
             testcase!(multiqueue_to_singlequeue_to_multiqueue),
+            testcase!(multiqueue_migration),
         ];
 
         let underlying_nic = match std::env::var("VIONA_TEST_NIC") {
@@ -2137,7 +2262,7 @@ mod test {
                 create_vnic(&underlying_nic, TEST_VNIC).await;
 
                 let test_ctx = create_test_ctx(test.name, TEST_VNIC);
-                (test.test_fn)(&test_ctx);
+                let test_ctx = (test.test_fn)(test_ctx);
                 drop(test_ctx);
 
                 delete_vnic(TEST_VNIC).await;


### PR DESCRIPTION
Legacy VirtIO devices did not have a mechanism to negotiate queue size, so we very strictly requred imported virtqueues to have the same size as the freshly-created queues for that device. If they didn't match, the old device state is simply not importable.

In transitional and modern VirtIO interfaces, there is a writable `queue_size` register, and we faithfully allow guests to configure queue sizes; the initial sizes are the maximums we support for a VirtIO device, and guests can pick a smaller number if they're so inclined.

My test virtio-nic driver set a relatively low but fixed queue size out of laziness (this made laying out memory a little more straightforward). Trying to migrate a device that driver has configured fails because queue import is overly-strict.

This bug seems pretty unlikely to hit in practice, because afaict guest OSes will just go with the maximum queue sizes we offer, but we should tolerate it.

I'm trying to reproduce a bug I see in Linux but I don't fully understand, and tripped across this along the way. The search continues..