### PR TITLE
propolis-cli: accept ip:port for server address

### DIFF
--- a/bin/propolis-cli/README.md
+++ b/bin/propolis-cli/README.md
@@ -27,14 +27,14 @@ pci-path = "0.5.0"
 To create and run a Propolis VM using this configuration:
 
 ```
-# propolis-cli -s <server ip> -p <port> new --config-toml <path> <VM name>
-# propolis-cli -s <server ip> -p <port> state run
+# propolis-cli -s <server ip>:<port> new --config-toml <path> <VM name>
+# propolis-cli -s <server ip>:<port> state run
 ```
 
 To connect to the VM's serial console:
 
 ```
-# propolis-cli -s <server ip> -p <port> serial
+# propolis-cli -s <server ip>:<port> serial
 ```
 
 Run `propolis-cli --help` to see the full list of supported commands and their

--- a/bin/propolis-cli/src/main.rs
+++ b/bin/propolis-cli/src/main.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::{
-    net::{IpAddr, SocketAddr, ToSocketAddrs},
+    net::{SocketAddr, ToSocketAddrs},
     os::unix::prelude::AsRawFd,
     time::Duration,
 };
@@ -48,13 +48,9 @@ use propolis_client::{
 #[clap(about, version)]
 /// A simple CLI tool to manipulate propolis-server
 struct Opt {
-    /// propolis-server address
-    #[clap(short, long, value_parser = resolve_host)]
-    server: IpAddr,
-
-    /// propolis-server port
-    #[clap(short, long, default_value = "12400", action)]
-    port: u16,
+    /// propolis-server address, as IP:PORT
+    #[clap(short, long, value_parser = resolve_server)]
+    server: SocketAddr,
 
     /// Enable debugging
     #[clap(short, long, action)]
@@ -132,13 +128,9 @@ enum Command {
 
     /// Migrate instance to new propolis-server
     Migrate {
-        /// Destination propolis-server address
-        #[clap(value_parser = resolve_host)]
-        dst_server: IpAddr,
-
-        /// Destination propolis-server port
-        #[clap(short = 'p', default_value = "12400", action)]
-        dst_port: u16,
+        /// Destination propolis-server address, as IP:PORT
+        #[clap(value_parser = resolve_server)]
+        dst_server: SocketAddr,
 
         /// Uuid for the destination instance
         #[clap(short = 'u', action)]
@@ -463,11 +455,11 @@ fn parse_json_file<T: serde::de::DeserializeOwned>(
     serde_json::from_reader(reader).map_err(|e| e.into())
 }
 
-/// Given a string representing an host, attempts to resolve it to a specific IP address
-fn resolve_host(server: &str) -> anyhow::Result<IpAddr> {
-    (server, 0)
+/// Resolve a `HOST:PORT` server argument to a socket address, performing a DNS
+/// lookup when the host is a name rather than a literal IP address.
+fn resolve_server(server: &str) -> anyhow::Result<SocketAddr> {
+    server
         .to_socket_addrs()?
-        .map(|sock_addr| sock_addr.ip())
         .next()
         .ok_or_else(|| anyhow!("failed to resolve server argument '{server}'"))
 }
@@ -922,7 +914,7 @@ async fn main() -> anyhow::Result<()> {
     let opt = Opt::parse();
     let log = create_logger(&opt);
 
-    let addr = SocketAddr::new(opt.server, opt.port);
+    let addr = opt.server;
     let client = Client::new(&format!("http://{addr}"));
 
     match opt.cmd {
@@ -965,8 +957,8 @@ async fn main() -> anyhow::Result<()> {
         Command::Serial { byte_offset } => {
             serial(addr, byte_offset, log).await?
         }
-        Command::Migrate { dst_server, dst_port, dst_uuid, crucible_disks } => {
-            let dst_addr = SocketAddr::new(dst_server, dst_port);
+        Command::Migrate { dst_server, dst_uuid, crucible_disks } => {
+            let dst_addr = dst_server;
             let dst_client = Client::new(&format!("http://{dst_addr}"));
             let dst_uuid = dst_uuid.unwrap_or_else(Uuid::new_v4);
             let disks = if let Some(crucible_disks) = crucible_disks {
@@ -1025,7 +1017,27 @@ impl Drop for RawTermiosGuard {
 
 #[cfg(test)]
 mod test {
-    use super::stdin_to_websockets_task;
+    use super::{resolve_server, stdin_to_websockets_task};
+
+    #[test]
+    fn resolve_server_accepts_ip_port() {
+        use std::net::SocketAddr;
+
+        assert_eq!(
+            resolve_server("127.0.0.1:12345").unwrap(),
+            "127.0.0.1:12345".parse::<SocketAddr>().unwrap()
+        );
+        assert_eq!(
+            resolve_server("[::1]:12345").unwrap(),
+            "[::1]:12345".parse::<SocketAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn resolve_server_rejects_missing_port() {
+        assert!(resolve_server("127.0.0.1").is_err());
+        assert!(resolve_server("not-a-valid-address").is_err());
+    }
 
     #[tokio::test]
     async fn test_stdin_to_websockets_task() {

--- a/docs/migrate-with-crucible.md
+++ b/docs/migrate-with-crucible.md
@@ -144,17 +144,17 @@ you desire, except for the boot disk, which will be specified through the API.
 
 Create the VM using the `--crucible-disks` flag and the JSON file. For example:
 ```
-$ ./target/debug/propolis-cli -s 172.20.3.73 -p 8000 new --crucible-disks disks.json vm0
+$ ./target/debug/propolis-cli -s 172.20.3.73:8000 new --crucible-disks disks.json vm0
 ```
 
 Run the VM:
 ```
-$ ./target/debug/propolis-cli -s 172.20.3.73 -p 8000 state run
+$ ./target/debug/propolis-cli -s 172.20.3.73:8000 state run
 ```
 
 You may wish to watch the console to make sure it boots:
 ```
-$ ./target/debug/propolis-cli -s 172.20.3.73 -p 8000 serial
+$ ./target/debug/propolis-cli -s 172.20.3.73:8000 serial
 ```
 
 ### Migrate the VM to the destination server
@@ -170,7 +170,7 @@ Ensure the destination server is running. Make a copy of the JSON file you
 created above and increment the generation number. Then, from the source, run
 something like:
 ```
-$ ./target/debug/propolis-cli -s 172.20.3.73 -p 8000 migrate 172.20.3.71 -p 8000 --crucible-disks disks2.json
+$ ./target/debug/propolis-cli -s 172.20.3.73:8000 migrate 172.20.3.71:8000 --crucible-disks disks2.json
 ```
 
 If successful, you should be able to run the VM and see the serial console on

--- a/docs/server-send-vcr.md
+++ b/docs/server-send-vcr.md
@@ -107,12 +107,12 @@ for dsc need to match what is in this file.
 Using a third window, create the VM and add the crucible disk like this:
 
 ```
-propolis-cli -s 127.0.0.1 -p 55400 new crub --crucible-disks crucible-disks.json
+propolis-cli -s 127.0.0.1:55400 new crub --crucible-disks crucible-disks.json
 ```
 
 Then, start the VM:
 ```
-propolis-cli -s 127.0.0.1 -p 55400 state run
+propolis-cli -s 127.0.0.1:55400 state run
 ```
 
 ## Replace a downstairs.
@@ -142,7 +142,7 @@ and `target[2]` is different.  Send this replace.json file over to the server
 with this propolis-cli command:
 
 ```
-propolis-cli -s 127.0.0.1 -p 55400 vcr -u 0cedae45-3d6e-4d90-b2cb-56f1a1a42a89 --vcr-replace ./replace.json
+propolis-cli -s 127.0.0.1:55400 vcr -u 0cedae45-3d6e-4d90-b2cb-56f1a1a42a89 --vcr-replace ./replace.json
 ```
 
 This should result in more messages on the propolis-server window, and,


### PR DESCRIPTION
`propolis-cli -s` parsed its argument as a bare host and discarded any port, so passing `-s 127.0.0.1:12345` (the form `propolis-server` prints and accepts) failed with "node name or service name not known". This parses the server argument as a full socket address and drops the now-redundant `-p` flag, so `-s` takes `IP:PORT` the same way `propolis-server run` already does. The `migrate` destination argument gets the same treatment, and the README/docs examples are updated to match.

Note this is a small breaking change to the CLI: a port is now required (there's no default `12400` anymore), per the issue's suggestion to "expect ip:port in all cases".

Closes #1062.

Tested with `cargo test -p propolis-cli` (added unit tests for the parser) and `cargo clippy`, built on Linux. I don't have an illumos host, so I couldn't exercise the CLI end-to-end against a running propolis-server.