### PR TITLE
register Oximeter metrics for local disks

### DIFF
--- a/bin/propolis-server/src/lib/initializer.rs
+++ b/bin/propolis-server/src/lib/initializer.rs
@@ -895,6 +895,8 @@ impl MachineInitializer<'_> {
                 }
             };
 
+            let block_size;
+            let volume_id;
             if let Some(crucible) = crucible {
                 let crucible =
                     match self.crucible_backends.entry(backend_id.clone()) {
@@ -910,27 +912,24 @@ impl MachineInitializer<'_> {
                         }
                     };
 
-                let Some(block_size) = crucible.block_size().await else {
-                    slog::error!(
-                        self.log,
-                        "Could not get Crucible backend block size, \
-                        virtual disk metrics can't be reported for it";
-                        "disk_id" => %backend_id,
-                    );
-                    continue;
+                block_size = crucible.block_size().await;
+                volume_id = crucible.get_uuid().await.ok();
+            } else {
+                // Not a Crucible backend, e.g. local disk
+                block_size = match &disk.backend_spec {
+                    StorageBackend::File(fsb) => Some(fsb.block_size),
+                    StorageBackend::Blob(_) => Some(512),
+                    _ => None,
                 };
-
-                let Ok(volume_id) = crucible.get_uuid().await else {
-                    slog::error!(
-                        self.log,
-                        "Could not get Crucible volume ID, \
-                        virtual disk metrics can't be reported for it";
-                        "disk_id" => %backend_id,
-                    );
-                    continue;
+                volume_id = match backend_id {
+                    SpecKey::Uuid(uuid) => Some(*uuid),
+                    _ => None,
                 };
-
-                if let Some(registry) = &self.producer_registry {
+            }
+            if let Some(registry) = &self.producer_registry {
+                if let (Some(block_size), Some(volume_id)) =
+                    (block_size, volume_id)
+                {
                     let block_metrics = BlockMetrics::new(
                         VirtualDisk {
                             attached_instance_id: self.properties.id,
@@ -957,7 +956,15 @@ impl MachineInitializer<'_> {
                     };
 
                     block_dev.attachment().set_metric_consumer(block_metrics);
-                };
+                } else {
+                    slog::error!(
+                        self.log,
+                        "Could not get backend volume UUID or block size, \
+                        virtual disk metrics can't be reported for it";
+                        "disk_id" => %backend_id,
+                    );
+                    continue;
+                }
             }
         }
         Ok(wanted_heap)


### PR DESCRIPTION
This will cause metrics to be reported for local disks (e.g. reads, writes, etc).

Tested by specifying a UUID in the instance spec toml file, and retrieving the metrics with `curl`, e.g.:

```toml
# Disk in slot 3
[block_dev.4e523bc0-cbaa-4b0e-8461-b7ebaa1053d4]
type = "file"
block_size = 4096
path = "/dev/zvol/rdsk/oxp_03/nocrypt/dump"
workers = 30

[dev.block3]
driver = "pci-nvme"
block_dev = "4e523bc0-cbaa-4b0e-8461-b7ebaa1053d4"
pci-path = "0.8.0"
```

```
$ curl http://0.0.0.0:37058/79c39656-34e2-4551-86a5-e94232bf6f06 | jq
...
  {
    "status": "ok",
    "info": [
      {
        "measurement": {
          "timestamp": "2026-05-20T18:00:42.931189546Z",
          "datum": {
            "type": "cumulative_u64",
            "datum": {
              "start_time": "2026-05-20T17:41:28.504981529Z",
              "value": 569 # <== number of read requests
            }
          }
        },
        "timeseries_name": "virtual_disk:reads", # <== metric name
        "timeseries_version": 1,
        "target": {
          "name": "virtual_disk",
          "fields": {
...
            "block_size": {
              "name": "block_size",
              "value": {
                "type": "u32",
                "value": 4096
              }
            },
            "disk_id": {
              "name": "disk_id",
              "value": {
                "type": "uuid",
                "value": "4e523bc0-cbaa-4b0e-8461-b7ebaa1053d4". # <=== matches block_dev UUID
              }
            },
...
          }
        },
        "metric": {
          "name": "reads",
          "fields": {}
        }
      },
```