### PR TITLE
improve slog component setting

### DIFF
--- a/bin/propolis-server/src/lib/vm/mod.rs
+++ b/bin/propolis-server/src/lib/vm/mod.rs
@@ -611,9 +611,11 @@ impl Vm {
             };
 
             let vm_for_driver = self.clone();
+            let base_log = log.clone();
             guard.driver = Some(tokio::spawn(async move {
                 state_driver::ensure_vm_and_launch_driver(
                     log_for_driver,
+                    base_log,
                     vm_for_driver,
                     external_publisher,
                     ensure_request,

--- a/bin/propolis-server/src/lib/vm/state_driver.rs
+++ b/bin/propolis-server/src/lib/vm/state_driver.rs
@@ -390,6 +390,7 @@ pub(super) struct StateDriverOutput {
 /// [`StateDriverOutput`] contains appropriate state for a failed VM.
 pub(super) async fn ensure_vm_and_launch_driver(
     log: slog::Logger,
+    base_log: slog::Logger,
     vm: Arc<super::Vm>,
     mut state_publisher: StatePublisher,
     ensure_request: VmEnsureRequest,
@@ -398,7 +399,7 @@ pub(super) async fn ensure_vm_and_launch_driver(
 ) -> StateDriverOutput {
     let ensure_options = Arc::new(ensure_options);
     let activated_vm = match ensure_active_vm(
-        &log,
+        &base_log,
         &vm,
         &mut state_publisher,
         &ensure_request,


### PR DESCRIPTION
In slog, you can set multiple values for the same key, and slog will just append them on to the end of the log record.
However, when the log is printed, we only show the first key and value and ignore the rest.

In propolis we had pretty early set:
```
log.new(slog::o!("component" => "vm_state_driver"));
```

We pass that log down to a bunch of other places, some of which we try to set component again:
```
slog::o!("component" => format!("crucible-{cru_id}")),
```
These later settings get dropped, so we end up with most of the logs having the `component` `vm_state_driver`.

Improving things a bit with this change, we can hold on to the base log and pass that down to children whom
will set their own component while sending the `vm_state_driver` log along for the places that are children
of it.  At least that was my best guess for where to split things out.  There could be more here to do, but this
at least got the problem I was trying to solve (crucible logs) and a few others as well

new component types that I did not see before:
```
21:59:33.211Z INFO propolis-server (vcpu_tasks): Starting vCPU thread vcpu = 0
21:59:33.205Z INFO propolis-server (attestation-server): attestation server created (sled-agent addr [fd9a:daae:107d:104::1]:12345 
21:59:33.325Z INFO propolis-server (oximeter-producer): listening
21:59:33.326Z INFO propolis-server (request_queue): enqueued external request
21:59:33.325Z INFO propolis-server (serial task): Entered serial task
```

These were all hidden behind the `vm_state_driver`