### PR TITLE
viona: do not lose used/avail indices

### DIFF
--- a/lib/propolis/src/hw/virtio/viona.rs
+++ b/lib/propolis/src/hw/virtio/viona.rs
@@ -1022,13 +1022,16 @@ impl From<&VirtQueue> for viona_api::vioc_ring_state {
         let desc_addr = state.mapping.desc_addr;
         let avail_addr = state.mapping.avail_addr;
         let used_addr = state.mapping.used_addr;
+        let avail_idx = state.avail_idx;
+        let used_idx = state.used_idx;
         viona_api::vioc_ring_state {
             vrs_index: id,
             vrs_qsize: size,
             vrs_qaddr_desc: desc_addr,
             vrs_qaddr_avail: avail_addr,
             vrs_qaddr_used: used_addr,
-            ..Default::default()
+            vrs_used_idx: used_idx,
+            vrs_avail_idx: avail_idx,
         }
     }
 }


### PR DESCRIPTION
When we're going to get virtio-nic device running after initialization or import, part of `queues_restart()` involves synchronizing the state of viona rings with the Propolis-side state for corresponding virtqueues; we're about to hand off operation of those queues to viona after all. When we stop a virtio-nic device, `queues_sync()` synchronizes viona ring state back into Propolis via VNA_IOC_RING_GET_STATE, and when exported we correctly retain all queue state.

On import we had omitted to set vrs_avail_idx and vrs_used_idx. The guest-side state for the wring then is written on top of the previously-exported memory, clobbering correct state with the now reset-to-initial queue indices. Resuming the guest at this point is a bit fraught, as there's no reason to believe that the descriptors at such indices are valid. In the lucky case you may catch a Linux guest logging something like:

> virtio_net virtio0: input.0:id 0 is not a head!

at which point it gives up on the very broken device.

... I could probably write a test for this, by setting `vrs_qaddr_avail` (and avail) to something and then migrating the device. there's no reason we need to actually send packets anywhere or rx interrupts etc...

anyhow, at this point `ping` from a host elsewhere on my network to the VM, and `ping` from the VM to an external host, both keep working across migration again. yay!!