### PR TITLE
update example of patching Omicron

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,12 +198,20 @@ zerocopy = "0.8.25"
 # dependencies.  If you want to use those, uncomment one of these blocks.
 #
 # [patch."https://github.com/oxidecomputer/omicron"]
-# internal-dns = { path = "../omicron/internal-dns" }
+# bootstore = { path = "../omicron/bootstore" }
+# illumos-utils = { path = "../omicron/illumos-utils" }
+# internal-dns-resolver = { path = "../omicron/internal-dns/resolver" }
+# internal-dns-types = { path = "../omicron/internal-dns/types" }
+# internal-dns-types-versions = { path = "../omicron/internal-dns/types/versions" }
 # nexus-client = { path = "../omicron/clients/nexus-client" }
 # omicron-common = { path = "../omicron/common" }
+# omicron-uuid-kinds = { path = "../omicron/uuid-kinds" }
+# oximeter = { path = "../omicron/oximeter/oximeter" }
 # oximeter-instruments = { path = "../omicron/oximeter/instruments" }
 # oximeter-producer = { path = "../omicron/oximeter/producer" }
-# oximeter = { path = "../omicron/oximeter/oximeter" }
+# sled-agent-client = { path = "../omicron/clients/sled-agent-client" }
+# sled-agent-types = { path = "../omicron/sled-agent/types" }
+# sled-agent-types-versions = { path = "../omicron/sled-agent/types/versions" }
 # [patch."https://github.com/oxidecomputer/crucible"]
 # crucible = { path = "../crucible/upstairs" }
 # crucible-client-types = { path = "../crucible/crucible-client-types" }


### PR DESCRIPTION
The list of packages supplied by the Omicron repo, and thus needing to be patched when testing local changes to Omicron, needs to be updated.  Verified that when patched, there are no references to the github Omicron repo in `Cargo.lock`, and `cargo check` passes.