### PR TITLE
Fix vsock test flake

### DIFF
--- a/lib/propolis/src/vsock/poller.rs
+++ b/lib/propolis/src/vsock/poller.rs
@@ -1477,11 +1477,7 @@ mod test {
         let payload = vec![0xAB_u8; chunk_size];
         let total_sent = num_chunks * chunk_size;
 
-        // This is the vsock poller copying the REQUEST data and calling
-        // `push_used` which bumps the tx ring's used index.
-        let initial_tx_used = harness.tx_used_idx();
-
-        for tx_consumed in (1u16..).take(num_chunks) {
+        for _ in 0..num_chunks {
             // Reuse descriptor slots each iteration. This is only safe because
             // this test ensures that all tx_avail descriptors are pushed back
             // to us via tx_used.
@@ -1501,17 +1497,18 @@ mod test {
 
             let d_hdr = harness.add_tx_readable(hdr_as_bytes(&rw_hdr));
             let d_body = harness.add_tx_readable(&payload);
+
+            // The vsock poller calls `push_used` which bumps the tx ring's
+            // used index after processing the `harness.publish_tx`.
+            let expected_tx = harness.tx_used_idx() + 1;
             harness.chain_tx(d_hdr, d_body);
             harness.publish_tx(d_hdr);
-            notify.queue_notify(VSOCK_TX_QUEUE).unwrap();
 
             // Wait for the poller to release the desc chain back to us via
             // tx_used. This is the running total of the REQUEST and n RW
             // packets.
-            wait_for_condition(
-                || harness.tx_used_idx() >= initial_tx_used + tx_consumed,
-                5000,
-            );
+            notify.queue_notify(VSOCK_TX_QUEUE).unwrap();
+            wait_for_condition(|| harness.tx_used_idx() >= expected_tx, 5000);
         }
 
         // Drain the data from the accepted socket to confirm it arrived

--- a/lib/propolis/src/vsock/poller.rs
+++ b/lib/propolis/src/vsock/poller.rs
@@ -1465,6 +1465,10 @@ mod test {
         let mut accepted = listener.accept().unwrap().0;
         accepted.set_nonblocking(false).unwrap();
         accepted.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+        // Wait for the `VsockPacketOp::Response` packet to arrive.
+        // The poller takes a desc from the rx_avail ring and writes the packet
+        // into it, and publishes it via `push_used` updating rx_used.
         wait_for_condition(|| harness.rx_used_idx() >= 1, 5000);
 
         // Send enough data to exceed half the buffer capacity (64KB).
@@ -1473,8 +1477,14 @@ mod test {
         let payload = vec![0xAB_u8; chunk_size];
         let total_sent = num_chunks * chunk_size;
 
+        // This is the vsock poller copying the `VsockPacketOp::Request` data
+        // and calling `push_used` which bumps the tx ring's used index.
+        let initial_tx_used = harness.tx_used_idx();
+
         for tx_consumed in (1u16..).take(num_chunks) {
-            // Reuse descriptor slots each iteration
+            // Reuse descriptor slots each iteration. This is only safe because
+            // we are ensuring that all tx_avail descriptors are pushed back to
+            // us via tx_used.
             harness.reset_tx_cursors();
 
             let mut rw_hdr = VsockPacketHeader::new();
@@ -1495,7 +1505,13 @@ mod test {
             harness.publish_tx(d_hdr);
             notify.queue_notify(VSOCK_TX_QUEUE).unwrap();
 
-            wait_for_condition(|| harness.tx_used_idx() >= tx_consumed, 5000);
+            // Wait for the poller to release the desc chain back to us via
+            // tx_used. This is the running total of the REQUEST and n
+            // RW packets.
+            wait_for_condition(
+                || harness.tx_used_idx() >= initial_tx_used + tx_consumed,
+                5000,
+            );
         }
 
         // Drain the data from the accepted socket to confirm it arrived

--- a/lib/propolis/src/vsock/poller.rs
+++ b/lib/propolis/src/vsock/poller.rs
@@ -1466,9 +1466,9 @@ mod test {
         accepted.set_nonblocking(false).unwrap();
         accepted.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
 
-        // Wait for the `VsockPacketOp::Response` packet to arrive.
-        // The poller takes a desc from the rx_avail ring and writes the packet
-        // into it, and publishes it via `push_used` updating rx_used.
+        // Wait for the RESPONSE packet to arrive. The poller takes a desc from
+        // the rx_avail ring, writes the packet into it, and publishes it via
+        // `push_used` updating rx_used.
         wait_for_condition(|| harness.rx_used_idx() >= 1, 5000);
 
         // Send enough data to exceed half the buffer capacity (64KB).
@@ -1477,14 +1477,14 @@ mod test {
         let payload = vec![0xAB_u8; chunk_size];
         let total_sent = num_chunks * chunk_size;
 
-        // This is the vsock poller copying the `VsockPacketOp::Request` data
-        // and calling `push_used` which bumps the tx ring's used index.
+        // This is the vsock poller copying the REQUEST data and calling
+        // `push_used` which bumps the tx ring's used index.
         let initial_tx_used = harness.tx_used_idx();
 
         for tx_consumed in (1u16..).take(num_chunks) {
             // Reuse descriptor slots each iteration. This is only safe because
-            // we are ensuring that all tx_avail descriptors are pushed back to
-            // us via tx_used.
+            // this test ensures that all tx_avail descriptors are pushed back
+            // to us via tx_used.
             harness.reset_tx_cursors();
 
             let mut rw_hdr = VsockPacketHeader::new();
@@ -1506,8 +1506,8 @@ mod test {
             notify.queue_notify(VSOCK_TX_QUEUE).unwrap();
 
             // Wait for the poller to release the desc chain back to us via
-            // tx_used. This is the running total of the REQUEST and n
-            // RW packets.
+            // tx_used. This is the running total of the REQUEST and n RW
+            // packets.
             wait_for_condition(
                 || harness.tx_used_idx() >= initial_tx_used + tx_consumed,
                 5000,


### PR DESCRIPTION
This fixes #1197.

The test is a simple off by one error which leads to a race condition. We end up waiting for
`harness.tx_used_idx()` to reach one less descriptor than we should be, which means calling
`reset_tx_cursors` at the top of the loop resets the `QueueWriter` too soon. This opens a window for
the poller to not read all the RW packets that we are sending. The log in the test confirms this,
and explains why our `read_exact()` fails.

```
Aug 14 02:51:12.719 WARN dropping invalid vsock packet: vsock packet header reported 8192 bytes but the descriptor chain contains 0, component: vsock-test
```