### PR TITLE
docs: fix standalone-with-crucible.md

### DIFF
--- a/docs/standalone-with-crucible.md
+++ b/docs/standalone-with-crucible.md
@@ -184,8 +184,8 @@ pci-path = "0.4.0"
 type = "crucible"
 # these MUST match the region configuration downstairs
 block_size = 4096
-blocks_per_extent = 131072
-extent_count = 128
+blocks_per_extent = 16384
+extent_count = 512
 targets = [
   "127.0.0.1:8810",
   "127.0.0.1:8820",


### PR DESCRIPTION
Minor fix to make the `propolis-standalone` TOML configuration file match the Crucible configuration used to create the downstairs.

The text before the code block reads:

> assuming you have used the above settings for block size, extent size, and extent count.

Which gives the expectation that the commands and TOML file should "just work" if you copy-and-paste things directly.