### PR TITLE
Deny broken doc comments (and fix a few warnings)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,8 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Test build documentation
       run: cargo doc --workspace --no-deps
+      env:
+        RUSTDOCFLAGS: "-D warnings"
   build-and-test:
     runs-on: ubuntu-latest
     steps:

--- a/lib/propolis/src/accessors.rs
+++ b/lib/propolis/src/accessors.rs
@@ -31,20 +31,20 @@
 //! accessor's API; only a wrapper that derefs as `T`.
 //!
 //! Accessor structures being the sole access mechanism to a guarded resource
-//! ensures that the resource can be added or removed *almost*[1] arbitrarily.
+//! ensures that the resource can be added or removed *almost*[^1] arbitrarily.
 //! [`MsiAccessor`] is an example of double-duty here; on one hand, a PCI bridge
 //! can have MSI enabled or disabled, as well as the functions behind that
 //! bridge. On the other hand, the MSI accessor is mostly just an `Arc<VmmHdl>`,
 //! and it would be unfortunate to have stray `Arc<VmmHdl>` littered across
-//! device emulation[2].
+//! device emulation[^2].
 //!
-//! 1: A user of Propolis should only change the guarded resource for devices that
+//! [^1]: A user of Propolis should only change the guarded resource for devices that
 //! are in the initial (pre-run) state, paused, or halted.  Removing a guarded
 //! resource during arbitrary device operation could, at worst, look to a device
 //! like it was the bus master while also losing its ownership of the bus!
 //! There is no expectation of correct operation in such a bogus state.
 //!
-//! 2: `Arc<VmmHdl>` has since found its way into device emulation in different
+//! [^2]: `Arc<VmmHdl>` has since found its way into device emulation in different
 //! ways, though the ownership model is simple enough there is little risk of
 //! cyclic references keeping a `VmmHdl` alive overly-long.
 
