### PR TITLE
propolis-cli should send boot_order along

### DIFF
--- a/crates/propolis-config-toml/src/lib.rs
+++ b/crates/propolis-config-toml/src/lib.rs
@@ -21,6 +21,9 @@ pub mod spec;
 // configuration will likely become more dynamic.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Config {
+    #[serde(default, rename = "main")]
+    pub machine_settings: MachineSettings,
+
     #[serde(default, rename = "pci_bridge")]
     pub pci_bridges: Vec<PciBridge>,
 
@@ -39,6 +42,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            machine_settings: MachineSettings::default(),
             pci_bridges: Vec::new(),
             chipset: Chipset { options: BTreeMap::new() },
             devices: BTreeMap::new(),
@@ -46,6 +50,15 @@ impl Default for Config {
             cpuid_profiles: BTreeMap::new(),
         }
     }
+}
+
+/// Settings covering the VM "at large".
+///
+/// This corresponds to (and is a subset of) the `main` block understood by
+/// `propolis-standalone`
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default)]
+pub struct MachineSettings {
+    pub boot_order: Option<Vec<String>>,
 }
 
 /// The instance's chipset.

--- a/crates/propolis-config-toml/src/spec.rs
+++ b/crates/propolis-config-toml/src/spec.rs
@@ -287,6 +287,26 @@ impl TryFrom<&super::Config> for SpecConfig {
             )?;
         }
 
+        if let Some(boot_order) = config.machine_settings.boot_order.as_ref() {
+            let settings = Component::BootSettings(
+                propolis_client::instance_spec::BootSettings {
+                    order: boot_order
+                        .iter()
+                        .map(|key| {
+                            propolis_client::instance_spec::BootOrderEntry {
+                                id: SpecKey::Name(key.to_owned()),
+                            }
+                        })
+                        .collect(),
+                },
+            );
+            spec_component_add(
+                &mut spec,
+                SpecKey::Name("boot-settings".to_string()),
+                settings,
+            )?;
+        }
+
         Ok(spec)
     }
 }

--- a/crates/propolis-config-toml/src/spec.rs
+++ b/crates/propolis-config-toml/src/spec.rs
@@ -11,10 +11,11 @@ use std::{
 
 use propolis_client::{
     instance_spec::{
-        Component, Cpuid, CpuidVendor, DlpiNetworkBackend, FileStorageBackend,
-        MigrationFailureInjector, NvmeDisk, P9fs, PciPath, PciPciBridge,
-        SoftNpuP9, SoftNpuPciPort, SoftNpuPort, SpecKey, VirtioDisk,
-        VirtioNetworkBackend, VirtioNic, VirtioSocket,
+        BootOrderEntry, BootSettings, Component, Cpuid, CpuidVendor,
+        DlpiNetworkBackend, FileStorageBackend, MigrationFailureInjector,
+        NvmeDisk, P9fs, PciPath, PciPciBridge, SoftNpuP9, SoftNpuPciPort,
+        SoftNpuPort, SpecKey, VirtioDisk, VirtioNetworkBackend, VirtioNic,
+        VirtioSocket,
     },
     support::nvme_serial_from_str,
 };
@@ -288,18 +289,14 @@ impl TryFrom<&super::Config> for SpecConfig {
         }
 
         if let Some(boot_order) = config.machine_settings.boot_order.as_ref() {
-            let settings = Component::BootSettings(
-                propolis_client::instance_spec::BootSettings {
-                    order: boot_order
-                        .iter()
-                        .map(|key| {
-                            propolis_client::instance_spec::BootOrderEntry {
-                                id: SpecKey::Name(key.to_owned()),
-                            }
-                        })
-                        .collect(),
-                },
-            );
+            let settings = Component::BootSettings(BootSettings {
+                order: boot_order
+                    .iter()
+                    .map(|key| BootOrderEntry {
+                        id: SpecKey::Name(key.to_owned()),
+                    })
+                    .collect(),
+            });
             spec_component_add(
                 &mut spec,
                 SpecKey::Name("boot-settings".to_string()),


### PR DESCRIPTION
would you believe that ever since Propolis has been able to set a boot order in fwcfg, we've never tried to use it in `propolis-cli`? `propolis-standalone` is where I use it often, and of course Nexus just uses the API directly with none of this "CLI program" nonsense.

well, @leftwo ran into a case where a VM was busted because the disk's PCI device was changed between where the image was created and the bench cosmo where it was being run, and the solution there is ... set a boot order and boot the thing at least once. we pretty quickly found that propolis-cli wasn't doing the needful, and now it does.