### PR TITLE
[meta] update to drift 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1914,9 +1914,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "drift"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cc7f4e6337c9c0d0402e2dccaeaea63fc38467a3e5ab3f465372dafce2cd89"
+checksum = "d46ae7066bba53a265e8412309dc64739d32c597d688f1938a44c01bd30629e7"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",

--- a/phd-tests/tests/src/cpuid.rs
+++ b/phd-tests/tests/src/cpuid.rs
@@ -318,8 +318,7 @@ impl<'a> LinuxGuestTopo<'a> {
                 break;
             }
 
-            let level: u8 =
-                level_out.parse().expect("cache level parses");
+            let level: u8 = level_out.parse().expect("cache level parses");
 
             let shared_cpu_list = self
                 .vm


### PR DESCRIPTION
Drift 0.1.4 includes https://github.com/oxidecomputer/drift/pull/20 and https://github.com/oxidecomputer/drift/pull/22 -- the latter is particularly important because it can lead to false negatives where actually-incompatible APIs are marked as compatible.
