### PR TITLE
standalone: ability to set viona rx/tx queue sizes

### DIFF
--- a/bin/propolis-standalone/README.md
+++ b/bin/propolis-standalone/README.md
@@ -39,6 +39,12 @@ pci-path = "0.4.0"
 driver = "pci-virtio-viona"
 vnic = "vnic_name"
 pci-path = "0.5.0"
+
+# Override Rx queue size
+# rx-queue-size = 2048
+
+# Override Tx queue size
+# tx-queue-size = 256
 ```
 
 Propolis will not destroy the VM instance on exit.  If one exists with the

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -1324,6 +1324,18 @@ fn setup_instance(
                 "pci-virtio-viona" => {
                     let vnic_name =
                         dev.options.get("vnic").unwrap().as_str().unwrap();
+                    let rxqsz = match dev.options.get("rx-queue-size") {
+                        Some(toml::Value::Integer(v)) => {
+                            hw::virtio::VqSize::new(u16::try_from(*v).unwrap())
+                        }
+                        _ => hw::virtio::viona::RX_QUEUE_SIZE,
+                    };
+                    let txqsz = match dev.options.get("tx-queue-size") {
+                        Some(toml::Value::Integer(v)) => {
+                            hw::virtio::VqSize::new(u16::try_from(*v).unwrap())
+                        }
+                        _ => hw::virtio::viona::TX_QUEUE_SIZE,
+                    };
                     let bdf = bdf.unwrap();
 
                     let viona_params =
@@ -1333,11 +1345,15 @@ fn setup_instance(
                     // The viona_params here (currently just copy_data and
                     // header_pad) require `viona::ApiVersion::V3`, below
                     // Propolis' minimum of V6, so we can always set them.
-                    let viona = hw::virtio::PciVirtioViona::new(
-                        vnic_name,
-                        &hdl,
-                        viona_params,
-                    )?;
+                    let viona =
+                        hw::virtio::PciVirtioViona::new_with_queue_sizes(
+                            vnic_name,
+                            rxqsz,
+                            txqsz,
+                            hw::virtio::viona::CTL_QUEUE_SIZE,
+                            &hdl,
+                            viona_params,
+                        )?;
                     guard.inventory.register_instance(&viona, &bdf.to_string());
                     chipset_pci_attach(bdf, viona);
                 }

--- a/lib/propolis/src/hw/virtio/mod.rs
+++ b/lib/propolis/src/hw/virtio/mod.rs
@@ -32,6 +32,7 @@ use crate::lifecycle::Lifecycle;
 use queue::VirtQueue;
 
 pub use block::PciVirtioBlock;
+pub use queue::VqSize;
 pub use viona::PciVirtioViona;
 pub use vsock::PciVirtioSock;
 


### PR DESCRIPTION
While running local network performance benchmarks I find it useful to be able to change queues sizes.