### PR TITLE
wait for viona Poller to run before declaring device running

### DIFF
--- a/lib/propolis/src/hw/virtio/viona.rs
+++ b/lib/propolis/src/hw/virtio/viona.rs
@@ -668,7 +668,10 @@ impl PciVirtioViona {
     fn poller_start(&self) {
         let mut inner = self.inner.lock().unwrap();
         let poller = inner.poller.as_mut().expect("poller should be spawned");
+        let wait_state = poller.state.clone();
         let _ = poller.sender.send(TargetState::Run);
+        drop(inner);
+        wait_state.wait_running();
     }
     fn poller_stop(&self, should_exit: bool) {
         let mut inner = self.inner.lock().unwrap();
@@ -689,7 +692,7 @@ impl PciVirtioViona {
     // Transition the emulation to a "running" state, either at initial start-up
     // or resumption from a "paused" state.
     fn run(&self) {
-        self.poller_start();
+        tokio::task::block_in_place(|| self.poller_start());
         if self.queues_restart().is_err() {
             self.virtio_state.set_needs_reset(self);
             self.notify_port_update(None);
@@ -1247,6 +1250,10 @@ impl PollerState {
         let guard = self.running.lock().unwrap();
         let _res = self.cv.wait_while(guard, |g| *g).unwrap();
     }
+    fn wait_running(&self) {
+        let guard = self.running.lock().unwrap();
+        let _res = self.cv.wait_while(guard, |g| !*g).unwrap();
+    }
     fn set_stopped(&self) {
         let mut guard = self.running.lock().unwrap();
         if *guard {
@@ -1256,7 +1263,10 @@ impl PollerState {
     }
     fn set_running(&self) {
         let mut guard = self.running.lock().unwrap();
-        *guard = true;
+        if !*guard {
+            *guard = true;
+            self.cv.notify_all();
+        }
     }
 }
 
@@ -1444,6 +1454,7 @@ mod test {
         VIRTIO_NET_F_STATUS,
     };
     use crate::hw::virtio::PciVirtioViona;
+    use crate::lifecycle::Lifecycle;
     use crate::migrate::{
         MigrateCtx, MigrateMulti, PayloadOffer, PayloadOffers, PayloadOutputs,
     };
@@ -1461,8 +1472,8 @@ mod test {
 
     impl Drop for TestCtx {
         fn drop(&mut self) {
-            crate::lifecycle::Lifecycle::pause(self.dev.as_ref());
-            crate::lifecycle::Lifecycle::halt(self.dev.as_ref());
+            Lifecycle::pause(self.dev.as_ref());
+            Lifecycle::halt(self.dev.as_ref());
         }
     }
 
@@ -1522,6 +1533,8 @@ mod test {
             let new_migrate = MigrateCtx { mem: &acc_mem };
             <PciVirtioViona>::import(&new_ctx.dev, &mut offers, &new_migrate)
                 .expect("can import PciVirtioViona");
+            Lifecycle::start(new_ctx.dev.as_ref())
+                .expect("can start viona device");
             new_ctx
         }
     }
@@ -2088,7 +2101,7 @@ mod test {
         // `Lifecycle::reset` is the kind of reset that occurs when a VM is
         // restarted. Do that now, as if the guest rebooted, triple faulted,
         // etc.
-        crate::lifecycle::Lifecycle::reset(test_ctx.dev.as_ref());
+        Lifecycle::reset(test_ctx.dev.as_ref());
 
         // After a reset, reinit the device as if through OVMF->bootloader->OS
         // again..
@@ -2114,7 +2127,7 @@ mod test {
         driver.modern_device_init(expected_feats);
         let mut driver = test_ctx.create_driver();
         driver.modern_device_init(expected_feats);
-        crate::lifecycle::Lifecycle::reset(test_ctx.dev.as_ref());
+        Lifecycle::reset(test_ctx.dev.as_ref());
         let mut driver = test_ctx.create_driver();
         driver.modern_device_init(expected_feats);
         let mut driver = test_ctx.create_driver();
@@ -2135,7 +2148,7 @@ mod test {
 
         let mut driver = test_ctx.create_driver();
         driver.modern_device_init(expected_feats | VIRTIO_NET_F_MQ);
-        crate::lifecycle::Lifecycle::reset(test_ctx.dev.as_ref());
+        Lifecycle::reset(test_ctx.dev.as_ref());
         let mut driver = test_ctx.create_driver();
         driver.modern_device_init(expected_feats);
         let mut driver = test_ctx.create_driver();
@@ -2154,7 +2167,16 @@ mod test {
 
         let mut driver = test_ctx.create_driver();
         driver.modern_device_init(expected_feats | VIRTIO_NET_F_MQ);
-        crate::lifecycle::Lifecycle::reset(test_ctx.dev.as_ref());
+
+        let drv_state = driver.export();
+        let test_ctx = test_ctx.migrate();
+        let driver = VirtioNetDriver::import(
+            &test_ctx.machine,
+            &test_ctx.dev,
+            drv_state,
+        );
+        Lifecycle::reset(test_ctx.dev.as_ref());
+
         let drv_state = driver.export();
         let test_ctx = test_ctx.migrate();
         let mut driver = VirtioNetDriver::import(
@@ -2163,7 +2185,14 @@ mod test {
             drv_state,
         );
         driver.modern_device_init(expected_feats);
-        let mut driver = test_ctx.create_driver();
+
+        let drv_state = driver.export();
+        let test_ctx = test_ctx.migrate();
+        let mut driver = VirtioNetDriver::import(
+            &test_ctx.machine,
+            &test_ctx.dev,
+            drv_state,
+        );
         driver.modern_device_init(expected_feats | VIRTIO_NET_F_MQ);
 
         test_ctx
@@ -2208,7 +2237,7 @@ mod test {
     #[test]
     #[cfg_attr(not(target_os = "illumos"), ignore)]
     fn run_viona_tests() {
-        let rt = tokio::runtime::Builder::new_current_thread()
+        let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .unwrap();
@@ -2262,6 +2291,8 @@ mod test {
                 create_vnic(&underlying_nic, TEST_VNIC).await;
 
                 let test_ctx = create_test_ctx(test.name, TEST_VNIC);
+                Lifecycle::start(test_ctx.dev.as_ref())
+                    .expect("can start viona device");
                 let test_ctx = (test.test_fn)(test_ctx);
                 drop(test_ctx);
 

--- a/lib/propolis/src/hw/virtio/viona.rs
+++ b/lib/propolis/src/hw/virtio/viona.rs
@@ -671,7 +671,12 @@ impl PciVirtioViona {
         let wait_state = poller.state.clone();
         let _ = poller.sender.send(TargetState::Run);
         drop(inner);
-        wait_state.wait_running();
+        // wait_running() will wait on a condition variable, but the signaller
+        // of that condition variable is the Poller task that we've also spawned
+        // on this runtime. `block_in_place` to avoid blocking this runtime
+        // thread and help make sure the Poller we've asked to start actually
+        // can.
+        tokio::task::block_in_place(|| wait_state.wait_running());
     }
     fn poller_stop(&self, should_exit: bool) {
         let mut inner = self.inner.lock().unwrap();
@@ -686,13 +691,14 @@ impl PciVirtioViona {
             poller.state.clone()
         };
         drop(inner);
-        wait_state.wait_stopped();
+        // Same general problem as `wait_running` in `poller_start` above.
+        tokio::task::block_in_place(|| wait_state.wait_stopped());
     }
 
     // Transition the emulation to a "running" state, either at initial start-up
     // or resumption from a "paused" state.
     fn run(&self) {
-        tokio::task::block_in_place(|| self.poller_start());
+        self.poller_start();
         if self.queues_restart().is_err() {
             self.virtio_state.set_needs_reset(self);
             self.notify_port_update(None);


### PR DESCRIPTION
When `Lifecycle::run()` completes, the device should be fully running. `PciVirtioViona` did not uphold this, as `run()` would return after having asked the poller to start, but before confirming it *was* started. If the device was paused shortly after, the poller may have never actually started. `running` would not be set, and "pause" would immediately succeed only for the Poller to begin running shortly after!

Worse, the device may be halted and the underlying link connected to the viona fd may have been destroyed, all while the poller was starting. At this point the `AsyncFd::with_interest()` will fail with ENXIO and panic the poller task.

This is another "never happens in practice" bug. But in unit tests that rapidly set up a viona device, configure it, and tear it down, this is quite consistently hit.

Working backwards from the ENXIO, I eventually ended up at the following to diagnose what specifically was causing the ENXIO:
```
> cat debug.d
fbt::viona_chpoll:entry {
  self->interested = 1;
  printf("chpoll");
}

fbt::ddi_get_soft_state:return / self->interested / {
  printf("ss->link: %p", ((viona_soft_state_t*)arg1)->ss_link);
}
```

(note this currently merges into #1117 but is kinda independent except that I noticed it as part of writing up #1117)