### PR TITLE
Refactor dladm crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,7 +1332,7 @@ dependencies = [
  "bytes",
  "crucible-common",
  "crucible-workspace-hack",
- "num_enum 0.7.4",
+ "num_enum 0.7.6",
  "schemars 0.8.22",
  "serde",
  "strum 0.27.2",
@@ -1849,7 +1849,9 @@ dependencies = [
 name = "dladm"
 version = "0.0.0"
 dependencies = [
+ "bitflags 2.9.4",
  "libc",
+ "num_enum 0.7.6",
  "strum 0.26.3",
 ]
 
@@ -1873,7 +1875,7 @@ source = "git+https://github.com/oxidecomputer/dlpi-sys#555fa6e1315a64f40c72716e
 dependencies = [
  "libc",
  "libdlpi-sys 0.1.0 (git+https://github.com/oxidecomputer/dlpi-sys)",
- "num_enum 0.7.4",
+ "num_enum 0.7.6",
  "pretty-hex 0.4.1",
  "thiserror 2.0.18",
 ]
@@ -4088,7 +4090,7 @@ dependencies = [
  "colored",
  "dlpi 0.2.0 (git+https://github.com/oxidecomputer/dlpi-sys)",
  "libc",
- "num_enum 0.7.4",
+ "num_enum 0.7.6",
  "nvpair 0.5.0",
  "nvpair-sys",
  "oxnet",
@@ -4819,11 +4821,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
- "num_enum_derive 0.7.4",
+ "num_enum_derive 0.7.6",
  "rustversion",
 ]
 
@@ -4841,9 +4843,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ newtype_derive = "0.1.6"
 newtype-uuid = { version = "1.0.1", features = [ "v4" ] }
 # "feature" for `utsname`, "poll" for `PollFlags`
 nix = { version = "0.31", features = [ "feature", "poll" ] }
+num_enum = "0.7.6"
 owo-colors = "4"
 oxide-tokio-rt = "0.1.2"
 paste = "1.0.15"

--- a/crates/dladm/Cargo.toml
+++ b/crates/dladm/Cargo.toml
@@ -11,3 +11,5 @@ doctest = false
 [dependencies]
 libc.workspace = true
 strum = { workspace = true, features = ["derive"] }
+bitflags.workspace = true
+num_enum.workspace = true

--- a/crates/dladm/src/lib.rs
+++ b/crates/dladm/src/lib.rs
@@ -2,135 +2,164 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::ffi::CString;
-use std::io::{BufRead, BufReader, Error, ErrorKind, Result};
-use std::process::{Command, Stdio};
-use std::slice;
+//! Ultra-low overhead (no_std, no_alloc) access to the dladm subsystem.
+//!
+//! While all usages of this crate will neccesitate a standard library
+//! (you may notice the `libc` includes) the purpose of `no_std` and
+//! `no_alloc` here is to be a Good Citizen within the VMM. Secondarily,
+//! there is one less thing to reason about when dealing with this crate.
+
+#![no_std]
+
+use core::ffi::CStr;
+use core::ptr::NonNull;
+use core::slice;
+use libc::c_void;
+use sys::{dladm_handle, dladm_status, PropType, MAXLINKNAMELEN};
 
 #[allow(non_camel_case_types)]
 mod sys;
 
-use libc::c_void;
-use sys::{datalink_class, dladm_handle_t, dladm_status};
+pub use sys::{datalink_class_t, DlAdmOpt, DlMediaType};
 
-pub struct Handle {
-    inner: dladm_handle_t,
+pub type Result<T> = core::result::Result<T, DladmError>;
+
+#[derive(Debug)]
+pub enum DladmError {
+    /// Hoisted straight from `libdladm`.
+    DladmSubsystem(dladm_status),
+
+    NoMacAddrsOnLink,
+
+    MalformedMacAddr,
+
+    InvalidLinkName,
+
+    UnexpectedNullPtr,
 }
-impl Handle {
+
+impl DladmError {
+    pub fn as_static_str(&self) -> &'static str {
+        match self {
+            Self::DladmSubsystem(err) => err.into(),
+            Self::InvalidLinkName => "invalid link name",
+            Self::UnexpectedNullPtr => {
+                "dladm_open succeeded but returned a null pointer"
+            }
+            Self::NoMacAddrsOnLink => "no mac addrs found on link",
+            Self::MalformedMacAddr => {
+                "no mac addr on the link had the correct length (6B)"
+            }
+        }
+    }
+}
+
+/// Rust-flavoured wrapper around `libdladm`.
+/// Brokers access to dladm without execing the dladm CLI.
+/// Ultimately `libdladm` communicates over doors with `dlmgmtd`,
+/// a daemon managed by SMF's `svc:/network/datalink-management:default`.
+pub struct Dladm {
+    inner: NonNull<dladm_handle>,
+}
+
+impl Dladm {
+    /// Open a handle to the `dladm` subsystem.
     pub fn new() -> Result<Self> {
-        let mut hdl: dladm_handle_t = std::ptr::null_mut();
-        Self::handle_dladm_err(unsafe {
-            sys::dladm_open(&mut hdl as *mut dladm_handle_t)
-        })?;
-        Ok(Self { inner: hdl })
+        let mut hdl: *mut dladm_handle = core::ptr::null_mut();
+        Self::handle_dladm_err(unsafe { sys::dladm_open(&mut hdl) })?;
+
+        let Some(ptr) = NonNull::new(hdl) else {
+            return Err(DladmError::UnexpectedNullPtr);
+        };
+
+        Ok(Self { inner: ptr })
     }
 
-    pub fn query_link(&self, name: &str) -> Result<LinkInfo> {
-        let name_cstr = CString::new(name).unwrap();
-        let mut link_id: sys::datalink_id_t = 0;
-        let mut class: i32 = 0;
+    pub fn describe_link(&self, name: &str) -> Result<LinkInfo> {
+        let nb = name.as_bytes();
+
+        const SPACE_NEEDED_FOR_NULL_TERMINATOR: usize = 1;
+
+        if nb.is_empty()
+            || nb.len() + SPACE_NEEDED_FOR_NULL_TERMINATOR > MAXLINKNAMELEN
+        {
+            return Err(DladmError::InvalidLinkName);
+        }
+
+        let mut buf = [0u8; MAXLINKNAMELEN];
+        let n = nb.len().min(MAXLINKNAMELEN - SPACE_NEEDED_FOR_NULL_TERMINATOR);
+        buf[..n].copy_from_slice(&nb[..n]);
+
+        let Ok(link_name) = CStr::from_bytes_until_nul(&buf) else {
+            return Err(DladmError::InvalidLinkName);
+        };
+
+        let mut link_id = 0;
+        let mut class = datalink_class_t::empty();
+        let mut flags = DlAdmOpt::empty();
+        let mut media = 0;
+
+        // SAFETY: All pointers we're passing to libdladm are valid
+        // for their upcoming accesses.
+        // The link name is a stack-allocated C-string that we've
+        // ensured contains exactly one null terminator.
         Self::handle_dladm_err(unsafe {
             sys::dladm_name2info(
-                self.inner,
-                name_cstr.to_bytes_with_nul().as_ptr(),
-                &mut link_id as *mut sys::datalink_id_t,
-                std::ptr::null_mut(),
+                self.inner.as_ptr(),
+                link_name.as_ptr(),
+                &mut link_id,
+                &mut flags,
                 &mut class,
-                std::ptr::null_mut(),
+                &mut media,
             )
         })?;
 
-        let mut res = LinkInfo { link_id, ..Default::default() };
+        let media = DlpiMediaType::new(media);
 
-        match datalink_class::from_repr(class) {
-            // acceptable values: this supports both VNICs
-            // and direct use of XDE/OPTE ports.
-            Some(datalink_class::DATALINK_CLASS_VNIC) => {
-                Self::get_vnic_mac(name, &mut res.mac_addr[..])?;
-            }
-            Some(datalink_class::DATALINK_CLASS_MISC) => {
-                self.get_misc_mac(link_id, &mut res.mac_addr[..])?;
-            }
-            Some(c) => {
-                return Err(Error::new(
-                    ErrorKind::InvalidInput,
-                    format!("{name} is not vnic/misc class, but {c:?}"),
-                ));
-            }
-            None => {
-                return Err(Error::new(
-                    ErrorKind::InvalidInput,
-                    format!("{name} is of invalid class {class:x}"),
-                ));
+        let mut res = LinkInfo {
+            link_id,
+            class,
+            flags,
+            media,
+            mtu: None,
+            mac_addr: [0; 6],
+        };
+
+        self.pick_first_mac(res.link_id, &mut res.mac_addr)?;
+
+        let mut buffer = [0; sys::DLADM_STRSIZE];
+        let mut len = 1u32;
+
+        Self::handle_dladm_err(unsafe {
+            sys::dladm_get_linkprop(
+                self.inner.as_ptr(),
+                res.link_id,
+                PropType::Current,
+                MTU_PROP_NAME.as_ptr(),
+                &mut buffer.as_mut_ptr(),
+                &mut len,
+            )
+        })?;
+
+        if len > 0 {
+            // SAFETY: it's a pointer to a stack alloc.
+            let mtu_string = unsafe { CStr::from_ptr(buffer.as_ptr()) };
+
+            if let Ok(s) = mtu_string.to_str() {
+                if let Ok(mtu) = s.parse() {
+                    res.mtu = Some(mtu);
+                }
             }
         }
-
-        res.mtu = Self::get_mtu(name).ok();
 
         Ok(res)
     }
-    fn get_mtu(name: &str) -> Result<u16> {
-        // dladm show-linkprop -c -o value -p mtu <NIC_NAME>
-        // 1500
-        let output = Command::new("dladm")
-            .args(["show-linkprop", "-c", "-o", "value", "-p", "mtu"])
-            .arg(name)
-            .stderr(Stdio::null())
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .output()?;
-        if !output.status.success() {
-            return Err(Error::other("failed dladm"));
-        }
-        BufReader::new(&output.stdout[..])
-            .lines()
-            .next()
-            .and_then(Result::ok)
-            .and_then(|line| line.parse::<u16>().ok())
-            .ok_or_else(|| Error::other("invalid mtu"))
-    }
-    fn get_vnic_mac(name: &str, mac: &mut [u8]) -> Result<()> {
-        // dladm show-vnic -p -o macaddress <VNIC_NAME>
-        // 2:8:20:2d:e9:24
-        let output = Command::new("dladm")
-            .args(["show-vnic", "-p", "-o", "macaddress"])
-            .arg(name)
-            .stderr(Stdio::null())
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .output()?;
-        if !output.status.success() {
-            return Err(Error::other("failed dladm"));
-        }
-        let addr = BufReader::new(&output.stdout[..])
-            .lines()
-            .next()
-            .and_then(Result::ok)
-            .and_then(|line| {
-                let fields: Vec<u8> = line
-                    .split(':')
-                    .filter_map(|f| u8::from_str_radix(f, 16).ok())
-                    .collect();
-                match fields.len() {
-                    ETHERADDRL => Some(fields),
-                    _ => None,
-                }
-            })
-            .ok_or_else(|| Error::other("cannot query mac addr"))?;
-        mac.copy_from_slice(&addr[..]);
-        Ok(())
-    }
-    fn get_misc_mac(
+
+    fn pick_first_mac(
         &self,
         linkid: sys::datalink_id_t,
         mac: &mut [u8],
     ) -> Result<()> {
-        // Unfortunately, XDE/OPTE creates 'misc' type devices, as it is
-        // a pseudo device. `dladm` has no built-in commands for these,
-        // and macaddr queries for all other link types go through their
-        // dedicated `dladm show-<X>` commands. As a consequence, we have
-        // to go to libdladm/libdllink directly here.
-
         // One-off callback function and arg struct.
         // This will use the first seen mac address attached to the link.
         unsafe extern "C" fn per_macaddr(
@@ -166,7 +195,7 @@ impl Handle {
         // to state is only held inside the callback.
         Self::handle_dladm_err(unsafe {
             sys::dladm_walk_macaddr(
-                self.inner,
+                self.inner.as_ptr(),
                 linkid,
                 &mut state as *mut _ as *mut c_void,
                 per_macaddr,
@@ -174,11 +203,9 @@ impl Handle {
         })?;
 
         if state.n_seen == 0 {
-            return Err(Error::other("no mac addrs found on link"));
+            return Err(DladmError::NoMacAddrsOnLink);
         } else if !state.written {
-            return Err(Error::other(
-                "no mac addrs on link had correct length (6B)",
-            ));
+            return Err(DladmError::MalformedMacAddr);
         }
 
         Ok(())
@@ -189,22 +216,47 @@ impl Handle {
             .unwrap_or(dladm_status::DLADM_STATUS_FAILED)
         {
             dladm_status::DLADM_STATUS_OK => Ok(()),
-            e => Err(Error::other(format!("{e:?}"))),
+            e => Err(DladmError::DladmSubsystem(e)),
         }
     }
 }
-impl Drop for Handle {
+
+impl Drop for Dladm {
     fn drop(&mut self) {
-        unsafe { sys::dladm_close(self.inner) }
-        self.inner = std::ptr::null_mut();
+        // Recall that dladm_handle_t is not just a close-able fd.
+        // dladm_close performs the necessary cleanups.
+        unsafe { sys::dladm_close(self.inner.as_mut()) }
     }
 }
 
 const ETHERADDRL: usize = 6;
 
-#[derive(Copy, Clone, Default)]
+static MTU_PROP_NAME: &CStr = c"mtu";
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum DlpiMediaType {
+    Known(DlMediaType),
+
+    /// Almost certainly this variant will never be constructed.
+    /// We include it for guaranteed forwards-compatibility.
+    Unknown(u32),
+}
+
+impl DlpiMediaType {
+    fn new(value: u32) -> Self {
+        match DlMediaType::try_from(value) {
+            Ok(d) => Self::Known(d),
+            _ => Self::Unknown(value),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
 pub struct LinkInfo {
     pub link_id: u32,
     pub mtu: Option<u16>,
     pub mac_addr: [u8; ETHERADDRL],
+    pub class: datalink_class_t,
+    pub flags: DlAdmOpt,
+    pub media: DlpiMediaType,
 }

--- a/crates/dladm/src/sys.rs
+++ b/crates/dladm/src/sys.rs
@@ -3,23 +3,24 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use libc::{c_char, c_int, c_uchar, c_uint, c_void};
+use num_enum::TryFromPrimitive;
 use strum::FromRepr;
+use strum::IntoStaticStr;
 
 #[cfg(target_os = "illumos")]
 #[link(name = "dladm")]
-extern "C" {
-    pub fn dladm_open(handle: *mut dladm_handle_t) -> c_int;
-    pub fn dladm_close(handle: dladm_handle_t);
-    pub fn dladm_name2info(
+unsafe extern "C" {
+    pub unsafe fn dladm_open(handle: *mut dladm_handle_t) -> c_int;
+    pub unsafe fn dladm_close(handle: dladm_handle_t);
+    pub unsafe fn dladm_name2info(
         handle: dladm_handle_t,
-        link: *const u8,
+        link: *const c_char,
         linkidp: *mut datalink_id_t,
-        flagp: *mut u32,
-        // parse to datalink_class
-        classp: *mut c_int,
+        flagp: *mut DlAdmOpt,
+        classp: *mut datalink_class_t,
         mediap: *mut u32,
     ) -> c_int;
-    pub fn dladm_walk_macaddr(
+    pub unsafe fn dladm_walk_macaddr(
         handle: dladm_handle_t,
         linkid: datalink_id_t,
         arg: *mut c_void,
@@ -27,6 +28,14 @@ extern "C" {
             *mut c_void,
             *mut dladm_macaddr_attr_t,
         ) -> boolean_t,
+    ) -> c_int;
+    pub unsafe fn dladm_get_linkprop(
+        handle: dladm_handle_t,
+        linkid: datalink_id_t,
+        prop_type: PropType,
+        prop_name: *const c_char,
+        prop_val: *mut *mut c_char,
+        val_cntp: *mut u32,
     ) -> c_int;
 }
 
@@ -43,11 +52,10 @@ mod compat {
     }
     pub unsafe extern "C" fn dladm_name2info(
         handle: dladm_handle_t,
-        link: *const u8,
+        link: *const c_char,
         linkidp: *mut datalink_id_t,
-        flagp: *mut u32,
-        // parse to datalink_class
-        classp: *mut c_int,
+        flagp: *mut DlAdmOpt,
+        classp: *mut datalink_class_t,
         mediap: *mut u32,
     ) -> c_int {
         panic!("illumos only");
@@ -63,14 +71,32 @@ mod compat {
     ) -> c_int {
         panic!("illumos only");
     }
+
+    pub fn dladm_get_linkprop(
+        handle: dladm_handle_t,
+        linkid: datalink_id_t,
+        prop_type: PropType,
+        prop_name: *const c_char,
+        prop_val: *mut *mut c_char,
+        val_cntp: *mut u32,
+    ) -> c_int {
+        panic!("illumos only");
+    }
 }
+
 #[cfg(not(target_os = "illumos"))]
 pub use compat::*;
 
 /* opaque dladm handle to libdladm functions */
-pub enum dladm_handle {}
+#[repr(C)]
+pub struct dladm_handle {
+    _data: (),
+    _marker: core::marker::PhantomData<()>,
+}
+
 pub type dladm_handle_t = *mut dladm_handle;
 pub type datalink_id_t = u32;
+
 #[repr(C)]
 pub struct dladm_macaddr_attr_t {
     pub ma_slot: c_uint,
@@ -80,6 +106,7 @@ pub struct dladm_macaddr_attr_t {
     pub ma_client_name: [c_char; MAXNAMELEN],
     pub ma_client_linkid: datalink_id_t,
 }
+
 #[repr(C)]
 pub enum boolean_t {
     B_FALSE,
@@ -88,23 +115,157 @@ pub enum boolean_t {
 
 const MAXMACADDRLEN: usize = 20;
 const MAXNAMELEN: usize = 256;
+pub(crate) const MAXLINKNAMELEN: usize = 32;
+pub(crate) const DLADM_STRSIZE: usize = 256;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, FromRepr)]
-#[repr(i32)]
-pub enum datalink_class {
-    DATALINK_CLASS_PHYS = 0x01,
-    DATALINK_CLASS_VLAN = 0x02,
-    DATALINK_CLASS_AGGR = 0x04,
-    DATALINK_CLASS_VNIC = 0x08,
-    DATALINK_CLASS_ETHERSTUB = 0x10,
-    DATALINK_CLASS_SIMNET = 0x20,
-    DATALINK_CLASS_BRIDGE = 0x40,
-    DATALINK_CLASS_IPTUN = 0x80,
-    DATALINK_CLASS_PART = 0x100,
-    DATALINK_CLASS_MISC = 0x400,
+bitflags::bitflags! {
+    /// Despite being mutually exclusive options,
+    /// values of this type double as a mask in
+    /// certain operations. It is very convenient
+    /// to simply pretend it is a bitflag.
+    #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+    #[repr(transparent)]
+    pub struct datalink_class_t: u32 {
+        const DATALINK_CLASS_PHYS = 0x01;
+        const DATALINK_CLASS_VLAN = 0x02;
+        const DATALINK_CLASS_AGGR = 0x04;
+        const DATALINK_CLASS_VNIC = 0x08;
+        const DATALINK_CLASS_ETHERSTUB = 0x10;
+        const DATALINK_CLASS_SIMNET = 0x20;
+        const DATALINK_CLASS_BRIDGE = 0x40;
+        const DATALINK_CLASS_IPTUN = 0x80;
+        const DATALINK_CLASS_PART = 0x100;
+        const DATALINK_CLASS_MISC = 0x400;
+    }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, FromRepr)]
+bitflags::bitflags! {
+    /// Annoyingly,`libdladm` does not define an enum for the various
+    /// `DLADM_OPT_*` bitflags. We introduce our own here and the
+    /// naming convention reflects that this is a Rust type
+    /// that happens to be marshallable across an FFI boundary.
+    #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+    #[repr(transparent)]
+    pub struct DlAdmOpt: u32 {
+        /// The function requests to bringup some configuration that only takes
+        /// effect on the active system (not persistent).
+        const ACTIVE     = 0x00000001;
+
+        /// The function requests to persist some configuration.
+        const PERSIST    = 0x00000002;
+
+        /// Today, only used by `dladm_set_secobj()` — requests to create a secobj.
+        const CREATE     = 0x00000004;
+
+        /// The function requests to execute a specific operation forcefully.
+        const FORCE      = 0x00000008;
+
+        /// The function requests to generate a link name using the specified prefix.
+        const PREFIX     = 0x00000010;
+
+        const ANCHOR     = 0x00000020;
+
+        /// Signifies VLAN creation code path.
+        const VLAN       = 0x00000040;
+
+        /// Do not refresh the daemon after setting parameter (used by STP mcheck).
+        const NOREFRESH  = 0x00000080;
+
+        /// Bypass check functions during boot (used by pool property since pools
+        /// can come up after link properties are set).
+        const BOOT       = 0x00000100;
+
+        /// Indicates that the link assigned to a zone is transient and will be
+        /// removed when the zone shuts down.
+        const TRANSIENT  = 0x00000200;
+    }
+}
+
+/// DLPI media types (DL_* constants from `<sys/dlpi.h>`).
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive)]
+#[non_exhaustive]
+pub enum DlMediaType {
+    /// IEEE 802.3 CSMA/CD network.
+    Csmacd = 0x0,
+    /// IEEE 802.4 Token Passing Bus.
+    Tpb = 0x1,
+    /// IEEE 802.5 Token Passing Ring.
+    Tpr = 0x2,
+    /// IEEE 802.6 Metro Net.
+    Metro = 0x3,
+    /// Ethernet Bus.
+    Ether = 0x4,
+    /// ISO HDLC protocol support.
+    Hdlc = 0x05,
+    /// Character Synchronous protocol support.
+    Char = 0x06,
+    /// IBM Channel-to-Channel Adapter.
+    Ctca = 0x07,
+    /// Fiber Distributed Data Interface.
+    Fddi = 0x08,
+    /// Any other medium not listed above.
+    Other = 0x09,
+    /// Frame Relay LAPF.
+    Frame = 0x0a,
+    /// Multi-protocol over Frame Relay.
+    MpFrame = 0x0b,
+    /// Character Asynchronous Protocol.
+    Async = 0x0c,
+    /// X.25 Classical IP interface.
+    IpX25 = 0x0d,
+    /// Software loopback.
+    Loop = 0x0e,
+    /// Fibre Channel interface.
+    Fc = 0x10,
+    /// ATM.
+    Atm = 0x11,
+    /// ATM Classical IP interface.
+    IpAtm = 0x12,
+    /// X.25 LAPB interface.
+    X25 = 0x13,
+    /// ISDN interface.
+    Isdn = 0x14,
+    /// HIPPI interface.
+    Hippi = 0x15,
+    /// 100 Based VG Ethernet.
+    Vg100 = 0x16,
+    /// 100 Based VG Token Ring.
+    Vg100Tpr = 0x17,
+    /// ISO 8802/3 and Ethernet.
+    EthCsma = 0x18,
+    /// 100 Base T.
+    Bt100 = 0x19,
+    /// Infiniband.
+    Ib = 0x1a,
+
+    /// IPv4 Tunnel Link.
+    Ipv4 = 0x8000_0001,
+    /// IPv6 Tunnel Link.
+    Ipv6 = 0x8000_0002,
+    /// Virtual network interface.
+    SunwVni = 0x8000_0003,
+    /// IEEE 802.11.
+    WiFi = 0x8000_0004,
+    /// `ipnet(4D)` link.
+    IpNet = 0x8000_0005,
+    /// IPMP stub interface.
+    SunwIpmp = 0x8000_0006,
+    /// 6to4 Tunnel Link.
+    SixToFour = 0x8000_0007,
+}
+
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum PropType {
+    Current = 1,
+    _Default,
+    _Modifiable,
+    _Persistent,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, FromRepr, IntoStaticStr)]
 #[repr(i32)]
 pub enum dladm_status {
     DLADM_STATUS_OK = 0,

--- a/crates/dladm/tests/dladm.rs
+++ b/crates/dladm/tests/dladm.rs
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![cfg(target_os = "illumos")]
+
+use dladm::datalink_class_t;
+use dladm::DlAdmOpt;
+use dladm::DlMediaType;
+use dladm::Dladm;
+use dladm::DlpiMediaType;
+
+#[test]
+#[ignore]
+fn empty_link_name() {
+    let hnd = Dladm::new().unwrap();
+
+    assert!(hnd.describe_link("").is_err());
+}
+
+#[test]
+#[ignore]
+fn bogus_name() {
+    let hnd = Dladm::new().unwrap();
+
+    assert!(hnd.describe_link("nonsense").is_err());
+}
+
+#[test]
+#[ignore]
+fn query() {
+    let hnd = Dladm::new().unwrap();
+
+    let opte0 = hnd.describe_link("opte0").unwrap();
+
+    assert_eq!(opte0.mtu.unwrap(), 1500);
+    assert_eq!(opte0.class, datalink_class_t::DATALINK_CLASS_MISC);
+    assert_eq!(opte0.flags, DlAdmOpt::ACTIVE);
+    assert_eq!(opte0.media, DlpiMediaType::Known(DlMediaType::Ether));
+}
+
+#[test]
+#[ignore]
+fn query_long_name() {
+    let hnd = Dladm::new().unwrap();
+
+    // To try out:
+    // dladm create-etherstub -t aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0
+
+    let iface = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0";
+
+    assert_eq!(iface.as_bytes().len(), 31);
+
+    let link = hnd.describe_link(iface).unwrap();
+
+    assert_eq!(link.mtu.unwrap(), 9000);
+    assert_eq!(link.class, datalink_class_t::DATALINK_CLASS_ETHERSTUB);
+    assert_eq!(link.flags, DlAdmOpt::ACTIVE);
+    assert_eq!(link.media, DlpiMediaType::Known(DlMediaType::Ether));
+}

--- a/lib/propolis/src/hw/virtio/viona.rs
+++ b/lib/propolis/src/hw/virtio/viona.rs
@@ -336,8 +336,13 @@ impl PciVirtioViona {
         vm: &VmmHdl,
         viona_params: Option<DeviceParams>,
     ) -> io::Result<Arc<PciVirtioViona>> {
-        let dlhdl = dladm::Handle::new()?;
-        let info = dlhdl.query_link(vnic_name)?;
+        let dladm = dladm::Dladm::new()
+            .map_err(|e| Error::new(ErrorKind::Other, e.as_static_str()))?;
+
+        let info = dladm
+            .describe_link(vnic_name)
+            .map_err(|e| Error::new(ErrorKind::Other, e.as_static_str()))?;
+
         let hdl = VionaHdl::new(info.link_id, vm.fd())?;
 
         #[cfg(feature = "falcon")]


### PR DESCRIPTION
This is a large, but self-contained change that
fixes up a few things in the dladm crate. In the
future I have Big Plans for running Bayesian
optimization loops on various link parameters,
and will need to use this crate. While this change is merely preparatory, I decided to fix some
things along the way.

First, dladm_handle_t is changed to no longer use the empty enum as an FFI type, which is unsound.
See: https://doc.rust-lang.org/nomicon/ffi.html

The crate no longer shells out to dladm.
It struck me as a bit gross to shell out to dladm
when we're linking against libdladm in the first place.

I renamed Handle to Dladm and called its most imporant method describe. In addition, some fields that
dladm furnishes us with anyway (upon calling
dladm_name2info) have been added to LinkInfo and
exported for use in Propolis.

Several disabled unit tests are added, which are useful for hacking on this crate.

Finally, I made it clear that this crate does no allocations. It's just one less thing to think about when reasoning about code linked into our VMM.