### PR TITLE
aspace: fix InverseIter starting cursor for non-zero ASpace start

### DIFF
--- a/lib/propolis/src/util/aspace.rs
+++ b/lib/propolis/src/util/aspace.rs
@@ -130,7 +130,7 @@ impl<T> ASpace<T> {
     ///
     /// Returns all space which does not overlap with registered regions.
     pub fn inverse_iter(&self) -> InverseIter<'_, T> {
-        InverseIter { inner: self.map.iter(), next: 0, end: self.end }
+        InverseIter { inner: self.map.iter(), next: self.start, end: self.end }
     }
 
     /// Get iterator for regions which are (partially or totally) covered by a range
@@ -503,6 +503,22 @@ mod test {
         // Entire address space empty
         let mut iter = s.inverse_iter();
         assert_eq!(Extent { start: 0, len: 100 }, iter.next().unwrap());
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn inverse_iterator_nonzero_start() {
+        let start = 50;
+        let end = 100;
+        let mut s: ASpace<()> = ASpace::new(start, end);
+
+        // Registration in the middle of a non-zero-based address space.
+        // Free regions should begin at `start`, not at 0.
+        assert!(s.register(60, 10, ()).is_ok());
+
+        let mut iter = s.inverse_iter();
+        assert_eq!(Extent { start: 50, len: 10 }, iter.next().unwrap());
+        assert_eq!(Extent { start: 70, len: 30 }, iter.next().unwrap());
         assert!(iter.next().is_none());
     }
 }


### PR DESCRIPTION
`InverseIter` was initialised with `next: 0` regardless of the ASpace's
`start` field. For any `ASpace::new(S, E)` where `S > 0`, this caused
`inverse_iter()` to yield extents beginning at address `0` — below the
actual lower bound of the space.

The fix is a one-token change: initialise `next` to `self.start` instead
of `0`.

No current caller in this repo exercises `inverse_iter()` on a non-zero-
start ASpace (all production `ASpace::new` calls use `start = 0`), but
the method is public API and the behaviour for non-zero starts was
silently wrong. All existing `inverse_iterator_*` tests used `start = 0`
and therefore never caught this.

A new test `inverse_iterator_nonzero_start` registers a region inside an
`ASpace::new(50, 100)` and asserts the returned extents start at `50`,
not `0`.