@@ -675,7 +675,7 @@ impl<T: AccessedResource> Accessor<T> {
     /// Will return [None] if any ancestor node disables access, or if the node
     /// is not attached to a hierarchy containing a valid resource.
     ///
-    /// Unlike [`Accesor::access()`], this returns a wrapped MutexGuard for this
+    /// Unlike [`Accessor::access()`], this returns a wrapped MutexGuard for this
     /// accessor node; callers must carefully consider lock ordering when
     /// holding this guard across other operations.  As with any other mutex,
     /// perfer holding this guard for as small a window as permitted.

--- a/lib/propolis/src/block/mod.rs
+++ b/lib/propolis/src/block/mod.rs
@@ -147,7 +147,7 @@ impl Result {
 pub struct QueueId(u8);
 impl QueueId {
     /// Arbitrary limit for per-device queues.
-    /// Sized to match [attachment::Bitmap] capacity
+    // Sized to match [attachment::Bitmap] capacity
     pub const MAX_QUEUES: usize = 64;
 
     pub const MAX: Self = Self(Self::MAX_QUEUES as u8);

--- a/lib/propolis/src/firmware/acpi/aml.rs
+++ b/lib/propolis/src/firmware/acpi/aml.rs
@@ -196,10 +196,10 @@ pub mod methods {
     method!(sta);
 }
 
-/// Device ID and Plug and Play (`PNP`) device codes used throughout ACPI tables.
-/// UEFI and ACPI use standardized IDs as described in https://uefi.org/PNP_ACPI_Registry,
-/// which itself points to reserved device IDs at
-/// https://uefi.org/sites/default/files/resources/devids%20%285%29.txt
+/// Device ID and Plug and Play (`PNP`) device codes used throughout ACPI
+/// tables.  UEFI and ACPI use standardized IDs as described in
+/// <https://uefi.org/PNP_ACPI_Registry>, which itself points to reserved device
+/// IDs at <https://uefi.org/sites/default/files/resources/devids%20%285%29.txt>
 pub mod devids {
     // --Interrupt Controllers--
     pub const AT_INT_CONTROLLER: &'static str = "PNP0000";

--- a/lib/propolis/src/firmware/acpi/fadt.rs
+++ b/lib/propolis/src/firmware/acpi/fadt.rs
@@ -97,7 +97,7 @@ impl Aml for Fadt {
     /// the individual fields.
     ///
     /// The current values are retained from the original EDK2 static tables.
-    /// https://github.com/oxidecomputer/edk2/blob/f33871f488bfbbc080e0f7e3881e04d0db0b6367/OvmfPkg/AcpiTables/Platform.h#L25-L56
+    /// <https://github.com/oxidecomputer/edk2/blob/f33871f488bfbbc080e0f7e3881e04d0db0b6367/OvmfPkg/AcpiTables/Platform.h#L25-L56>
     ///
     /// fwts reports 1 high failure for this table:
     ///   - fadt: FADT X_GPE0_BLK Access width 0x00 but it should be 1 (byte access).

--- a/lib/propolis/src/firmware/acpi/mod.rs
+++ b/lib/propolis/src/firmware/acpi/mod.rs
@@ -16,7 +16,7 @@
 //! currently focused on retaining compatibility with the original static EDK2
 //! tables. The original tables can be found in the EDK2 fork repository.
 //!
-//! https://github.com/oxidecomputer/edk2/tree/propolis/edk2-stable202105/OvmfPkg/AcpiTables
+//! <https://github.com/oxidecomputer/edk2/tree/propolis/edk2-stable202105/OvmfPkg/AcpiTables>
 
 use serde::{Deserialize, Serialize};
 

--- a/lib/propolis/src/firmware/acpi/ssdt_edk2.rs
+++ b/lib/propolis/src/firmware/acpi/ssdt_edk2.rs
@@ -4,7 +4,7 @@
 
 //! Generates the same SSDT table as the original EDK2 static tables.
 //!
-//! The [`Ssdt`] struct implements the `Aml` trait of the `acpi_tables` crate
+//! The [`SsdtEdk2`] struct implements the `Aml` trait of the `acpi_tables` crate
 //! and can write the AML bytecode to any AmlSink, like a `Vec<u8>`.
 
 // This SSDT table is kept the same as the original EDK2 static table.

--- a/lib/propolis/src/hw/qemu/fwcfg.rs
+++ b/lib/propolis/src/hw/qemu/fwcfg.rs
@@ -1420,10 +1420,9 @@ pub mod formats {
     /// ```
     /// Adapted from <https://docs.kernel.org/firmware-guide/acpi/namespace.html>
     ///
-    /// These addresses are only know at boot time, so each reference has a
-    /// corresponding [`AddPointerCommand`] that the firmware executes on boot.
-    /// And since the table has been modified, they also need a
-    /// [`AddChecksumCommand`] to recalculate the final table checksum.
+    /// These addresses are only known at boot time, so a series of fixups are
+    /// recorded into the produced `TableLoader` for firmware to correct table
+    /// pointers and checksums.
     pub struct AcpiTablesBuilder<'a> {
         config: &'a AcpiConfig<'a>,
         tables: Vec<u8>,
@@ -1721,6 +1720,13 @@ pub mod formats {
     /// Stores commands that will be executed by the EDK2 firmware when the
     /// ACPI tables are loaded.
     ///
+    /// ACPI tables provided via `fw_cfg` are only placed into memory at boot
+    /// time, so inter-table pointers become invalid as EDK2 chooses where to
+    /// place individual tables. `fw_cfg` includes a small command language
+    /// analogous to a binary loader to fix up these pointers and checksums of
+    /// tables including them, the content of which is prepared through
+    /// `TableLoader` via the table-loading builder functions implemented on it.
+    ///
     /// Refer to the EDK2 source code for more information on the commands.
     ///
     /// <https://github.com/oxidecomputer/edk2/blob/f33871f488bfbbc080e0f7e3881e04d0db0b6367/OvmfPkg/AcpiPlatformDxe/QemuLoader.h>
@@ -1733,6 +1739,8 @@ pub mod formats {
             Self { commands: Vec::new() }
         }
 
+        /// Add a `QEMU_LOADER_ALLOCATE` command to this table loader's command
+        /// stream.
         pub fn add_allocate(
             &mut self,
             file: &str,
@@ -1749,6 +1757,8 @@ pub mod formats {
             self.write_command(CommandType::Allocate, cmd.as_bytes());
         }
 
+        /// Add a `QEMU_LOADER_ADD_POINTER` command to this table loader's
+        /// command stream.
         pub fn add_pointer(
             &mut self,
             dest_file: &str,
@@ -1767,6 +1777,8 @@ pub mod formats {
             self.write_command(CommandType::AddPointer, cmd.as_bytes());
         }
 
+        /// Add a `QEMU_LOADER_ADD_CHECKSUM` command to this table loader's
+        /// command stream.
         pub fn add_checksum(
             &mut self,
             file: &str,

--- a/lib/propolis/src/hw/virtio/viona.rs
+++ b/lib/propolis/src/hw/virtio/viona.rs
@@ -51,7 +51,7 @@ pub const fn max_num_queues() -> usize {
     PROPOLIS_MAX_MQ_PAIRS as usize * 2
 }
 
-/// The index of the control queue when multiqueue ([`VIRTIO_NET_F_MQ`]) has
+/// The index of the control queue when multiqueue (`VIRTIO_NET_F_MQ`) has
 /// not been negotiated.
 ///
 /// In this case, the driver will behave as though we have allocated only one
@@ -425,7 +425,7 @@ pub enum PromiscLevel {
     /// The device should receive only packets for its installed MAC
     /// filters.
     ///
-    /// Today this allows solely [`PciVirtioViona::mac_addr`].
+    /// Today this allows solely `PciVirtioViona::mac_addr`.
     #[default]
     None,
     /// The device should receive all multicast traffic in addition


### PR DESCRIPTION
While we tested that doc comments *built*, which checks example code is syntactically valid, calls items that exist, etc we did not actually deny warnings when checking doc comments.

Typically, one might see those warnings and fix them, and in practice the doc comments in Propolis and the related crates all build without issue. Over time some issues do creep in though, and we might as well catch and reject them in CI to keep things tidy. Otherwise the warnings end up in CI logs that likely no one is checking...

this is mostly me peeling out the unrelated docs cleanup from #1210 into its own change and fixing the underlying issue that let these warnings creep in over time :)