### PR TITLE
expand zerocopy IntoBytes/FromByes use in guest memory accesses

### DIFF
--- a/lib/propolis/src/hw/nvme/admin.rs
+++ b/lib/propolis/src/hw/nvme/admin.rs
@@ -16,6 +16,8 @@ use super::{
     cmds, NvmeCtrl, NvmeError, PciNvme, MAX_NUM_IO_QUEUES, MAX_NUM_QUEUES,
 };
 
+use zerocopy::IntoBytes;
+
 #[usdt::provider(provider = "propolis")]
 mod probes {
     fn nvme_abort(cid: u16, devsq_id: u64) {}
@@ -511,7 +513,7 @@ impl NvmeCtrl {
     /// The `data` type must be `repr(packed(1))`
     ///
     /// Returns `Some(())` if successful, else None
-    fn write_admin_result<T: Copy>(
+    fn write_admin_result<T: Copy + IntoBytes>(
         prp: cmds::PrpIter,
         data: &T,
         mem: &MemCtx,

--- a/lib/propolis/src/hw/nvme/bits.rs
+++ b/lib/propolis/src/hw/nvme/bits.rs
@@ -5,7 +5,7 @@
 #![allow(dead_code)]
 
 use bitstruct::bitstruct;
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, IntoBytes};
 
 /// A Submission Queue Entry as represented in memory.
 ///
@@ -105,7 +105,7 @@ impl SubmissionQueueEntry {
 /// A Completion Queue Entry as represented in memory.
 ///
 /// See NVMe 1.0e Section 4.5 Completion Queue Entry
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone, IntoBytes)]
 #[repr(C, packed(1))]
 pub struct CompletionQueueEntry {
     /// Dword 0 (DW0)
@@ -739,7 +739,7 @@ pub enum StatusCodeType {
 /// Describes the characteristics of a specific power state.
 ///
 /// See NVMe 1.0e Section 5.11, Figure 67 Identify - Power State Descriptor Data Structure
-#[derive(Default, Copy, Clone)]
+#[derive(Default, Copy, Clone, IntoBytes)]
 #[repr(C, packed(1))]
 pub struct PowerStateDescriptor {
     /// Maximum Power
@@ -797,7 +797,7 @@ bitstruct! {
     /// Queue Entry Size Required & Maximum (both Completion & Submission)
     ///
     /// Defines the required and maximum Queue entry sizes when using the NVM Command Set.
-    #[derive(Copy, Clone)]
+    #[derive(Copy, Clone, IntoBytes)]
     pub struct NvmQueueEntrySize(pub u8) {
         /// The required (minimum) Queue Entry Size.
         ///
@@ -818,7 +818,7 @@ bitstruct! {
 /// Describes the characteristics of the controller.
 ///
 /// See NVMe 1.0e Section 5.11, Figure 66 Identify - Identify Controller Data Structure
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, IntoBytes)]
 #[repr(C, packed(1))]
 pub struct IdentifyController {
     // bytes 0-255 - Controller Capabilities and Features
@@ -1050,7 +1050,7 @@ impl Default for IdentifyController {
 ///
 /// Describes a specific Logical Block Address (LBA) format.
 /// See NVMe 1.0e Section 5.11, Figure 69 Identify - LBA Format Data Structure, NVM Command Set Specific
-#[derive(Default, Copy, Clone)]
+#[derive(Default, Copy, Clone, IntoBytes)]
 #[repr(C, packed(1))]
 pub struct LbaFormat {
     /// Metadata Size (MS)
@@ -1079,7 +1079,7 @@ pub struct LbaFormat {
 /// Describes the characteristics of a namespace.
 ///
 /// See NVMe 1.0e Section 5.11, Figure 68 Identify - Identify Namespace Data Structure, NVM Command Set Specific
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, IntoBytes)]
 #[repr(C, packed(1))]
 pub struct IdentifyNamespace {
     /// Namespace Size (NSZE)

--- a/lib/propolis/src/hw/virtio/block.rs
+++ b/lib/propolis/src/hw/virtio/block.rs
@@ -22,6 +22,7 @@ use bits::*;
 
 use futures::future::BoxFuture;
 use lazy_static::lazy_static;
+use zerocopy::FromBytes;
 
 /// Sizing for virtio-block is specified in 512B sectors
 const SECTOR_SZ: usize = 512;
@@ -352,7 +353,7 @@ impl MigrateMulti for PciVirtioBlock {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, FromBytes)]
 #[repr(C)]
 struct VbReq {
     rtype: u32,
@@ -360,7 +361,7 @@ struct VbReq {
     sector: u64,
 }
 
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, FromBytes)]
 #[repr(C)]
 struct DiscardWriteZeroes {
     sector: u64,

--- a/lib/propolis/src/hw/virtio/p9fs.rs
+++ b/lib/propolis/src/hw/virtio/p9fs.rs
@@ -32,6 +32,7 @@ use p9ds::proto::{
     Tgetattr, Tlopen, Tread, Treaddir, Tstatfs, Twalk, Version,
 };
 use slog::{warn, Logger};
+use zerocopy::IntoBytes;
 
 /// This const is to add headroom into serialized P9 data packets. These packets
 /// go through a virtio transport. It's been observed with Linux guests that we
@@ -46,7 +47,7 @@ const P9FS_VIRTIO_READ_HEADROOM: usize = 20;
 // to the length of the vector and filling that vector is what we're
 // explicitly trying to avoid here.
 #[repr(C, packed)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, IntoBytes)]
 struct RreadHeader {
     size: u32,
     typ: u8,

--- a/lib/propolis/src/hw/virtio/queue.rs
+++ b/lib/propolis/src/hw/virtio/queue.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{fence, AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use bitflags::bitflags;
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, IntoBytes};
 
 use super::probes;
 use super::{VirtioIntr, VqIntr};
@@ -62,7 +62,7 @@ struct VqdDesc {
     next: u16,
 }
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, IntoBytes)]
 struct VqdUsed {
     id: u32,
     len: u32,
@@ -756,7 +756,11 @@ impl Chain {
         self.bufs.clear();
     }
 
-    pub fn read<T: Copy>(&mut self, item: &mut T, mem: &MemCtx) -> bool {
+    pub fn read<T: Copy + FromBytes>(
+        &mut self,
+        item: &mut T,
+        mem: &MemCtx,
+    ) -> bool {
         let item_sz = mem::size_of::<T>();
         if (self.read_stat.bytes_remain as usize) < item_sz {
             return false;
@@ -804,7 +808,11 @@ impl Chain {
         assert_eq!(remain, 0);
         Some(bufs)
     }
-    pub fn write<T: Copy>(&mut self, item: &T, mem: &MemCtx) -> bool {
+    pub fn write<T: Copy + IntoBytes>(
+        &mut self,
+        item: &T,
+        mem: &MemCtx,
+    ) -> bool {
         let item_sz = mem::size_of::<T>();
         if (self.write_stat.bytes_remain as usize) < item_sz {
             return false;

--- a/lib/propolis/src/hw/virtio/testutil.rs
+++ b/lib/propolis/src/hw/virtio/testutil.rs
@@ -12,7 +12,7 @@
 
 use std::sync::Arc;
 
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::accessors::MemAccessor;
 use crate::common::GuestAddr;
@@ -48,7 +48,7 @@ pub const fn align_up(val: u64, align: u64) -> u64 {
 
 /// 16-byte virtio descriptor, matching the on-wire/in-memory layout.
 #[repr(C)]
-#[derive(Copy, Clone, Default, FromBytes)]
+#[derive(Copy, Clone, Default, FromBytes, IntoBytes)]
 pub struct RawDesc {
     pub addr: u64,
     pub len: u32,

--- a/lib/propolis/src/hw/virtio/viona.rs
+++ b/lib/propolis/src/hw/virtio/viona.rs
@@ -72,13 +72,14 @@ mod probes {
 pub mod control {
     use super::ETHERADDRL;
     use std::convert::TryFrom;
+    use zerocopy::FromBytes;
 
     /// The control message header has two data: a u8 representing the "class"
     /// of control message, which describes what the message applies to, and a
     /// "command", which describes what action we should take in response to the
     /// command. So for example, class Mq and command Set means to set the
     /// number of multiqueue queue pairs.
-    #[derive(Clone, Copy, Debug, Default)]
+    #[derive(Clone, Copy, Debug, Default, FromBytes)]
     #[repr(C)]
     pub struct Header {
         class: u8,
@@ -141,7 +142,7 @@ pub mod control {
         mac: [u8; ETHERADDRL],
     }
 
-    #[derive(Clone, Copy, Debug, Default)]
+    #[derive(Clone, Copy, Debug, Default, FromBytes)]
     #[repr(C)]
     pub struct Mq {
         pub npairs: u16,

--- a/lib/propolis/src/vmm/mem.rs
+++ b/lib/propolis/src/vmm/mem.rs
@@ -21,7 +21,7 @@ use crate::common::{
 use crate::util::aspace::ASpace;
 use crate::vmm::VmmHdl;
 
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, IntoBytes};
 
 bitflags! {
     /// Bitflags representing memory protections.
@@ -643,7 +643,7 @@ impl SubMapping<'_> {
     }
 
     /// Writes `value` into the mapping.
-    pub fn write<T: Copy>(&self, value: &T) -> Result<()> {
+    pub fn write<T: Copy + IntoBytes>(&self, value: &T) -> Result<()> {
         self.check_write_access()?;
         let typed = self.ptr.as_ptr() as *mut T;
         unsafe {
@@ -653,7 +653,7 @@ impl SubMapping<'_> {
     }
 
     /// Writes `values` into the mapping.
-    pub fn write_many<T: Copy>(&self, values: &[T]) -> Result<()> {
+    pub fn write_many<T: Copy + IntoBytes>(&self, values: &[T]) -> Result<()> {
         self.check_write_access()?;
         let copy_len = size_of_val(values);
         if self.len < copy_len {
@@ -1045,7 +1045,7 @@ impl MemCtx {
         )
     }
     /// Writes a value to guest memory.
-    pub fn write<T: Copy>(&self, addr: GuestAddr, val: &T) -> bool {
+    pub fn write<T: Copy + IntoBytes>(&self, addr: GuestAddr, val: &T) -> bool {
         if let Some(mapping) =
             self.region_covered(addr, size_of::<T>(), Prot::WRITE)
         {
@@ -1082,7 +1082,11 @@ impl MemCtx {
     ///
     /// If the memory offset and value(s) size would result in the copy crossing
     /// vmm memory segments, this will fail.
-    pub fn write_many<T: Copy>(&self, addr: GuestAddr, val: &[T]) -> bool {
+    pub fn write_many<T: Copy + IntoBytes>(
+        &self,
+        addr: GuestAddr,
+        val: &[T],
+    ) -> bool {
         if let Some(mapping) =
             self.region_covered(addr, size_of_val(val), Prot::WRITE)
         {


### PR DESCRIPTION
Forever ago (oct 2024) when I'd added FromBytes bounds for reads from guest memory in ff0b76d, I'd overlooked virtio queues and that the constraint is interesting on the write path too.

does the things @FelixMcFelix very rightfully suggested in #1126.