### PR TITLE
fix nits on non-x86

### DIFF
--- a/crates/cpuid-utils/src/host.rs
+++ b/crates/cpuid-utils/src/host.rs
@@ -87,7 +87,7 @@ pub fn query(leaf: CpuidIdent) -> CpuidValues {
 }
 
 #[cfg(not(target_arch = "x86_64"))]
-pub fn query(leaf: CpuidIdent) -> CpuidValues {
+pub fn query(_leaf: CpuidIdent) -> CpuidValues {
     panic!("host CPUID queries only work on x86-64 hosts")
 }
 

--- a/lib/propolis/src/vcpu.rs
+++ b/lib/propolis/src/vcpu.rs
@@ -26,7 +26,7 @@ use migrate::VcpuReadWrite;
 use thiserror::Error;
 
 use bhyve_api::ApiVersion;
-use propolis_types::{CpuidIdent, CpuidValues, CpuidVendor};
+use propolis_types::{CpuidIdent, CpuidVendor};
 
 #[usdt::provider(provider = "propolis")]
 mod probes {
@@ -77,7 +77,9 @@ impl Vcpu {
         #[cfg(target_arch = "x86_64")]
         fn query_hardware_vendor() -> CpuidVendor {
             let res = unsafe { core::arch::x86_64::__cpuid(0) };
-            CpuidValues::from(res).try_into().expect("CPU vendor is recognized")
+            propolis_types::CpuidValues::from(res)
+                .try_into()
+                .expect("CPU vendor is recognized")
         }
 
         #[cfg(not(target_arch = "x86_64"))]


### PR DESCRIPTION
Fix a couple of warnings when running `cargo check` on non-x86 machines, e.g. an ARM64 Mac.