### PR TITLE
nvme: compute number of requested log page words correctly

### DIFF
--- a/lib/propolis/src/hw/nvme/cmds.rs
+++ b/lib/propolis/src/hw/nvme/cmds.rs
@@ -93,10 +93,15 @@ impl AdminCmd {
                 })
             }
             bits::ADMIN_OPC_GET_LOG_PAGE => {
+                // Convert from 0's based dword.
+                //
+                // As of NVMe 1.0e this field is 12 bits, but beware that in
+                // later versions the Log Page Attributes' Extended Data Support
+                // bit extends this.
+                let log_dwords = ((raw.cdw10 >> 16) & 0xFFF) + 1;
                 AdminCmd::GetLogPage(GetLogPageCmd {
                     nsid: raw.nsid,
-                    // Convert from 0's based dword
-                    len: (((raw.cdw10 & 0xFFF) >> 16) + 1) * 4,
+                    len: log_dwords * 4,
                     log_page_ident: LogPageIdent::from(raw.cdw10 as u8),
                     prp1: raw.prp1,
                     prp2: raw.prp2,


### PR DESCRIPTION
`(foo & 0xFFF) >> 16` is a rather doomed expression. this fixes the secondary issue I'd noticed in https://github.com/oxidecomputer/propolis/issues/1213, where log pages seemed to have random data in them from call to call.

the field we're trying to extract here is `NUMDL` in bits `31:16` of cdw10. basically all the symbols were right, just.. in the wrong order. the consequence here was that we were computing a log page request for 0 (meaning, 1) dword, and filling in the first four bytes of the request with zero. Linux has been requesting 127 (meaning, 128) dwords the entire time, to fill all 512 bytes of defined-and-reserved space in the log page.

I don't know why this goes from being what I observed with garbage data in 22.04, to being zeroed later on. I assume that's a kernel change, since prp1 becomes always-aligned, and I assume that the kernel decides to zero the page to guard against misbehaving devices like ours that don't write all the bits they're supposed to!