### PR TITLE
remove atty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6863,7 +6863,6 @@ name = "propolis-mock-server"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "atty",
  "base64 0.21.7",
  "clap",
  "dropshot 0.17.1",
@@ -6908,7 +6907,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "atty",
  "base64 0.21.7",
  "bit_field",
  "bitvec",
@@ -6984,7 +6982,6 @@ name = "propolis-standalone"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "atty",
  "bhyve_api 0.0.0",
  "clap",
  "cpuid_profile_config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,6 @@ vm-attest = { git = "https://github.com/oxidecomputer/vm-attest", rev = "deaf020
 acpi_tables = { git = 'https://github.com/oxidecomputer/acpi_tables.git', tag = "v0.2.1-oxide.1" }
 anyhow = "1.0"
 async-trait = "0.1.88"
-atty = "0.2.14"
 backoff = "0.4.0"
 backtrace = "0.3.66"
 base64 = "0.21"

--- a/bin/mock-server/Cargo.toml
+++ b/bin/mock-server/Cargo.toml
@@ -19,7 +19,6 @@ doctest = false
 test = false
 
 [dependencies]
-atty.workspace = true
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 base64.workspace = true

--- a/bin/mock-server/src/main.rs
+++ b/bin/mock-server/src/main.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::io::IsTerminal;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -34,7 +35,7 @@ enum Args {
 }
 
 fn build_logger() -> slog::Logger {
-    let main_drain = if atty::is(atty::Stream::Stdout) {
+    let main_drain = if std::io::stdout().is_terminal() {
         let decorator = slog_term::TermDecorator::new().build();
         let drain = slog_term::FullFormat::new(decorator).build().fuse();
         slog_async::Async::new(drain)

--- a/bin/propolis-server/Cargo.toml
+++ b/bin/propolis-server/Cargo.toml
@@ -17,7 +17,6 @@ doctest = false
 test = false
 
 [dependencies]
-atty.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 bit_field.workspace = true

--- a/bin/propolis-server/src/main.rs
+++ b/bin/propolis-server/src/main.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::fmt;
+use std::io::IsTerminal;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -203,7 +204,7 @@ fn run_server(
 fn build_logger(level: slog::Level) -> slog::Logger {
     use slog::Drain;
 
-    let main_drain = if atty::is(atty::Stream::Stdout) {
+    let main_drain = if std::io::stdout().is_terminal() {
         let decorator = slog_term::TermDecorator::new().build();
         let drain = slog_term::FullFormat::new(decorator).build().fuse();
         slog_async::Async::new(drain)

--- a/bin/propolis-standalone/Cargo.toml
+++ b/bin/propolis-standalone/Cargo.toml
@@ -13,7 +13,6 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-atty.workspace = true
 bhyve_api.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 cpuid_utils.workspace = true

--- a/bin/propolis-standalone/src/main.rs
+++ b/bin/propolis-standalone/src/main.rs
@@ -5,7 +5,7 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt;
 use std::fs::File;
-use std::io::{Error, ErrorKind, Result};
+use std::io::{Error, ErrorKind, IsTerminal, Result};
 use std::path::Path;
 use std::process::ExitCode;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -823,7 +823,7 @@ fn open_bootrom(path: &str) -> Result<(File, usize)> {
 }
 
 fn build_log(level: slog::Level) -> slog::Logger {
-    let main_drain = if atty::is(atty::Stream::Stdout) {
+    let main_drain = if std::io::stdout().is_terminal() {
         let decorator = slog_term::TermDecorator::new().build();
         let drain = slog_term::CompactFormat::new(decorator).build().fuse();
         slog_async::Async::new(drain)

--- a/phd-tests/framework/src/disk/crucible.rs
+++ b/phd-tests/framework/src/disk/crucible.rs
@@ -337,7 +337,7 @@ impl Inner {
             ];
 
             // NOTE: `log_format` is ignored here because Crucible determines
-            // Bunyan or plain formatting based on `atty::is()`. In practice
+            // Bunyan or plain formatting based on `is_terminal()`. In practice
             // this is fine, and matches what we want right now, but it might be
             // nice to connect this more directly to the output desire expressed
             // by the test runner.


### PR DESCRIPTION
atty is unmaintained: https://github.com/advisories/GHSA-g98v-hv3f-hcfr

The only use is detecting if stdout is a terminal, which is supported in `std` since 1.70.

Not tested.